### PR TITLE
translate migration80/deprecated to pt_br

### DIFF
--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d7a2a4e3f7114ec8f0a71da90ed7e55b70fb77ec Maintainer: geekcom Status: wip --><!-- CREDITS: geekcom -->
+<!-- EN-Revision: d7a2a4e3f7114ec8f0a71da90ed7e55b70fb77ec Maintainer: geekcom Status: ready --><!-- CREDITS: geekcom -->
 
 <sect1 xml:id="migration80.deprecated">
  <title>Recursos depreciados</title>
@@ -10,31 +10,31 @@
   <itemizedlist>
    <listitem>
     <para>
-     If a parameter with a default value is followed by a required parameter, the default value has
-     no effect. This is deprecated as of PHP 8.0.0 and can generally be resolved by dropping the
-     default value, without a change in functionality:
+     Se um parâmetro com um valor padrão é seguido por um parâmetro obrigatório, o valor padrão não tem
+     efeito. Essa funcionalidade está depreciada a partir do PHP 8.0.0 e geralmente pode ser resolvido eliminando o
+     valor padrão, sem mudança na funcionalidade:
     </para>
     <para>
      <programlisting role="php">
 <![CDATA[
 <?php
-function test($a = [], $b) {} // Before
-function test($a, $b) {}      // After
+function test($a = [], $b) {} // Antes
+function test($a, $b) {}      // Depois
 ?>
 ]]>
      </programlisting>
     </para>
     <para>
-     One exception to this rule are parameters of the form <code>Type $param = null</code>, where
-     the null default makes the type implicitly nullable. This usage remains allowed, but it is
-     recommended to use an explicit nullable type instead:
+     Uma exceção a esta regra são os parâmetros escritos de seguinte forma: <code>Type $param = null</code>, onde
+     o valor padrão nulo torna o tipo implicitamente anulável. Este uso continua permitido, mas é
+     recomendado o uso de um tipo anulável explícito:
     </para>
     <para>
      <programlisting role="php">
 <![CDATA[
 <?php
-function test(A $a = null, $b) {} // Still allowed
-function test(?A $a, $b) {}       // Recommended
+function test(A $a = null, $b) {} // Ainda é permitido
+function test(?A $a, $b) {}       // Recomendável
 ?>
 ]]>
      </programlisting>
@@ -42,9 +42,9 @@ function test(?A $a, $b) {}       // Recommended
    </listitem>
    <listitem>
     <para>
-     Calling <function>get_defined_functions</function> with <parameter>exclude_disabled</parameter>
-     explicitly set to &false; is deprecated and no longer has an effect.
-     <function>get_defined_functions</function> will never include disabled functions.
+     Chamar a função <function>get_defined_functions</function> com o parâmetro <parameter>exclude_disabled</parameter>
+     definido explicitamente como &false; está depreciado e não tem mais efeito.
+     A função <function>get_defined_functions</function> nunca incluirá funções desabilitadas.
     </para>
    </listitem>
   </itemizedlist>
@@ -56,34 +56,34 @@ function test(?A $a, $b) {}       // Recommended
   <itemizedlist>
    <listitem>
     <para>
-     <function>enchant_broker_set_dict_path</function> and
+     <function>enchant_broker_set_dict_path</function> e
      <function>enchant_broker_get_dict_path</function>
-     are deprecated, because that functionality is neither available in libenchant &lt; 1.5 nor in
+     estão depreciadas, porque essa funcionalidade não está disponível no libenchant &lt; 1.5 nem na
      libenchant-2.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_add_to_personal</function> is deprecated; use
-     <function>enchant_dict_add</function> instead.
+     <function>enchant_dict_add_to_personal</function> está depreciada; use
+     <function>enchant_dict_add</function> em seu lugar.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_is_in_session</function> is deprecated; use
-     <function>enchant_dict_is_added</function> instead.
+     <function>enchant_dict_is_in_session</function> está depreciada; use
+     <function>enchant_dict_is_added</function> em seu lugar.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_broker_free</function> and <function>enchant_broker_free_dict</function> are
-     deprecated; unset the object instead.
+     <function>enchant_broker_free</function> e <function>enchant_broker_free_dict</function> estão
+     depreciadas; em vez disso destrua/unset o objeto.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <constant>ENCHANT_MYSPELL</constant> and <constant>ENCHANT_ISPELL</constant> constants are
-     deprecated.
+     As constantes <constant>ENCHANT_MYSPELL</constant> e <constant>ENCHANT_ISPELL</constant> estão
+     depreciadas.
     </para>
    </listitem>
   </itemizedlist>
@@ -93,9 +93,9 @@ function test(?A $a, $b) {}       // Recommended
   <title>LibXML</title>
 
   <para>
-   <function>libxml_disable_entity_loader</function> has been deprecated. As libxml 2.9.0 is now
-   required, external entity loading is guaranteed to be disabled by default, and this function is
-   no longer needed to protect against XXE attacks.
+   A função <function>libxml_disable_entity_loader</function> foi depreciada. Como a libxml 2.9.0 agora é
+   obrigatória, o carregamento de entidade externa está desabilitado por padrão, e esta função
+   não é mais necessária para a proteção contra ataques XXE.
   </para>
  </sect2>
 
@@ -105,14 +105,14 @@ function test(?A $a, $b) {}       // Recommended
   <itemizedlist>
    <listitem>
     <para>
-     The constant <constant>PG_VERSION_STR</constant> now has the same value as
-     <constant>PG_VERSION</constant>, and thus is deprecated.
+     A constante <constant>PG_VERSION_STR</constant> agora tem o mesmo valor que
+     <constant>PG_VERSION</constant>, portanto, está depreciada.
     </para>
    </listitem>
    <listitem>
     <para>
-     Function aliases in the pgsql extension have been deprecated.
-     See the following list for which functions should be used instead:
+     Os apelidos de função na extensão pgsql foram depreciados.
+     Consulte a lista a abaixo para saber quais funções devem ser usadas em seu lugar:
     </para>
     <para>
      <simplelist>
@@ -147,22 +147,22 @@ function test(?A $a, $b) {}       // Recommended
  </sect2>
 
  <sect2 xml:id="migration80.deprecated.standard">
-  <title>Standard Library</title>
+  <title>Biblioteca Padrão</title>
 
   <itemizedlist>
    <listitem>
     <para>
-     Sort comparison functions that return &true; or &false; will now throw a deprecation warning, and
-     should be replaced with an implementation that returns an integer less than, equal to, or greater
-     than zero.
+     Funções sort que retornam &true; ou &false; agora lançam um aviso de depreciação, e
+     deve ser substituído por uma implementação que retorna um número inteiro menor, igual ou maior
+     que zero.
     </para>
     <para>
      <programlisting role="php">
 <![CDATA[
 <?php
-// Replace
+// Substituir
 usort($array, fn($a, $b) => $a > $b);
-// With
+// Por
 usort($array, fn($a, $b) => $a <=> $b);
 ?>
 ]]>
@@ -178,27 +178,27 @@ usort($array, fn($a, $b) => $a <=> $b);
   <itemizedlist>
    <listitem>
     <para>
-     Using an empty file as ZipArchive is deprecated. Libzip 1.6.0 does not accept empty files as
-     valid zip archives any longer. The existing workaround will be removed in the next version.
+     Usar um arquivo vazio como ZipArchive está depreciado. A Libzip 1.6.0 não aceita mais arquivos vazios como
+     arquivos zip válidos. A solução alternativa existente será removida na próxima versão.
     </para>
    </listitem>
    <listitem>
     <para>
-     The procedural API of Zip is deprecated. Use <classname>ZipArchive</classname> instead.
-     Iteration over all entries can be accomplished using <methodname>ZipArchive::statIndex</methodname>
-     and a <link linkend="control-structures.for">for</link> loop:
+     A API procedural do Zip está depreciada. Use <classname>ZipArchive</classname> em seu lugar.
+     A iteração em todas as entradas pode ser realizada usando <methodname>ZipArchive::statIndex</methodname>
+     e um laço <link linkend="control-structures.for">for</link>:
     </para>
     <para>
      <programlisting role="php">
 <![CDATA[
 <?php
-// iterate using the procedural API
+// iterar usando a API procedural
 assert(is_resource($zip));
 while ($entry = zip_read($zip)) {
     echo zip_entry_name($entry);
 }
 
-// iterate using the object-oriented API
+// iterar usando a API orientada a objetos
 assert($zip instanceof ZipArchive);
 for ($i = 0; $entry = $zip->statIndex($i); $i++) {
     echo $entry['name'];
@@ -217,18 +217,18 @@ for ($i = 0; $entry = $zip->statIndex($i); $i++) {
   <itemizedlist>
    <listitem>
     <para>
-     <methodname>ReflectionFunction::isDisabled</methodname> is deprecated, as it is no longer
-     possible to create a <classname>ReflectionFunction</classname> for a disabled function. This
-     method now always returns &false;.
+     O método <methodname>ReflectionFunction::isDisabled</methodname> está depreciado, pois não é mais
+     possível criar uma classe <classname>ReflectionFunction</classname> para uma função desativada. Este
+     método agora sempre retorna &false;.
     </para>
    </listitem>
    <listitem>
     <para>
      <methodname>ReflectionParameter::getClass</methodname>,
-     <methodname>ReflectionParameter::isArray</methodname>, and
-     <methodname>ReflectionParameter::isCallable</methodname> are deprecated.
-     <methodname>ReflectionParameter::getType</methodname> and the
-     <classname>ReflectionType</classname> APIs should be used instead.
+     <methodname>ReflectionParameter::isArray</methodname>, e
+     <methodname>ReflectionParameter::isCallable</methodname> estão depreciados.
+     <methodname>ReflectionParameter::getType</methodname> e
+     <classname>ReflectionType</classname> devem ser usados em seu lugar.
     </para>
    </listitem>
   </itemizedlist>

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -25,7 +25,7 @@ function test($a, $b) {}      // Depois
      </programlisting>
     </para>
     <para>
-     Uma exceção a esta regra são os parâmetros escritos de seguinte forma: <code>Type $param = null</code>, onde
+     Uma exceção à esta regra são os parâmetros escritos de seguinte forma: <code>Type $param = null</code>, onde
      o valor padrão nulo torna o tipo implicitamente anulável. Este uso continua permitido, mas é
      recomendado o uso de um tipo anulável explícito:
     </para>
@@ -112,7 +112,7 @@ function test(?A $a, $b) {}       // Recomendável
    <listitem>
     <para>
      Os apelidos de função na extensão pgsql foram depreciados.
-     Consulte a lista a abaixo para saber quais funções devem ser usadas em seu lugar:
+     Consulte a lista abaixo para saber quais funções devem ser usadas em seu lugar:
     </para>
     <para>
      <simplelist>


### PR DESCRIPTION
Tradução completa do guia de migração para PHP8-Recursos depreciados.

Status: ready