### PR TITLE
Fix minor "lost in translation" mistake in language.types.string

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -506,7 +506,7 @@ EOT;
     &example.outputs;
     <screen>
 <![CDATA[
-Meu nome é Meu nome. Eu estou imprimindo Foo.
+Meu nome é "Meu nome". Eu estou imprimindo Foo.
 Agora, eu estou imprimindo Bar2.
 Isto deve imprimir um 'A' maiúsculo: A]]>
     </screen>


### PR DESCRIPTION
O exemplo de saída do heredoc com interpolação original em inglês incluía as aspas duplas na saída (que é o esperado, já que o heredoc não altera aspas de nenhum tipo, nem ao redor de interpolações).

Fiquei confuso por um momento se eu deveria escapar as aspas duplas ou não, até conferir a doc original em inglês e verificar que foi apenas um detalhe que ficou "perdido na tradução".