### PR TITLE
Tradução da documentação de gethostbyname

### DIFF
--- a/reference/network/functions/gethostbyname.xml
+++ b/reference/network/functions/gethostbyname.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: saviorenato Status: ready -->
+<refentry xml:id="function.gethostbyname" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gethostbyname</refname>
+  <refpurpose>
+   Obtenha o endereço IPv4 correspondente a um determinado nome de host da Internet
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>gethostbyname</methodname>
+   <methodparam><type>string</type><parameter>hostname</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retorna o endereço IPv4 do host da Internet especificado por
+   <parameter>hostname</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>hostname</parameter></term>
+     <listitem>
+      <para>
+       O nome do host.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retorna o endereço IPv4 ou uma string contendo o endereço não modificado
+   <parameter>hostname</parameter> em caso de falha.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Um exemplo simples <function>gethostbyname</function> </title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$ip = gethostbyname('www.example.com');
+
+echo $ip;
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>gethostbyaddr</function></member>
+    <member><function>gethostbynamel</function></member>
+    <member><function>inet_pton</function></member>
+    <member><function>inet_ntop</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Criando tradução de gethostbyname 
EN: https://www.php.net/manual/en/function.gethostbyname.php
PT_BR: https://www.php.net/manual/pt_BR/function.gethostbyname.php