### PR TITLE
Fix typo - "errro" to "erro"

### DIFF
--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -98,7 +98,7 @@
   <note>
    <para>
     Em alguns sistemas é impossível distinguir entre resultado vazio ou um
-    errro.
+    erro.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
Em alguns sistemas é impossível distinguir entre resultado vazio ou um errro --> Fixed: Em alguns sistemas é impossível distinguir entre resultado vazio ou um
    erro.