### PR TITLE
Atualiza file_get_contents()

### DIFF
--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -152,6 +152,74 @@
     </para>
    </refsect1>
 
+   <refsect1 role="examples">
+    &reftitle.examples;
+    <para>
+     <example>
+      <title>Obtém e exibe o código-fonte da página inicial de um website</title>
+      <programlisting role="php">
+  <![CDATA[
+  <?php
+  $homepage = file_get_contents('http://www.example.com/');
+  echo $homepage;
+  ?>
+  ]]>
+      </programlisting>
+     </example>
+     <example>
+      <title>Buscando no include_path</title>
+      <programlisting role="php">
+  <![CDATA[
+  <?php
+  // If strict types are enabled i.e. declare(strict_types=1);
+  $file = file_get_contents('./people.txt', true);
+  // Otherwise
+  $file = file_get_contents('./people.txt', FILE_USE_INCLUDE_PATH);
+  ?>
+  ]]>
+      </programlisting>
+     </example>
+     <example>
+      <title>Lendo uma sessão de um arquivo</title>
+      <programlisting role="php">
+  <![CDATA[
+  <?php
+  // Read 14 characters starting from the 21st character
+  $section = file_get_contents('./people.txt', FALSE, NULL, 20, 14);
+  var_dump($section);
+  ?>
+  ]]>
+      </programlisting>
+      &example.outputs.similar;
+      <screen>
+  <![CDATA[
+  string(14) "lle Bjori Ro" 
+  ]]>
+      </screen>
+     </example>
+     <example>
+      <title>Usando stream contexts</title>
+      <programlisting role="php">
+  <![CDATA[
+  <?php
+  // Create a stream
+  $opts = array(
+    'http'=>array(
+      'method'=>"GET",
+      'header'=>"Accept-language: en\r\n" .
+                "Cookie: foo=bar\r\n"
+    )
+  );
+  $context = stream_context_create($opts);
+  // Open the file using the HTTP headers set above
+  $file = file_get_contents('http://www.example.com/', false, $context);
+  ?>
+  ]]>
+      </programlisting>
+     </example>
+    </para>
+   </refsect1>
+
    <refsect1 role="changelog">
     &reftitle.changelog;
     <para>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -76,6 +76,11 @@
          O ponto onde a leitura deve começar na stream original.
          Offsets negativos contam a partir do final da stream.
         </para>
+        <para>
+         <parameter>offset</parameter> não é suportado em arquivos remotos.
+         Tentar buscar (seek) em arquivos não locais pode funcionar com offsets
+         pequenos, mas isso é imprevisível pois só funciona na stream em buffer.
+        </para>
        </listitem>
       </varlistentry>
       <varlistentry>
@@ -98,6 +103,16 @@
    A função retorna os dados lidos &return.falseforfailure;.
     </para>
     &return.falseproblem;
+   </refsect1>
+
+   <refsect1 role="errors">
+    &reftitle.errors;
+    <para>
+     Um erro de nível <constant>E_WARNING</constant> é gerado se
+     <parameter>filename</parameter> não puder ser encontrado,
+     <parameter>maxlength</parameter> é menor que zero, ou se a busca na stream
+     pelo <parameter>offset</parameter> especificado falhar.
+    </para>
    </refsect1>
 
    <refsect1 role="examples">

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -10,9 +10,9 @@
     <methodsynopsis>
      <type>string</type><methodname>file_get_contents</methodname>
      <methodparam><type>string</type><parameter>filename</parameter></methodparam>
-     <methodparam choice="opt"><type>int</type><parameter>flags</parameter></methodparam>
+     <methodparam choice="opt"><type>bool</type><parameter>use_include_path</parameter><initializer>&false;</initializer></methodparam>
      <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>
-     <methodparam choice="opt"><type>int</type><parameter>offset</parameter></methodparam>
+     <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>-1</initializer></methodparam>
      <methodparam choice="opt"><type>int</type><parameter>maxlen</parameter></methodparam>
     </methodsynopsis>
     <para>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -132,7 +132,9 @@
        <term><parameter>maxlen</parameter></term>
        <listitem>
         <para>
-     Comprimento máximo dos dados lidos.
+     Comprimento máximo dos dados lidos. O padrão é ler até que o fim do arquivo
+     seja alcançado. Note que este parâmetro é aplicado para a stream processada
+     pelos filtros.
         </para>
        </listitem>
       </varlistentry>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -48,7 +48,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><parameter>flags</parameter></term>
+       <term><parameter>use_include_path</parameter></term>
        <listitem>
         <note>
          <para>
@@ -57,57 +57,6 @@
       <link linkend="ini.include-path">include path</link>.
          </para>
         </note>
-        <para>
-     O valor de <parameter>flags</parameter> pode ser qualquer combinação das
-     seguintes flags (com algumas restrições), unidas com o operador binário OR
-     (<literal>|</literal>).
-        </para>
-        <para>
-         <table>
-          <title>Flags disponíveis</title>
-          <tgroup cols="2">
-           <thead>
-            <row>
-             <entry>Flag</entry>
-             <entry>Descrição</entry>
-            </row>
-           </thead>
-           <tbody>
-            <row>
-             <entry>
-              <constant>FILE_USE_INCLUDE_PATH</constant>
-             </entry>
-             <entry>
-        Procura o arquivo <parameter>filename</parameter> nos diretórios de include.
-        Veja <link linkend="ini.include-path">include_path</link> para mais
-        informações.
-             </entry>
-            </row>
-            <row>
-             <entry>
-              <constant>FILE_TEXT</constant>
-             </entry>
-             <entry>
-        Se a semântica unicode estiver habilitada, o encoding padrão dos dados
-        lidos é UTF-8. Você pode especificar um encoding diferente criando um
-        contexto personalizado ou alterando o encoding padrão utilizando
-        <function>stream_default_encoding</function>. Esta flag não pode ser
-        usada com <constant>FILE_BINARY</constant>.
-             </entry>
-            </row>
-            <row>
-             <entry>
-              <constant>FILE_BINARY</constant>
-             </entry>
-             <entry>
-        Com esta flag, o arquivo é lido em modo binário. Esta é a opção
-        padrão e não pode ser usada com <constant>FILE_TEXT</constant>.
-             </entry>
-            </row>
-           </tbody>
-          </tgroup>
-         </table>
-        </para>
        </listitem>
       </varlistentry>
       <varlistentry>
@@ -242,13 +191,6 @@
          <entry>
       Adicionados os parâmetros <parameter>offset</parameter> e
       <parameter>maxlen</parameter>.
-         </entry>
-        </row>
-        <row>
-         <entry>6.0.0</entry>
-         <entry>
-      O parâmetro <parameter>use_include_path</parameter> foi substituído
-          pelo parâmetro <parameter>flags</parameter>.
          </entry>
         </row>
        </tbody>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -124,7 +124,8 @@
        <term><parameter>offset</parameter></term>
        <listitem>
         <para>
-         O ponto onde a leitura deve começar.
+         O ponto onde a leitura deve começar na stream original.
+         Offsets negativos contam a partir do final da stream.
         </para>
        </listitem>
       </varlistentry>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -13,13 +13,13 @@
      <methodparam choice="opt"><type>bool</type><parameter>use_include_path</parameter><initializer>&false;</initializer></methodparam>
      <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>
      <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
-     <methodparam choice="opt"><type>int</type><parameter>maxlen</parameter></methodparam>
+     <methodparam choice="opt"><type>int</type><parameter>length</parameter></methodparam>
     </methodsynopsis>
     <para>
    Esta função é semelhante à <function>file</function>, exceto que
    <function>file_get_contents</function> retorna o arquivo em uma
    <type>string</type>, começando a partir de <parameter>offset</parameter>
-   até <parameter>maxlen</parameter> bytes. Em caso de falha,
+   até <parameter>length</parameter> bytes. Em caso de falha,
    <function>file_get_contents</function> retornará &false;.
     </para>
     <para>
@@ -88,7 +88,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><parameter>maxlen</parameter></term>
+       <term><parameter>length</parameter></term>
        <listitem>
         <para>
      Comprimento máximo dos dados lidos. O padrão é ler até que o fim do arquivo
@@ -114,7 +114,7 @@
     <para>
      Um erro de nível <constant>E_WARNING</constant> é gerado se
      <parameter>filename</parameter> não puder ser encontrado,
-     <parameter>maxlength</parameter> é menor que zero, ou se a busca na stream
+     <parameter>length</parameter> é menor que zero, ou se a busca na stream
      pelo <parameter>offset</parameter> especificado falhar.
     </para>
     <para>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -217,6 +217,7 @@
       <member><function>file_put_contents</function></member>
       <member><function>stream_get_contents</function></member>
       <member><function>stream_context_create</function></member>
+      <member><link linkend="reserved.variables.httpresponseheader">$http_response_header</link></member>
      </simplelist>
     </para>
    </refsect1>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -12,7 +12,7 @@
      <methodparam><type>string</type><parameter>filename</parameter></methodparam>
      <methodparam choice="opt"><type>bool</type><parameter>use_include_path</parameter><initializer>&false;</initializer></methodparam>
      <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>
-     <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>-1</initializer></methodparam>
+     <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
      <methodparam choice="opt"><type>int</type><parameter>maxlen</parameter></methodparam>
     </methodsynopsis>
     <para>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -117,6 +117,11 @@
      <parameter>maxlength</parameter> é menor que zero, ou se a busca na stream
      pelo <parameter>offset</parameter> especificado falhar.
     </para>
+    <para>
+     Quando <function>file_get_contents</function> é chamada em um diretório, um
+     erro nível <constant>E_WARNING</constant> é gerado no Windows, e a partir
+     do PHP 7.4 em outros sistemas operacionais também.
+    </para>
    </refsect1>
 
    <refsect1 role="examples">

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -124,6 +124,30 @@
     </para>
    </refsect1>
 
+   <refsect1 role="changelog">
+    &reftitle.changelog;
+    <para>
+     <informaltable>
+      <tgroup cols="2">
+       <thead>
+        <row>
+         <entry>&Version;</entry>
+         <entry>&Description;</entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>7.1.0</entry>
+         <entry>
+          Suporte para <parameter>offset</parameter>s negativos foi adicionado.
+         </entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </informaltable>
+    </para>
+   </refsect1>
+
    <refsect1 role="examples">
     &reftitle.examples;
     <para>
@@ -189,30 +213,6 @@
   ]]>
       </programlisting>
      </example>
-    </para>
-   </refsect1>
-
-   <refsect1 role="changelog">
-    &reftitle.changelog;
-    <para>
-     <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>&Version;</entry>
-         <entry>&Description;</entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>7.1.0</entry>
-         <entry>
-          Suporte para <parameter>offset</parameter>s negativos foi adicionado.
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
     </para>
    </refsect1>
 

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -196,16 +196,9 @@
        </thead>
        <tbody>
         <row>
-         <entry>5.0.0</entry>
+         <entry>7.1.0</entry>
          <entry>
-          Adicionado suporte a contexto.
-         </entry>
-        </row>
-        <row>
-         <entry>5.1.0</entry>
-         <entry>
-      Adicionados os parâmetros <parameter>offset</parameter> e
-      <parameter>maxlen</parameter>.
+          Suporte para <parameter>offset</parameter>s negativos foi adicionado.
          </entry>
         </row>
        </tbody>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -50,18 +50,13 @@
       <varlistentry>
        <term><parameter>flags</parameter></term>
        <listitem>
-        <warning>
+        <note>
          <para>
-      Para todas as versões anteriores ao PHP 6, este parâmetro é chamado
-      <parameter>use_include_path</parameter> e é um <type>bool</type>.
-          O parâmetro <parameter>flags</parameter> está disponível somente
-      a partir do PHP 6. Se você estiver usando uma versão anterior e quiser buscar
-      o arquivo <parameter>filename</parameter> no
-      <link linkend="ini.include-path">include_path</link>, este
-      parâmetro deve ser &true;. A partir do PHP 6, você deve usar a flag
-      <constant>FILE_USE_INCLUDE_PATH</constant>.
+      A constante <constant>FILE_USE_INCLUDE_PATH</constant>
+      pode ser usada para acionar a busca no
+      <link linkend="ini.include-path">include path</link>.
          </para>
-        </warning>
+        </note>
         <para>
      O valor de <parameter>flags</parameter> pode ser qualquer combinação das
      seguintes flags (com algumas restrições), unidas com o operador binário OR

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -145,8 +145,9 @@
    <refsect1 role="returnvalues">
     &reftitle.returnvalues;
     <para>
-   A função retorna os dados lidos ou &false; em caso de falha.
+   A função retorna os dados lidos &return.falseforfailure;.
     </para>
+    &return.falseproblem;
    </refsect1>
 
    <refsect1 role="examples">

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -8,7 +8,7 @@
    <refsect1 role="description">
     &reftitle.description;
     <methodsynopsis>
-     <type>string</type><methodname>file_get_contents</methodname>
+     <type class="union"><type>string</type><type>false</type></type><methodname>file_get_contents</methodname>
      <methodparam><type>string</type><parameter>filename</parameter></methodparam>
      <methodparam choice="opt"><type>bool</type><parameter>use_include_path</parameter><initializer>&false;</initializer></methodparam>
      <methodparam choice="opt"><type>resource</type><parameter>context</parameter></methodparam>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- EN-Revision: n/a Maintainer: diogo Status: ready --><!-- CREDITS: ae -->
-  <refentry xml:id="function.file-get-contents" xmlns="http://docbook.org/ns/docbook">
+  <refentry xml:id="function.file-get-contents" xmlns:xlink="http://www.w3.org/1999/xlink">
    <refnamediv>
     <refname>file_get_contents</refname>
     <refpurpose>Lê todo o conteúdo de um arquivo para uma string</refpurpose>
@@ -55,6 +55,10 @@
       A constante <constant>FILE_USE_INCLUDE_PATH</constant>
       pode ser usada para acionar a busca no
       <link linkend="ini.include-path">include path</link>.
+      Isto não é possível se a
+      <link linkend="language.types.declarations.strict">tipagem estrita</link>
+      estiver habilitada, já que <constant>FILE_USE_INCLUDE_PATH</constant> é um
+      <type>int</type>. Em vez disso, use &true;.
          </para>
         </note>
        </listitem>


### PR DESCRIPTION
Aplica modificações feitas na documentação em inglês da função `file_get_contents()`.

Commits originais analisados:
- php/doc-en@871a231
- php/doc-en@6a7a96c
- php/doc-en@ef88bff
- php/doc-en@a9a6224
- php/doc-en@b95d28e
- php/doc-en@be5b0f3
- php/doc-en@b824e2b
- php/doc-en@52ac14f
- php/doc-en@b8758b0
- php/doc-en@728e8c4
- php/doc-en@d225d89
- php/doc-en@5702a6c
- php/doc-en@e41aab5
- php/doc-en@eda3b06
- php/doc-en@33040b3
- php/doc-en@821c5e4
- php/doc-en@6c29c4c
- php/doc-en@a387db6
- php/doc-en@82ad9d6
- php/doc-en@c02fdb4
- php/doc-en@658b27b
- php/doc-en@076bad3
- php/doc-en@3e57d6c
- php/doc-en@7af997f
- php/doc-en@f658721
- php/doc-en@67b72af
- php/doc-en@a3be604
- php/doc-en@b51dded
- php/doc-en@242fa85
- php/doc-en@8bf5f1a
- php/doc-en@4375ee5
- php/doc-en@5730e7a
- php/doc-en@f8416d8