### PR TITLE
Fix revision tags status

### DIFF
--- a/reference/ds/ds/stack/count.xml
+++ b/reference/ds/ds/stack/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: @rafaelbernard Status: ready $ -->
+<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: @rafaelbernard Status: ready -->
 
 <refentry xml:id="ds-stack.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/ds/ds/stack/peek.xml
+++ b/reference/ds/ds/stack/peek.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: @rafaelbernard Status: ready $ -->
+<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: @rafaelbernard Status: ready -->
 
 <refentry xml:id="ds-stack.peek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/funchand/functions/func-get-args.xml
+++ b/reference/funchand/functions/func-get-args.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: felipe Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: felipe Status: ready -->
 <refentry xml:id="function.func-get-args" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>func_get_args</refname>

--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/funchand.xml, last change in rev 1.1 -->
   <refentry xml:id="function.register-shutdown-function" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8932dc479ab319693fe984a4eed2b3c768540256 Maintaner: @rafaelbernard Status: ready $ -->
+<!-- EN-Revision: 8932dc479ab319693fe984a4eed2b3c768540256 Maintaner: @rafaelbernard Status: ready -->
 
 <phpdoc:classref xml:id="class.gmp" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/reflection/reflectionnamedtype/getname.xml
+++ b/reference/reflection/reflectionnamedtype/getname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c5971e972a89c151ff1455853fdc41c19483788c Maintaner: @rafaelbernard Status: ready $ -->
+<!-- EN-Revision: c5971e972a89c151ff1455853fdc41c19483788c Maintaner: @rafaelbernard Status: ready -->
 
 <refentry xml:id="reflectionnamedtype.getname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/shmop/configure.xml
+++ b/reference/shmop/configure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: marcelo Status: ready -->
 <section xml:id="shmop.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>

--- a/reference/shmop/functions/shmop-open.xml
+++ b/reference/shmop/functions/shmop-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/shmop.xml, last change in rev 1.12 -->
   <refentry xml:id="function.shmop-open" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/shmop/functions/shmop-read.xml
+++ b/reference/shmop/functions/shmop-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/shmop.xml, last change in rev 1.1 -->
   <refentry xml:id="function.shmop-read" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/shmop/functions/shmop-write.xml
+++ b/reference/shmop/functions/shmop-write.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/shmop.xml, last change in rev 1.1 -->
   <refentry xml:id="function.shmop-write" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.3 -->
   <refentry xml:id="function.socket-bind" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-close.xml
+++ b/reference/sockets/functions/socket-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.1 -->
   <refentry xml:id="function.socket-close" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-connect.xml
+++ b/reference/sockets/functions/socket-connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.1 -->
   <refentry xml:id="function.socket-connect" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-create-pair.xml
+++ b/reference/sockets/functions/socket-create-pair.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-create-pair" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.4 -->
   <refentry xml:id="function.socket-create" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-get-option.xml
+++ b/reference/sockets/functions/socket-get-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-get-option" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-getpeername.xml
+++ b/reference/sockets/functions/socket-getpeername.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-getpeername" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-getsockname" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-last-error.xml
+++ b/reference/sockets/functions/socket-last-error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.1 -->
   <refentry xml:id="function.socket-last-error" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-listen.xml
+++ b/reference/sockets/functions/socket-listen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.1 -->
   <refentry xml:id="function.socket-listen" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-read.xml
+++ b/reference/sockets/functions/socket-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.8 -->
   <refentry xml:id="function.socket-read" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-recvfrom.xml
+++ b/reference/sockets/functions/socket-recvfrom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-recvfrom" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-select" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-send.xml
+++ b/reference/sockets/functions/socket-send.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-send" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-sendto" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-set-block.xml
+++ b/reference/sockets/functions/socket-set-block.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
   <refentry xml:id="function.socket-set-block" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>
     <refname>socket_set_block</refname>

--- a/reference/sockets/functions/socket-set-nonblock.xml
+++ b/reference/sockets/functions/socket-set-nonblock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-set-nonblock" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-set-option" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-shutdown.xml
+++ b/reference/sockets/functions/socket-shutdown.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-shutdown" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-strerror.xml
+++ b/reference/sockets/functions/socket-strerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.8 -->
   <refentry xml:id="function.socket-strerror" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/sockets/functions/socket-write.xml
+++ b/reference/sockets/functions/socket-write.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: marcelo Status: ready $ -->
+<!-- EN-Revision: n/a Maintainer: marcelo Status: ready -->
 <!-- splitted from ./en/functions/sockets.xml, last change in rev 1.27 -->
   <refentry xml:id="function.socket-write" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>

--- a/reference/swoole/swoole/http/server/on.xml
+++ b/reference/swoole/swoole/http/server/on.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: @rafaelbernard Status: ready $ -->
+<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: @rafaelbernard Status: ready -->
 
 <refentry xml:id="swoole-http-server.on" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/http/server/start.xml
+++ b/reference/swoole/swoole/http/server/start.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: @rafaelbernard Status: ready $ -->
+<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: @rafaelbernard Status: ready -->
 
 <refentry xml:id="swoole-http-server.start" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Corrige o a tag de status de alguns arquivos, removendo um `$` extra antes do fechamento.

![image](https://user-images.githubusercontent.com/7695608/148717001-e26f37a9-0a47-43ac-b0af-9c21eef40ed1.png)
