### PR TITLE
Corrige rev

### DIFF
--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b092be08b845c8b3c3e029704b5cd937b750347d Maintainer: enzogamads Status: ready --><!-- CREDITS: adiel, enzogamads, fernandoc -->
+<!-- EN-Revision: b7f8c11e56ff1c57a2993e2ed7e5c5ace18637fd Maintainer: enzogamads Status: ready --><!-- CREDITS: adiel, enzogamads, fernandoc -->
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>


### PR DESCRIPTION
Essa rev está apontando para [b092be08b845c8b3c3e029704b5cd937b750347d](https://github.com/php/doc-en/blob/b092be08b845c8b3c3e029704b5cd937b750347d/reference/curl/functions/curl-multi-exec.xml), que não é um hash válido, corrigindo para a última revisão, já que o conteúdo está atualizado [b7f8c11e56ff1c57a2993e2ed7e5c5ace18637fd](https://github.com/php/doc-en/blob/b7f8c11e56ff1c57a2993e2ed7e5c5ace18637fd/reference/curl/functions/curl-multi-exec.xml)