### PR TITLE
Remoção massificada de documentação muito antiga, desatualizada e/ou errada no manual

### DIFF
--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -103,8 +103,9 @@ var_dump ($first_token, $second_token);
     &example.outputs;
     <screen>
 <![CDATA[
-    string(0) ""
     string(9) "something"
+    string(0) ""
+
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Corrige a ordenação do Resultado indicado ao executar a função strtok na versão mais antiga do PHP. (Exemplo #2)