### PR TITLE
[77227] Remove ambiguous documentation block

### DIFF
--- a/reference/filesystem/functions/delete.xml
+++ b/reference/filesystem/functions/delete.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: rarruda Status: ready -->
-<refentry xml:id="function.delete" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.delete" role="noversion">
  <refnamediv>
   <refname>delete</refname>
   <refpurpose>Veja <function>unlink</function> ou <function>unset</function></refpurpose>
@@ -8,21 +8,10 @@
  
  <refsect1 role="description">
   &reftitle.description;
-   <methodsynopsis>
-    <type>void</type><methodname>delete</methodname>
-    <void />
-   </methodsynopsis>
   <para>
-   Esta é uma seção falsa do manual, criada para satisfazer
-   as pessoas que estão procurando por <function>unlink</function>
-   ou <function>unset</function> no lugar errado.
-  </para>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   &return.void;
+   Não existe função ou instrução <code>delete</code> em PHP.
+   Se você chegou nesta página procurando por deletar arquivos, veja <function>unlink</function>.
+   Para deletar uma variável de um escopo local, veja <function>unset</function>.
   </para>
  </refsect1>
 
@@ -30,12 +19,12 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>unlink</function> para deletar arquivos</member>
-    <member><function>unset</function> para deletar variáveis</member>
+    <member><function>unlink</function></member>
+    <member><function>unset</function></member>
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
As reported on https://bugs.php.net/bug.php?id=77227 this page looked different in Portuguese and gave the impression that there was such statement `delete()`. This Pull Request is a replication of the English file with a translation of the text.