### PR TITLE
Fix Typo

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -291,8 +291,8 @@
      <listitem>
       <simpara>
        O diretório padrão onde localizar extensões carregáveis dinamicamente
-       (podendo ser sobrecrito por <link linkend="ini.extension-dir">extension_dir</link>).
-       Tem como o padrao <constant>PHP_PREFIX</constant> (ou <code>PHP_PREFIX . "\\ext"</code> no Windows).
+       (podendo ser sobrescrito por <link linkend="ini.extension-dir">extension_dir</link>).
+       Tem como o padrão <constant>PHP_PREFIX</constant> (ou <code>PHP_PREFIX . "\\ext"</code> no Windows).
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Correção da palavra "sobrecrito" (correto seria sobrescrito) e a acentuação da palavra "padrão".