### PR TITLE
Função array-walk sem o parâmetro de callback

### DIFF
--- a/reference/array/functions/array-walk.xml
+++ b/reference/array/functions/array-walk.xml
@@ -9,13 +9,13 @@
   &reftitle.description;
    <methodsynopsis>
     <type>bool</type><methodname>array_walk</methodname>
-    <methodparam><type>array</type><parameter role="reference">arrary</parameter></methodparam>
-    <methodparam><type>string</type><parameter>funcname</parameter></methodparam>
+    <methodparam><type>array</type><parameter role="reference">array</parameter></methodparam>
+    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
     <methodparam choice="opt"><type>mixed</type><parameter>userdata</parameter></methodparam>
    </methodsynopsis>
   <simpara>
-   Aplica uma função definida pelo usuário nomeada pelo argumento
-   <parameter>funcname</parameter> em cada elemento de <parameter>array</parameter>.
+   Aplica uma função definida pelo usuário passada pelo argumento
+   <parameter>callback</parameter> em cada elemento de <parameter>array</parameter>.
   </simpara>
   <para>
    <function>array_walk</function> não é afetado pelo ponteiro interno de
@@ -36,18 +36,18 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>funcname</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
-       Normalmente, <parameter>funcname</parameter> recebe dois parâmetros.
+       Normalmente, <parameter>callback</parameter> recebe dois parâmetros.
        O valor do parâmetro <parameter>array</parameter> sendo o primeiro, e 
        a chave/índice o segundo.
       </para>
       <note>
        <para>
-        Se <parameter>funcname</parameter> precisar alterar realmente os valores 
+        Se <parameter>callback</parameter> precisar alterar realmente os valores 
         do array, especifique que o primeiro parâmetro de
-        <parameter>funcname</parameter> deve ser passado por <link linkend="language.references">
+        <parameter>callback</parameter> deve ser passado por <link linkend="language.references">
         referência</link>. Então qualquer mudança feita nesses elementos serão feitas 
         no próprio array também.
        </para>
@@ -66,7 +66,7 @@
       <para>
        Se o parâmetro opcional <parameter>userdata</parameter> é fornecido,
        será passado como o terceiro parâmetro para o callback
-       <parameter>funcname</parameter>.
+       <parameter>callback</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -82,7 +82,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Se <parameter>funcname</parameter> necessita de mais argumentos do que o que
+   Se <parameter>callback</parameter> necessita de mais argumentos do que o que
    está sendo passado para ela, um erro do nível <link linkend="errorfunc.constants">
    E_WARNING</link> será gerado a cada vez que 
    <function>array_walk</function> executar


### PR DESCRIPTION
A função array_walk() pode receber a função de manipulação como callback. Na nossa versão em português dizia que tinha que ser passado o nome da função.