### PR TITLE
Fix "prôvem" (#164)

### DIFF
--- a/reference/exec/book.xml
+++ b/reference/exec/book.xml
@@ -9,7 +9,7 @@
  <preface xml:id="intro.exec">
   &reftitle.intro;
   <para>
-   Estas funções prôvem meios para executar comandos no sistema
+   Estas funções provém meios para executar comandos no sistema
    em si, e meios de tornar seguros estes comandos.
   </para>
  </preface>


### PR DESCRIPTION
Proponho a correção da palavra "prôvem". A palavra correta seria provém.