### PR TITLE
Traduz seção `language.namespaces.faq`

### DIFF
--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1066,8 +1066,9 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
     </listitem>
     <listitem>
      <simpara>
-      <link linkend="language.namespaces.faq.globalclass">How do I use internal or global
-      classes in a namespace?</link>
+      <link linkend="language.namespaces.faq.globalclass">
+       Como utilizar classes internas ou globais dentro de um namespace?
+      </link>
      </simpara>
     </listitem>
     <listitem>
@@ -1177,21 +1178,21 @@ $a = new stdClass;
    </para>
   </sect2>
   <sect2 xml:id="language.namespaces.faq.globalclass">
-   <title>How do I use internal or global classes in a namespace?</title>
+   <title>Como utilizar classes internas ou globais dentro de um namespace?</title>
    <para>
     <example>
-     <title>Accessing internal classes in namespaces</title>
+     <title>Acessando classes internas em namespaces</title>
      <programlisting role="php">
 <![CDATA[
 <?php
 namespace foo;
 $a = new \stdClass;
 
-function test(\ArrayObject $parameter_type_example = null) {}
+function test(\ArrayObject $exemplo_com_tipo_de_parametro = null) {}
 
 $a = \DirectoryIterator::CURRENT_AS_FILEINFO;
 
-// extending an internal or global class
+// herança de uma classe interna ou global
 class MyException extends \Exception {}
 ?>
 ]]>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1059,8 +1059,9 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
    <orderedlist>
     <listitem>
      <simpara>
-      <link linkend="language.namespaces.faq.shouldicare">If I don't use namespaces, should
-      I care about any of this?</link>
+      <link linkend="language.namespaces.faq.shouldicare">
+       Se eu não utilizo namespames, devo me importar com esta documentação?
+      </link>
      </simpara>
     </listitem>
     <listitem>
@@ -1141,15 +1142,15 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
    </orderedlist>
   </para>
   <sect2 xml:id="language.namespaces.faq.shouldicare">
-   <title>If I don't use namespaces, should I care about any of this?</title>
+   <title>Se eu não utilizo namespames, devo me importar com esta documentação?</title>
    <para>
-    No.  Namespaces do not affect any existing code in any way, or any
-    as-yet-to-be-written code that does not contain namespaces.  You can
-    write this code if you wish:
+    Não. Namespaces não afetam nenhum código que já exista, ou que venha
+    a existir, que não contenha namespaces. Você pode escrever o seguinte se
+    quiser:
    </para>
    <para>
     <example>
-     <title>Accessing global classes outside a namespace</title>
+     <title>Acessando classes glboais fora de um namespace</title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -1160,7 +1161,7 @@ $a = new \stdClass;
     </example>
    </para>
    <para>
-    This is functionally equivalent to:
+    O exemplo acima é equivalente ao seguinte código:
    </para>
    <para>
     <example>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1073,8 +1073,9 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
     </listitem>
     <listitem>
      <simpara>
-      <link linkend="language.namespaces.faq.innamespace">How do I use namespaces classes
-      functions, or constants in their own namespace?</link>
+      <link linkend="language.namespaces.faq.innamespace">
+       Como utilizar classes, funções ou constantes em um namespace, dentro de seu próprio namespace?
+      </link>
      </simpara>
     </listitem>
     <listitem>
@@ -1202,31 +1203,30 @@ class MyException extends \Exception {}
   </sect2>
   <sect2 xml:id="language.namespaces.faq.innamespace">
    <title>
-    How do I use namespaces classes, functions, or constants in their own
-    namespace?
+    Como utilizar classes, funções ou constantes em um namespace, dentro de seu próprio namespace?
    </title>
    <para>
     <example>
-     <title>Accessing internal classes, functions or constants in namespaces</title>
+    <title>Acessando classes, funções ou constantes internas em um namespace</title>
      <programlisting role="php">
 <![CDATA[
 <?php
 namespace foo;
 
-class MyClass {}
+class MinhaClasse {}
 
-// using a class from the current namespace as a parameter type
-function test(MyClass $parameter_type_example = null) {}
-// another way to use a class from the current namespace as a parameter type
-function test(\foo\MyClass $parameter_type_example = null) {}
+// utilizando uma classe do namespace atual como tipo de parâmetro
+function test(MinhaClasse $exemplo_com_tipo_de_parametro = null) {}
+// outra forma de utilizar a classe do namespace atual como tipo de parâmetro
+function test(\foo\MinhaClasse $exemplo_com_tipo_de_parametro = null) {}
 
-// extending a class from the current namespace
+// herança de classe a partir do namespace atual
 class Extended extends MyClass {}
 
-// accessing a global function
+// acessando uma função global
 $a = \globalfunc();
 
-// accessing a global constant
+// acessando uma constante global
 $b = \INI_ALL;
 ?>
 ]]>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1048,14 +1048,14 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
   </example>
  </sect1>
  <sect1 xml:id="language.namespaces.faq">
-  <title>FAQ: things you need to know about namespaces</title>
+  <title>Perguntas Frequentes (FAQ): Coisas que você precisa saber sobre namespaces</title>
   <?phpdoc print-version-for="namespaces"?>
   <para>
-   This FAQ is split into two sections: common questions, and some specifics of
-   implementation that are helpful to understand fully.
+   Este FAQ se divide em duas seções: perguntas comuns e alguns detalhes de
+   implementação úteis de se entender completamente.
   </para>
   <para>
-   First, the common questions.
+   Primeiro, as perguntas comuns.
    <orderedlist>
     <listitem>
      <simpara>
@@ -1105,8 +1105,8 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
    </orderedlist>
   </para>
   <para>
-   There are a few implementation details of the namespace implementations
-   that are helpful to understand.
+   Há alguns detalhes de implementação dos namespaces que são úteis de se
+   entender.
    <orderedlist>
     <listitem>
      <simpara>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1081,8 +1081,8 @@ A\B::foo();   // calls method "foo" of class "B" from namespace "A\A"
     <listitem>
      <simpara>
       <link linkend="language.namespaces.faq.full">
-       How does a name like <literal>\my\name</literal> or <literal>\name</literal>
-       resolve?
+       Como nomes como <literal>\meu\nome</literal> e <literal>\nome</literal>
+       são resolvidos?
       </link>
      </simpara>
     </listitem>
@@ -1236,22 +1236,22 @@ $b = \INI_ALL;
   </sect2>
   <sect2 xml:id="language.namespaces.faq.full">
    <title>
-     How does a name like <literal>\my\name</literal> or <literal>\name</literal>
-     resolve?
+     Como nomes como <literal>\meu\nome</literal> e <literal>\nome</literal>
+     são resolvidos?
    </title>
    <para>
-    Names that begin with a <literal>\</literal> always resolve to what they
-    look like, so <literal>\my\name</literal> is in fact <literal>my\name</literal>,
-    and <literal>\Exception</literal> is <literal>Exception</literal>.
+    Nomes que começam com uma barra invertida (<literal>\</literal>) sempre resolvem
+    para seu conteúdo exato. Então <literal>\meu\nome</literal> é o mesmo que <literal>meu\nome</literal>,
+    e <literal>\Exception</literal> é o mesmo que <literal>Exception</literal>.
     <example>
-     <title>Fully Qualified names</title>
+     <title>Nomes totalmente qualificados (FQN)</title>
      <programlisting role="php">
 <![CDATA[
 <?php
 namespace foo;
-$a = new \my\name(); // instantiates "my\name" class
-echo \strlen('hi'); // calls function "strlen"
-$a = \INI_ALL; // $a is set to the value of constant "INI_ALL"
+$a = new \meu\nome(); // cria uma instância da classe "meu\nome"
+echo \strlen('olá'); // invoca a função "strlen"
+$a = \INI_ALL; // $a recebe o valor da constante "INI_ALL"
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
Este PR traduz algumas partes do `language.namespaces.faq` de acordo com a coordenação de #150 

Traduzido:

* `language.namespaces.faq`
* `language.namespaces.faq.shouldicare`
* `language.namespaces.faq.globalclass`
* `language.namespaces.faq.innamespace`
* `language.namespaces.faq.full`
