### PR TITLE
Fix "Estabilitade" (#165)

### DIFF
--- a/security/current.xml
+++ b/security/current.xml
@@ -8,7 +8,7 @@
     melhoramento. Cada versão nova normalmente incluirá mudanças, sejam grandes
     ou pequenas, para melhorar a segurança e reparar falhas, erros de
     configuração, e outros problemas que podem afetar a segurança geral
-    e estabilitade do seu sistema.
+    e estabilidade do seu sistema.
    </simpara>
    <simpara>
     Como outras linguagens de script e programas de nível de sistema, a melhor


### PR DESCRIPTION
Proponho a correção da palavra "Estabilitade". O correto seria estabilidade.