### PR TITLE
Remove mudanças do PHP 4.x.x em reference

### DIFF
--- a/reference/array/functions/array-search.xml
+++ b/reference/array/functions/array-search.xml
@@ -94,13 +94,6 @@
         parâmetros inválidos.
        </entry>
       </row>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        Antes do PHP 4.2.0, <function>array_search</function> retorna &null;
-        em caso de falha ao invés de &false;.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/array/functions/array-sum.xml
+++ b/reference/array/functions/array-sum.xml
@@ -36,31 +36,7 @@
    Retorna a soma de valores como um inteiro ou float.
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2.1</entry>
-       <entry>
-        Versões do PHP anteriores a 4.2.1 modificam o valor do próprio array passado
-        e converte string para números (que na maioria das vezes converte para
-        zero, dependendo do valor).
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/array-walk.xml
+++ b/reference/array/functions/array-walk.xml
@@ -92,30 +92,7 @@
    ou usando <function>error_reporting</function>.
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        Passagem da chave e <parameter>userdata</parameter> para
-        <parameter>funcname</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   <para>
    <example>

--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -79,29 +79,7 @@
    </para>
   </caution>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        O parâmetro opcional <parameter>mode</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/extract.xml
+++ b/reference/array/functions/extract.xml
@@ -159,44 +159,7 @@
    símbolo.
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <constant>EXTR_REFS</constant> foi adicionado.
-       </entry>
-      </row>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        <constant>EXTR_IF_EXISTS</constant> e <constant>EXTR_PREFIX_IF_EXISTS</constant>
-        foram adicionados.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.5</entry>
-       <entry>
-        Esta função agora retorna um número de variáveis extraídas.
-        <constant>EXTR_PREFIX_INVALID</constant> foi adicionado.
-        <constant>EXTR_PREFIX_ALL</constant> inclue variáveis numéricas também.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -64,29 +64,7 @@
    &false; caso contrário.
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        <parameter>needle</parameter> pode agora ser um array.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/ksort.xml
+++ b/reference/array/functions/ksort.xml
@@ -49,29 +49,7 @@
    &return.success;
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        O parâmetro opcional <parameter>sort_flags</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/array/functions/usort.xml
+++ b/reference/array/functions/usort.xml
@@ -57,30 +57,7 @@
    &return.success;
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.1.0</entry>
-       <entry>
-        O novo algoritmo de ordenação foi introduzido. A <parameter>cmp_function</parameter>
-        não mantem a ordenação original para elementos comparando como igual.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/classobj/functions/get-class-methods.xml
+++ b/reference/classobj/functions/get-class-methods.xml
@@ -56,12 +56,6 @@
         foram declarados (case-sensitive). No PHP 4 eles ficavam em minúsculo.
        </entry>
       </row>
-      <row>
-       <entry>4.0.6</entry>
-       <entry>
-        A possibilidade de especificar o próprio objeto foi adicionada.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/dir/functions/opendir.xml
+++ b/reference/dir/functions/opendir.xml
@@ -83,14 +83,6 @@
         URL wrapper.
        </entry>
       </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <parameter>path</parameter> pode também ser uma URL que suporte
-        listagem de diretório, contudo somente o <literal>file://</literal>
-        URL wrapper suporta isto no PHP 4
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -189,22 +189,6 @@
         O parâmetro <parameter>error_types</parameter> foi introzido.
        </entry>
       </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Ao invés do nome da função, uma matriz contendo a referência a um objeto
-        e um nome de metodo pode também ser dada como argumento para
-        <parameter>error_handler</parameter>.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.2</entry>
-       <entry>
-        Três parâmetros opcionais foram adicionados para a função do usuário <parameter>error_handler</parameter>.
-        Estes são o nome do arquivo, p número da linha e
-        o contexto.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -47,35 +47,7 @@
     <function>exif_imagetype</function> é mais rápida.
    </para>
   </refsect1>
-  <refsect1 role="changelog">
-   &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>4.3.2</entry>
-        <entry>
-         Suporte para <acronym>JPC</acronym>, <acronym>JP2</acronym>,
-         <acronym>JPX</acronym>, <acronym>JB2</acronym>,
-         <acronym>XBM</acronym>, e <acronym>WBMP</acronym>
-        </entry>
-       </row>
-       <row>
-        <entry>4.3.0</entry>
-        <entry>Suporte para <acronym>SWC</acronym></entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
-  </refsect1>
+
   <refsect1 role="constants">
    &reftitle.constants;
    <para>

--- a/reference/exif/functions/exif-thumbnail.xml
+++ b/reference/exif/functions/exif-thumbnail.xml
@@ -78,37 +78,7 @@
    miniatura.
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        O parâmetro opcional <parameter>width</parameter>,
-        <parameter>height</parameter>, e <parameter>imagetype</parameter>
-        tornaram-se disponíveis.
-       </entry>
-      </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Pode retornar miniatura no formato <acronym>TIFF</acronym>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/filesystem/functions/copy.xml
+++ b/reference/filesystem/functions/copy.xml
@@ -94,14 +94,6 @@
         Adicionado suporte à contexto.
        </entry>
       </row>
-      <row>
-     <entry>4.3.0</entry>
-     <entry>
-      Ambos <parameter>source</parameter> e <parameter>dest</parameter>
-      podem ser URLs se "fopen wrappers" tenham sido habilitados.
-      Veja <function>fopen</function> para mais detalhes.
-     </entry>
-    </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -132,12 +132,6 @@
         -->
        </entry>
       </row>
-      <row>
-       <entry>4.3.5</entry>
-       <entry>
-        <function>fgetcsv</function> passou a ser segura para binários (binary-safe)
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/filesystem/functions/fgets.xml
+++ b/reference/filesystem/functions/fgets.xml
@@ -61,30 +61,6 @@
     </para>
    </refsect1>
 
-   <refsect1 role="changelog">
-    &reftitle.changelog;
-    <para>
-     <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>&Version;</entry>
-         <entry>&Description;</entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>4.3.0</entry>
-         <entry>
-          <function>fgets</function> passou a ser segura para binários
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
-    </para>
-   </refsect1>
-
    <refsect1 role="examples">
     &reftitle.examples;
     <para>

--- a/reference/filesystem/functions/file.xml
+++ b/reference/filesystem/functions/file.xml
@@ -173,12 +173,6 @@
         habilitado com 1
        </entry>
       </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <function>file</function> tornou-se segura para binários
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -94,33 +94,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.1</entry>
-       <entry>
-        As constantes <literal>LOCK_XXX</literal> foram adicionadas. Ao invés de
-        você precisa usar 1 para <constant>LOCK_SH</constant>, 2 
-        <constant>LOCK_EX</constant>, 3 para <constant>LOCK_UN</constant> e
-        4 para <constant>LOCK_NB</constant>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/filesystem/functions/fopen.xml
+++ b/reference/filesystem/functions/fopen.xml
@@ -264,41 +264,6 @@ $handle = fopen("c:\\data\\info.txt", "r");
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.2</entry>
-       <entry>
-        A partir do PHP 4.3.2, o modo padrão é definido para binário em todas
-        as plataformas que distinguem entre modo texto e binário. Se você estiver
-        tendo problemas com seus scripts depois de uma atualização, tente acrescentar a
-        flag <literal>'t'</literal> como um paliativo até que você tenha tornado seus
-        scripts portáveis como mencionado acima.
-       </entry>
-      </row>
-      <row>
-       <entry>4.3.2</entry>
-       <entry>
-        As opções <literal>'x'</literal> e <literal>'x+'</literal> foram
-        adicionadas
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -69,32 +69,6 @@
    devem ser passados por referência.
   </para>
  </refsect1>
- 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Antes do PHP 4.3.0, o maior número de caracteres lidos do
-        arquivo era 512 (ou o primeiro \n, o que viesse primeiro).
-        Agora, linhas de qualquer comprimento são lidas e interpretadas.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/filesystem/functions/mkdir.xml
+++ b/reference/filesystem/functions/mkdir.xml
@@ -105,12 +105,6 @@
         <function>mkdir</function>
        </entry>
       </row>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        O parâmetro <parameter>mode</parameter> tornou-se opcional.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -85,13 +85,6 @@
         Valores envolvidos em aspas duplas podem conter novas linhas.
        </entry>
       </row>
-      <row>
-       <entry>4.2.1</entry>
-       <entry>
-        Esta função agora é afetada por &safemode; e
-        <link linkend="ini.open-basedir">open_basedir</link>.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/filesystem/functions/rename.xml
+++ b/reference/filesystem/functions/rename.xml
@@ -92,17 +92,6 @@
         <function>rename</function> suporta.
        </entry>
       </row>
-      <row>
-       <entry>4.3.3</entry>
-       <entry>
-        <function>rename</function> agora pode renomear arquivos de diferente
-        partições em sistemas baseados em *nix, desde que as permissões
-        possam ser preservadas. Warnings são emitidos se o filesytem destino
-        não permite chamadas <literal>chown()</literal> ou
-        <literal>chmod()</literal> nos arquivos —
-        por exemplo, se a destinação é um filesystem FAT.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/filesystem/functions/stat.xml
+++ b/reference/filesystem/functions/stat.xml
@@ -137,32 +137,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.6</entry>
-       <entry>
-        Além de retornar estes atributos em um array numérico, eles
-        podem ser acessados com índices associativos, como notado para cada
-        parâmetro
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="notes">
   &reftitle.notes;
   &note.clearstatcache;

--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -53,48 +53,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.6</entry>
-       <entry>
-        Antes do PHP 4.0.6 o comportamento da função
-        <function>tempnam</function> era dependente do sistema. No 
-        Windows a váriavel de ambiente do sistema TMP irá sobreescrever o 
-        parâmetro <parameter>dir</parameter>; no Linux a váriavel de ambiente TMPDIR 
-        tem precedência, enquanto SVR4 irá sempre usar 
-        o parâmetro <parameter>dir</parameter> se o diretório para o qual
-        ele aponta existe. Consulte a documentação do seu sistema
-        para a função tempnam(3) na dúvida.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.3</entry>
-       <entry>
-        O comportamento desta função mudou na versão 4.0.3. O arquivo
-        temporário é também criado para evitar uma condição de corrida (race)
-        onde o arquivo pode aparecer no filesystem entre o tempo que a string
-        foi gerada e antes que o script tem tempo para criar o arquivo. Note que você
-        precisa remover o arquivo caso não vá mais utilizá-lo, pois isso não é feito
-        automaticamente.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/ftp/functions/ftp-connect.xml
+++ b/reference/ftp/functions/ftp-connect.xml
@@ -80,29 +80,7 @@ $conn_id = ftp_connect($ftp_server) or die("Couldn't connect to $ftp_server");
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        <parameter>timeout</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -112,29 +112,7 @@ fclose($handle);
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <parameter>resumepos</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/ftp/functions/ftp-fput.xml
+++ b/reference/ftp/functions/ftp-fput.xml
@@ -108,29 +108,7 @@ fclose($fp);
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <parameter>startpos</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/ftp/functions/ftp-get.xml
+++ b/reference/ftp/functions/ftp-get.xml
@@ -109,29 +109,7 @@ ftp_close($conn_id);
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <parameter>resumepos</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/ftp/functions/ftp-put.xml
+++ b/reference/ftp/functions/ftp-put.xml
@@ -103,29 +103,7 @@ ftp_close($conn_id);
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <parameter>startpos</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/ftp/functions/ftp-rawlist.xml
+++ b/reference/ftp/functions/ftp-rawlist.xml
@@ -102,29 +102,7 @@ array(3) {
    </example>
   </para>
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <parameter>recursive</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/gmp/functions/gmp-init.xml
+++ b/reference/gmp/functions/gmp-init.xml
@@ -57,30 +57,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.1.0</entry>
-       <entry>
-        O parâmetro opcional <parameter>base</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
     <para>

--- a/reference/ibase/functions/ibase-connect.xml
+++ b/reference/ibase/functions/ibase-connect.xml
@@ -132,31 +132,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        Os parâmetros <parameter>buffers</parameter>, <parameter>dialect</parameter>
-        e <parameter>role</parameter> foram adicionados.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/ibase/functions/ibase-pconnect.xml
+++ b/reference/ibase/functions/ibase-pconnect.xml
@@ -130,31 +130,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        Os parâmetros <parameter>buffers</parameter>, <parameter>dialect</parameter>
-        e <parameter>role</parameter> foram adicionados
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/image/functions/imagefttext.xml
+++ b/reference/image/functions/imagefttext.xml
@@ -134,29 +134,7 @@
   &reftitle.notes;
   &note.freetype;
  </refsect1>
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.5</entry>
-       <entry>
-        <parameter>extrainfo</parameter> tornou-se opcional.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-    </para>
-   </refsect1>
+
   </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/mysql/functions/mysql-connect.xml
+++ b/reference/mysql/functions/mysql-connect.xml
@@ -96,49 +96,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Adicionado o parâmetro <parameter>client_flags</parameter>.
-       </entry>
-      </row>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        Adicionado o parâmetro <parameter>new_link</parameter>.
-       </entry>
-      </row>
-      <row>
-       <entry>3.0.10</entry>
-       <entry>
-        Adicionado o suporte para ":/caminho/para/socket" com 
-        <parameter>server</parameter>.
-       </entry>
-      </row>
-      <row>
-       <entry>3.0.0</entry>
-       <entry>
-        Adicionado o suporte para ":porta" com <parameter>server</parameter>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysql/functions/mysql-db-query.xml
+++ b/reference/mysql/functions/mysql-db-query.xml
@@ -55,32 +55,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.6</entry>
-       <entry>
-        Esta função é obsoleta, não use esta função. Use 
-        <function>mysql_select_db</function> e 
-        <function>mysql_query</function> ao invés.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysql/functions/mysql-escape-string.xml
+++ b/reference/mysql/functions/mysql-escape-string.xml
@@ -49,31 +49,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        This function became deprecated, do not use this function. Instead, 
-        use <function>mysql_real_escape_string</function>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysql/functions/mysql-pconnect.xml
+++ b/reference/mysql/functions/mysql-pconnect.xml
@@ -112,43 +112,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Adicionado o parâmetro <parameter>client_flags</parameter>.
-       </entry>
-      </row>
-      <row>
-       <entry>3.0.10</entry>
-       <entry>
-        Adicionado o suporte a ":/path/to/socket" com
-        <parameter>server</parameter>.
-       </entry>
-      </row>
-      <row>
-       <entry>3.0.0</entry>
-       <entry>
-        Adicionado o suporte a ":port" com <parameter>server</parameter>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="notes">
   &reftitle.notes;
   <note>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -247,13 +247,6 @@
         enviados ao navegador.
        </entry>
       </row>
-      <row>
-       <entry>4.3.2</entry>
-       <entry>
-        Esta função foi modificada para retornar &false; no caso de
-        <parameter>output_callback</parameter> não for executável.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -33,14 +33,6 @@
      </entry>
      <entry></entry>
     </row>
-    <row xml:id="constant.preg-offset-capture">
-     <entry><constant>PREG_OFFSET_CAPTURE</constant></entry>
-     <entry>
-      Veja a descrição da
-      <constant>PREG_SPLIT_OFFSET_CAPTURE</constant>.
-     </entry>
-     <entry>4.3.0</entry>
-    </row>
     <row xml:id="constant.preg-split-no-empty">
      <entry><constant>PREG_SPLIT_NO_EMPTY</constant></entry>
      <entry>
@@ -48,25 +40,6 @@
       branco.
      </entry>
      <entry></entry>
-    </row>
-    <row xml:id="constant.preg-split-delim-capture">
-     <entry><constant>PREG_SPLIT_DELIM_CAPTURE</constant></entry>
-     <entry>
-      Esta flag diz a <function>preg_split</function> capturar
-      expressões entre parênteses no delimitador do padrão também.
-     </entry>
-     <entry>4.0.5</entry>
-    </row>
-    <row xml:id="constant.preg-split-offset-capture">
-     <entry><constant>PREG_SPLIT_OFFSET_CAPTURE</constant></entry>
-     <entry>
-      Se esta flag é usada, para cada combinação será retornada também a posição da
-      string. Note que esta modificação retorna valores em um array onde cada
-      elemento é um array consistindo da string combinada no índice 0 e a posição
-      na string alvo na índice 1. Esta flag somente é
-      utilizada por <function>preg_split</function>.
-     </entry>
-     <entry>4.3.0</entry>
     </row>
     <row xml:id="constant.preg-unmatched-as-null">
      <entry><constant>PREG_UNMATCHED_AS_NULL</constant></entry>

--- a/reference/pcre/functions/preg-grep.xml
+++ b/reference/pcre/functions/preg-grep.xml
@@ -63,44 +63,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        O parâmetro <parameter>flags</parameter> foi adicionado.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.4</entry>
-       <entry>
-        <para>
-         Antes desta versão, o array retornado era indexado diferente das
-         chaves do array de <parameter>input</parameter>.
-        </para>
-        <para>
-         Se você quer reproduzir o antigo comportamento, use
-         <function>array_values</function> no array retornado para reindexar
-          os valores.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/pcre/functions/preg-split.xml
+++ b/reference/pcre/functions/preg-split.xml
@@ -104,42 +104,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        A <constant>PREG_SPLIT_OFFSET_CAPTURE</constant> foi adicionada
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.5</entry>
-       <entry>
-        A <constant>PREG_SPLIT_DELIM_CAPTURE</constant> foi adicionada
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        O parâmetro <parameter>flags</parameter> foi adicionado
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/session/functions/session-start.xml
+++ b/reference/session/functions/session-start.xml
@@ -101,15 +101,6 @@
         Anteriormente, &true; era retornado.
        </entry>
       </row>
-      <row>
-       <entry>4.3.3</entry>
-       <entry>
-        A partir do PHP 4.3.3, chamar <function>session_start</function>
-        depois da sessão já ter iniciada resultará em um
-        erro de level <constant>E_NOTICE</constant>.  E a
-        a segunda chamada para iniciar a sessão simplesmente será ignorada.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -95,12 +95,6 @@
         Suporte a <parameter>limit</parameter> negativo foi adicionado
        </entry>
       </row>
-      <row>
-       <entry>4.0.1</entry>
-       <entry>
-        O parâmetro <parameter>limit</parameter> foi adicionado
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -124,18 +124,6 @@
         O parâmetro <parameter>double_encode</parameter> foi adicionado.
        </entry>
       </row>
-      <row>
-       <entry>4.1.0</entry>
-       <entry>
-        O parâmetro <parameter>charset</parameter> foi adicionado.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.3</entry>
-       <entry>
-        O parâmetro <parameter>quote_style</parameter> foi adicionado.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/ltrim.xml
+++ b/reference/strings/functions/ltrim.xml
@@ -94,30 +94,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.1.0</entry>
-       <entry>
-        O parâmetro <parameter>charlist</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/strings/functions/nl2br.xml
+++ b/reference/strings/functions/nl2br.xml
@@ -41,32 +41,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.5</entry>
-       <entry>
-        <function>nl2br</function> é agora XHTML compliant. Todas versões anteriores
-        retornam <parameter>string</parameter> com '&lt;br&gt;' inserido
-        antes de newlines ao invés de '&lt;br /&gt;'.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
    <para>

--- a/reference/strings/functions/parse-str.xml
+++ b/reference/strings/functions/parse-str.xml
@@ -67,30 +67,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.3</entry>
-       <entry>
-        O parâmetro <parameter>arr</parameter> foi adicionado
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
     <para>

--- a/reference/strings/functions/rtrim.xml
+++ b/reference/strings/functions/rtrim.xml
@@ -96,30 +96,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.1.0</entry>
-       <entry>
-        O parâmetro <parameter>charlist</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/strings/functions/sprintf.xml
+++ b/reference/strings/functions/sprintf.xml
@@ -230,30 +230,6 @@ printf($format, $num, $location);
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.6</entry>
-       <entry>
-        Suporte para argumento numerado/troca foi adicionado
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/reference/strings/functions/str-replace.xml
+++ b/reference/strings/functions/str-replace.xml
@@ -110,25 +110,6 @@ surfmax, amandavale -->
         O parâmetro <parameter>count</parameter> foi adicionado.
        </entry>
       </row>
-      <row>
-       <entry>4.3.3</entry>
-       <entry>       
-        O comportamento desta função foi modificado. Em antigas versões um bug 
-        existia ao se usar arrays em ambos os parâmetros <parameter>search</parameter> 
-        e <parameter>replace</parameter> que causava índices de 
-        <parameter>search</parameter> vazios para serem pulados sem avançar o
-        apontador interno no array <parameter>replace</parameter>. 
-        Isto foi corrigido no PHP 4.3.3, quaisquer scripts que contavam com este
-        bug removeriam valores de pesquisa vazios anteriores à chamada desta função
-        afim de imitar o comportamento original.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.5</entry>
-       <entry>
-        Mais parâmetros podem agora ser um <type>array</type>.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/str-rot13.xml
+++ b/reference/strings/functions/str-rot13.xml
@@ -64,33 +64,6 @@ echo str_rot13('PHP 4.3.0'); // CUC 4.3.0
    </example>
   </para>
  </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        O comportamento desta função foi reparado. Antes disso, o
-        <parameter>str</parameter> foi também modificado, como se fosse por
-        referência.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- 
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/strings/functions/strcspn.xml
+++ b/reference/strings/functions/strcspn.xml
@@ -69,31 +69,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        O <parameter>start</parameter> e <parameter>length</parameter>
-        foram adicionados
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="notes">
   &reftitle.notes;
   &note.bin-safe;

--- a/reference/strings/functions/strip-tags.xml
+++ b/reference/strings/functions/strip-tags.xml
@@ -76,18 +76,6 @@
         <function>strip_tags</function> tornou-se binary safe
        </entry>
       </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Comentários HTML são sempre retirados
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        O parâmetro <parameter>allowable_tags</parameter> foi adicionado
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/stristr.xml
+++ b/reference/strings/functions/stristr.xml
@@ -85,12 +85,6 @@
         Adicionado o parâmetro opcional <parameter>before_needle</parameter>.
        </entry>
       </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <function>stristr</function> tornou-se binary safe.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/strspn.xml
+++ b/reference/strings/functions/strspn.xml
@@ -84,31 +84,6 @@ $var = strspn("42 is the answer, what is the question ...", "1234567890");
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        Os parâmetros <parameter>start</parameter> e <parameter>length</parameter>
-        foram adicionados
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/strings/functions/strstr.xml
+++ b/reference/strings/functions/strstr.xml
@@ -95,12 +95,6 @@
         Adicionado o parâmetro opcional <parameter>before_needle</parameter>.
        </entry>
       </row>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        <function>strstr</function> tornou-se binary safe.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -85,31 +85,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        Os parâmetros <parameter>to</parameter> e <parameter>from</parameter>
-        foram adicionados.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/strings/functions/trim.xml
+++ b/reference/strings/functions/trim.xml
@@ -94,30 +94,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.1.0</entry>
-       <entry>
-        O parâmetro opcional <parameter>charlist</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/strings/functions/wordwrap.xml
+++ b/reference/strings/functions/wordwrap.xml
@@ -73,30 +73,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.3</entry>
-       <entry>
-        O parâmetro opcional <parameter>cut</parameter> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -50,42 +50,6 @@
      houverem mais linhas.
     </para>
    </refsect1>
-   
-   <refsect1 role="changelog">
-    &reftitle.changelog;
-    <para>
-     <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>&Version;</entry>
-         <entry>&Description;</entry>
-        </row>
-       </thead>
-      <tbody>
-      <row>
-       <entry>4.3.3</entry>
-       <entry>
-        Esta função existe quando compilado com suporte a IBM DB2 ou UnixODBC.
-       </entry>
-      </row>
-      <row>
-       <entry>4.3.2</entry>
-       <entry>
-        Esta função existe quando compilado para Windows.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.2</entry>
-       <entry>
-        Esta função existe quando compilado com suporte DBMaker.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -51,42 +51,6 @@
     </para>
    </refsect1>
 
-   <refsect1 role="changelog">
-    &reftitle.changelog;
-    <para>
-     <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>&Version;</entry>
-         <entry>&Description;</entry>
-        </row>
-       </thead>
-      <tbody>
-       <row>
-        <entry>4.3.3</entry>
-        <entry>
-         Esta função existe quando compilado com suporte a IBM DB2 ou UnixODBC.
-        </entry>
-       </row>
-       <row>
-        <entry>4.3.2</entry>
-        <entry>
-         Esta função existe quando compilada para o Windows.
-        </entry>
-       </row>
-       <row>
-        <entry>4.0.2</entry>
-        <entry>
-         Esta função existe quando compilado com suporte DBMaker.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
-  </refsect1>
-
   <refsect1 role="seealso">
    &reftitle.seealso;
    <para>

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -78,44 +78,6 @@
   &note.uses-ob;
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.3.0</entry>
-       <entry>
-        O parâmetro <parameter>return</parameter> foi adicionado. Se você
-        precisar capturar a saída de <function>print_r</function> em uma
-        função anterior do PHP, utilize <link linkend="ref.outcontrol">funções
-        de controle de saída</link>.
-       </entry>
-      </row>
-      <row>
-       <entry>4.0.4</entry>
-       <entry>
-        Antes de PHP 4.0.4, <function>print_r</function> será executada para
-        sempre se forem fornecidos <type>array</type> ou
-        <type>objeto</type> que contêm uma referência direta ou indireta para
-        eles mesmos. Um exemplo é <literal>print_r($GLOBALS)</literal> porque 
-        <literal>$GLOBALS</literal> é ela própria uma variável global que contém uma
-        referência para ela mesma.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -193,31 +193,6 @@ Before unset: 3, after unset: 23
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.0.0</entry>
-       <entry>
-        <function>unset</function> tornou-se uma expressão. (No PHP 3,
-        <function>unset</function> sempre retorna 1).
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/zlib/functions/gzencode.xml
+++ b/reference/zlib/functions/gzencode.xml
@@ -72,33 +72,7 @@
    A string codificada, ou &false; se aconteceu um erro.
   </para>
  </refsect1>
- 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2</entry>
-       <entry>
-        <parameter>level</parameter> foi adicionado. <function>gzencode</function>
-        apenas tinha os parâmetros <parameter>data</parameter> e o opcional
-        <parameter>encoding_mode</parameter> antes.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Parece haver um movimento¹ na documentação em inglês para eliminar changelogs relacionados ao PHP 7.0.0, 5.x e 4.x.

Se aceito, este pull request irá remover todas as entradas de changelog do PHP 4.x.x na pasta reference, que não existem mais na documentação original. No momento existem essas entradas no repo php/doc-en:

```
doc-en$ grep -r '<entry>4\.' reference | sort
reference/fdf/functions/fdf-get-value.xml:       <entry>4.3.0</entry>
reference/ldap/functions/ldap-read.xml:       <entry>4.0.5</entry>
reference/mysql/configure.xml:      <entry>4.x.x</entry>
reference/mysql/functions/mysql-list-tables.xml:       <entry>4.3.7</entry>
reference/yaz/functions/yaz-connect.xml:       <entry>4.1.0</entry>
```

Destas, apenas a do arquivo `reference/mysql/configure.xml` existe aqui e será mantida.

1. Exemplos de commits relacionados no repositório php/doc-en:
    - php/doc-en@04c08d2238 really remove PHP 5 changelog.
    - php/doc-en@fc54f9a81a fix example; remove PHP 5 changelog.
    - php/doc-en@3e15d2894f Remove more changelog entries, mostly from PHP 5.4 era.
    - php/doc-en@7f569e1f17 Remove more changelog entries, mostly from PHP 5.3 era.
    - php/doc-en@9af43469f4 Remove more changelog entries, mostly from PHP 5.2 era.
    - php/doc-en@be5b0f33a1 Remove more changelog entries, mostly from PHP 5.1 era.
    - php/doc-en@53bdffa6b9 Removed some of the PHP5 changelogs.
