### PR TITLE
Atualiza a tradução na linha 275 security_levels para security_level

### DIFF
--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ef86d18a949522c72b0d5cf5a6bb94afd583f11 Maintainer: fabioluciano Status: rev --><!-- CREDITS: fabioluciano,lhsazevedo,leofranca47 -->
+<!-- EN-Revision: 9ef86d18a949522c72b0d5cf5a6bb94afd583f11 Maintainer: fabioluciano Status: ready --><!-- CREDITS: fabioluciano,lhsazevedo,leofranca47 -->
 
 <refentry xml:id="context.ssl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" role="noversion">
  <refnamediv>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: fabioluciano Status: ready --><!-- CREDITS: fabioluciano,lhsazevedo -->
+<!-- EN-Revision: 9ef86d18a949522c72b0d5cf5a6bb94afd583f11 Maintainer: fabioluciano Status: rev --><!-- CREDITS: fabioluciano,lhsazevedo,leofranca47 -->
 
 <refentry xml:id="context.ssl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" role="noversion">
  <refnamediv>
@@ -272,7 +272,7 @@
       <row>
        <entry>7.2.0</entry>
        <entry>
-        Adicionado <parameter>security_levels</parameter>. Requer OpenSSL &gt;= 1.1.0.
+        Adicionado <parameter>security_level</parameter>. Requer OpenSSL &gt;= 1.1.0.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Foi verificado que na documentação em inglês estava no singular e na tradução para pt_br estava no plural