### PR TITLE
docs: remove double spaces in some folders.

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -302,7 +302,7 @@ Retorna o tamanho da string dada.
   <para>
    Observe também que o manual PHP é escrito no tempo presente, e não no futuro,
    mesmo que para recursos documentados que ainda não estão disponíveis. A razão para isto
-   é que o manual pode resistir ao teste do tempo, portanto não exige  tediosas
+   é que o manual pode resistir ao teste do tempo, portanto não exige tediosas
    atualizações gramaticais a cada nova release do PHP.
   </para>
   <para>

--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -15,7 +15,7 @@
  <para>
   Antes de utilizar essas tabelas, é importante entender os tipos e seus
   significados. Por exemplo, <literal>"42"</literal> é uma <type>string</type>
-  enquanto <literal>42</literal> é um <type>int</type>.  &false; é um
+  enquanto <literal>42</literal> é um <type>int</type>. &false; é um
   <type>bool</type> enquanto <literal>"false"</literal> é uma
   <type>string</type>.
  </para>

--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -295,7 +295,7 @@ fclose($fp);
     um array associativo.
 
     <parameter>level</parameter> descreve o nível
-    de compressão a ser usada (1-9).  Números mais altos geralmente resultam em cargas menores com
+    de compressão a ser usada (1-9). Números mais altos geralmente resultam em cargas menores com
     o custo de tempo de processamento adicional. Dois níveis especiais de compressão também existem:
     0 (para nenhuma compressão), e -1 (padrão interno da zlib -- atualmente 6).
 
@@ -597,7 +597,7 @@ class AES_CBC
    }
    public static function decryptFile($password, $aes_filename, $out_stream) {
       $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
-      $hmac_raw = file_get_contents($aes_filename, false, NULL,  0, 32);
+      $hmac_raw = file_get_contents($aes_filename, false, NULL, 0, 32);
       $hmac_salt = file_get_contents($aes_filename, false, NULL, 32, $iv_size);
       $hmac_calc = self::calculate_hmac_after_32bytes($password, $hmac_salt, $aes_filename);
       $fc = fopen($aes_filename, "rb");
@@ -640,7 +640,7 @@ class AES_CBC
 class FileSkip32Bytes extends php_user_filter
 {
    private $skipped=0;
-   function filter($in, $out, &$consumed, $closing)  {
+   function filter($in, $out, &$consumed, $closing) {
       while ($bucket = stream_bucket_make_writeable($in)) {
          $outlen = $bucket->datalen;
          if ($this->skipped<32){

--- a/appendices/history.xml
+++ b/appendices/history.xml
@@ -4,7 +4,7 @@
 <appendix xml:id="history" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>História do PHP e Projetos Relacionados</title>
  <para>
-  PHP já percorreu um longo caminho desde seu nascimento em meados  da década de 1990.
+  PHP já percorreu um longo caminho desde seu nascimento em meados da década de 1990.
   De origens humildes para se tornar uma das mais proeminentes
   linguagens que alimentam a web, a evolução do PHP é um conto
   de fadas geek. Lembre-se, esse crescimento explosivo não foi fácil.
@@ -13,50 +13,50 @@
   da história da internet, você pode encontrar antigas releases do PHP
   no <link xlink:href="&url.php.museum;">Museu PHP</link>.
  </para>
- 
+
  <sect1 xml:id="history.php">
   <title>História do PHP</title>
-  
+
   <sect2 xml:id="history.phpfi">
    <title>PHP Tools, FI, Kit de Construção, e PHP/FI</title>
    <para>
-    O PHP como é conhecido hoje, é na verdade o sucessor para um 
+    O PHP como é conhecido hoje, é na verdade o sucessor para um
     produto chamado PHP/FI. Criado em 1994 por Rasmus Lerdof,
     a primeira encarnação do PHP foi um simples conjunto
-    de binários Common Gateway Interface (CGI) escrito em 
-    linguagem de programação C. Originalmente usado para 
+    de binários Common Gateway Interface (CGI) escrito em
+    linguagem de programação C. Originalmente usado para
     acompanhamento de visitas para seu currículo online,
-    ele nomeou o conjunto de scripts de "Personal Home Page Tools"  mais frequentemente referenciado como "PHP Tools."
+    ele nomeou o conjunto de scripts de "Personal Home Page Tools" mais frequentemente referenciado como "PHP Tools."
     Ao longo do tempo, mais funcionalidades foram desejadas, e Rasmus
     reescreveu o PHP Tools, produzindo uma maior e rica implementação.
     Este novo modelo foi capaz de interações com Banco de Dados e mais,
-    fornecendo uma estrutura no qual os usuários poderiam desenvolver simples e dinâmicas 
+    fornecendo uma estrutura no qual os usuários poderiam desenvolver simples e dinâmicas
     aplicações web, como um livros de visitas. Em Junho de 1995,
     Rasmus <link xlink:href="&url.php.release1.0.0;">liberou</link>
-    o código fonte do PHP Tools para o público, o que permitiu 
+    o código fonte do PHP Tools para o público, o que permitiu
     que desenvolvedores usassem da forma como desejassem. Isso permitiu - e encorajou
-    - usuários a fornecerem correções para bugs no código, e em geral, 
+    - usuários a fornecerem correções para bugs no código, e em geral,
     aperfeiçoá-lo.
    </para>
    <para>
     Em Setembro do mesmo ano, Rasmus expandiu o PHP e - por um breve período
     - mudou o nome PHP. Agora referindo-se a ferramenta como FI,
-    abreviação para "Forms Interpreter", a nova implementação 
+    abreviação para "Forms Interpreter", a nova implementação
     incluiu algumas funcionalidades básicas do PHP como bem conhecemos
-    hoje. Tinha variáveis no estilo Perl, interpretação automática de 
-    variáveis de formulários, e sintaxe HTML embutida. A sintaxe em si era muito 
+    hoje. Tinha variáveis no estilo Perl, interpretação automática de
+    variáveis de formulários, e sintaxe HTML embutida. A sintaxe em si era muito
     similar com a do Perl, porém muito mais limitada, simples, e um pouco inconsistente.
     De fato, para embutir o código em um arquivo HTML, desenvolvedores tinham que usar comentários
-    HTML. Embora este método não sido inteiramente 
+    HTML. Embora este método não sido inteiramente
     bem-recebido, FI continuou a desfrutar
     um crescimento e aceitação como uma ferramente CGI --- mas ainda não como uma linguagem.
-    Contudo, isso começou a mudar no mês seguinte; em Outubro, 1995 Rasmus liberou 
-    um completa reescrita do código. Trazendo de volta o nome PHP, estava agora (brevemente) nomeado 
-    "Personal Home Page Contruction 
-    Kit" e foi o primeiro lançamento a vangloriar-se que era, na época, 
+    Contudo, isso começou a mudar no mês seguinte; em Outubro, 1995 Rasmus liberou
+    um completa reescrita do código. Trazendo de volta o nome PHP, estava agora (brevemente) nomeado
+    "Personal Home Page Contruction
+    Kit" e foi o primeiro lançamento a vangloriar-se que era, na época,
     considerado um avançado script de interface. A linguagem foi
-    desenvolvida para, deliberadamente, ser parecida com C, tornando-a fácil 
-    para ser adotada por desenvolvedores habituados com C, Perl e linguagens similares. 
+    desenvolvida para, deliberadamente, ser parecida com C, tornando-a fácil
+    para ser adotada por desenvolvedores habituados com C, Perl e linguagens similares.
     Tendo sido até este momento exclusiva para sistemas UNIX e sistemas compatíveis com POSIX,
     o potencial para uma implementação em um Windows NT começava a ser explorada.
    </para>
@@ -64,8 +64,8 @@
     O código tem outra reforma completa, e em Abril de 1996,
     combinando os nomes dos últimos lançamentos, Rasmus introduziu
     o PHP/FI. Esta segunda geração da implementação começou a realmente
-    evoluir o PHP de um conjunto de ferramentas para sua própria linguagem  de programação.
-    Ele incluía suporte embutido dos banco de dados DBM, mSQL, e Postgres95, 
+    evoluir o PHP de um conjunto de ferramentas para sua própria linguagem de programação.
+    Ele incluía suporte embutido dos banco de dados DBM, mSQL, e Postgres95,
     cookies, funções de apoio definidas pelo usuário, e muito mais.
     Em Junho, PHP/FI ganhou o status de versão 2.0. Um interessante fato
     sobre isso, porém, é que existia apenas um única completa versão do PHP 2.0.
@@ -75,14 +75,14 @@
    <para>
     Apesar de ter tido um curto período de desenvolvimento, ele continuava
     defrutar uma crescente popularidade em um ainda jovem mundo web desenvolvimento,
-    Em 1997 e 1998, PHP/FI teve o apoio de milhares de usuários 
-    ao redor do  mundo.
+    Em 1997 e 1998, PHP/FI teve o apoio de milhares de usuários
+    ao redor do mundo.
     Uma pesquisa Netcraft de Maio de 1998, indicou que cerca de 60.000 domínios
-    relataram ter cabeçalhos contendo "PHP", 
-    indicando que o servidor de hospedagem de fato tinha o PHP instalado. 
+    relataram ter cabeçalhos contendo "PHP",
+    indicando que o servidor de hospedagem de fato tinha o PHP instalado.
     Este número pode ser equiparado com aproximadamente 1% de todos os domínios
-    da Internet da época. Apesar destes números impressionantes, o amadurecimento 
-    do PHP/FI foi condenado a limitações; enquanto haviam vários contribuintes menores, 
+    da Internet da época. Apesar destes números impressionantes, o amadurecimento
+    do PHP/FI foi condenado a limitações; enquanto haviam vários contribuintes menores,
     ainda era desenvolvido principalmente por uma única pessoa.
    </para>
    <para>
@@ -116,28 +116,28 @@
    <para>
     PHP 3.0 foi a primeira versão que se assemelha com o PHP como existe
     hoje. PHP/FI se encontrava ainda ineficiente e não tinha recursos que precisava
-    para prover uma aplicação eCommerce que estavam desenvolvendo para um 
-    projeto da Universidade, Andi Gutmans e 
+    para prover uma aplicação eCommerce que estavam desenvolvendo para um
+    projeto da Universidade, Andi Gutmans e
     Zeev Suraski de Tel Aviv, Israel, começaram
-    outra completa reescrita do interpretador em 1997. 
-    Abordando Rasmus online, eles discutiram vários aspectos para a corrente 
-    implementação e redesenvolvimento do PHP. Em um esforço para melhorar a engine 
+    outra completa reescrita do interpretador em 1997.
+    Abordando Rasmus online, eles discutiram vários aspectos para a corrente
+    implementação e redesenvolvimento do PHP. Em um esforço para melhorar a engine
     e iniciar a construção em cima da base de usuários existentes
     do PHP/FI, Andi, Rasmus, e Zeev decidiram colaborar no desenvolvimento
     de uma nova e independente linguagem de programação.
     Essa nova linguagem foi lançada com um novo nome, que removeu
     a impressão do limitado uso pessoal que o nome PHP/FI 2.0 tinha mantido.
-    Foi renomeado simplesmente para 'PHP', com o significado se tornando 
+    Foi renomeado simplesmente para 'PHP', com o significado se tornando
     um acrônimo recursivo - PHP: Hypertext Preprocessor.
    </para>
    <para>
-    Um dos maiores pontos fortes do PHP 3.0 foram os fortes recursos de 
+    Um dos maiores pontos fortes do PHP 3.0 foram os fortes recursos de
     extensibilidade. Além de fornecer a usuários finais uma interface robusta
-    para múltiplos banco de dados, protocolos, e APIs, a facilidade 
+    para múltiplos banco de dados, protocolos, e APIs, a facilidade
     de estender a sua própria linguagem atraiu dezenas de desenvolvedores
-    que submeteram uma variedade de módulos. Indiscutivelmente esta foi 
+    que submeteram uma variedade de módulos. Indiscutivelmente esta foi
     a chave para o PHP 3.0 ter sido um tremendo sucesso. Outro recurso chave
-    foi introduzido no PHP 3.0 incluindo o suporte a programação orientada 
+    foi introduzido no PHP 3.0 incluindo o suporte a programação orientada
     a objeto e a uma mais poderosa e consistente sintaxe de linguagem.
    </para>
    <para>
@@ -146,13 +146,13 @@
     como o sucessor oficial para o PHP/FI 2.0. As melhorias no PHP/FI 2.0,
     cessaram em Novembro do ano anterior e agora foi oficialmente finalizado.
     Depois de nove meses de testes abertos ao público, quando o anúncio do lançamento
-    oficial do PHP 3.0 chegou, prontamente foi instalado em 
+    oficial do PHP 3.0 chegou, prontamente foi instalado em
     70.000 domínios em todo mundo,
-    e já não era mais limitado ao sistemas 
-    operacionais compatíveis ao POSIX. 
+    e já não era mais limitado ao sistemas
+    operacionais compatíveis ao POSIX.
     Uma parcela relativamente pequena de domínios informaram que o PHP foi instalado
     em um host com servidores executando Windows 95, 98 e NT, Macintosh. E em seu pico,
-    PHP 3.0 foi instalado em aproximadamente 10% 
+    PHP 3.0 foi instalado em aproximadamente 10%
     dos servidores web da internet.
    </para>
   </sect2>
@@ -161,21 +161,21 @@
    <title>PHP 4</title>
    <para>
     No inverno de 1998, logo após o PHP 3.0 ter sido oficialmente
-    lançado, Andi Gutmans e Zeev Suraski começaram a trabalhar 
-    em uma reescrita do core do PHP. Os objetivos do projeto 
+    lançado, Andi Gutmans e Zeev Suraski começaram a trabalhar
+    em uma reescrita do core do PHP. Os objetivos do projeto
     eram melhorar performance das aplicações complexas, e melhorar
-    a modularização do código base do PHP. Tais aplicações só foram 
+    a modularização do código base do PHP. Tais aplicações só foram
     possíveis pelos novos recursos e suporte para uma ampla
     variedades de banco de dados de terceiros e APIs do PHP 3.0, mas o PHP 3.0 não foi projetado para trabalhar com aplicações
     complexas de forma eficiente.
    </para>
    <para>
-    O novo motor, chamado 'Zend Engine' (composto pelos primeiros 
-    nome, Zeev e Andi), alcançou os objetivos do projeto com sucesso, 
-    e foi introduzido em meados de 1999. O PHP 4.0 baseado neste motor, 
+    O novo motor, chamado 'Zend Engine' (composto pelos primeiros
+    nome, Zeev e Andi), alcançou os objetivos do projeto com sucesso,
+    e foi introduzido em meados de 1999. O PHP 4.0 baseado neste motor,
     e uma variedade de novos recursos adicionais, foi oficialmente
-    lançado em Maio de 2000, 
-    quase dois anos após seu antecessor. Além 
+    lançado em Maio de 2000,
+    quase dois anos após seu antecessor. Além
     da altíssima melhoria da performance nesta versão, o PHP 4.0 incluiu
     outros recursos chaves, tais como suporte para maioria dos servidores
     web, sessões HTTP, saídas de buffering, mais maneiras seguras para manipular
@@ -187,34 +187,34 @@
    <title>PHP 5</title>
    <para>
     O PHP 5 foi lançado em Julho de 2004 após um longo desenvolvimento e vários
-    pré-lançamentos. Principalmente impulsionado pelo seu core o 
+    pré-lançamentos. Principalmente impulsionado pelo seu core o
     <literal>Zend Engine 2.0</literal> com um novo modelo de objeto
     e dezenas de outros novos recursos.
    </para>
    <para>
     O time de desenvolvimento PHP inclui dezenas de desenvolvedores, também
-    dezenas de outros trabalhando em algo relacionado ao PHP e apoio a 
-    projetos como PEAR, PECL, documentação, infra-estrutura de 
-    rede subjacente de bem mais de uma centena de servidores web 
+    dezenas de outros trabalhando em algo relacionado ao PHP e apoio a
+    projetos como PEAR, PECL, documentação, infra-estrutura de
+    rede subjacente de bem mais de uma centena de servidores web
     em seis dos sete continentes do mundo. Embora seja apenas uma estimativa baseada
-    sobre estatísticas de anos anteriores, é seguro presumir 
-    que o PHP está agora instalado em dezenas, ou mesmo talvez 
+    sobre estatísticas de anos anteriores, é seguro presumir
+    que o PHP está agora instalado em dezenas, ou mesmo talvez
     centenas, de milhões de domínios em todo mundo.
    </para>
   </sect2>
  </sect1>
- 
+
  <sect1 xml:id="history.php.related">
   <title>História de projetos relacionado ao PHP</title>
-  
+
   <!-- Hope Stig and/or Egon can do this
-  
+
   <sect2 xml:id="history.phpdoc">
    <title>PHP Documentation Project</title>
    <para>
    </para>
   </sect2>
-  
+
   -->
 
   <sect2 xml:id="history.pear">
@@ -222,23 +222,23 @@
    <para>
     <link xlink:href="&url.php.pear;">PEAR</link>, a <literal>PHP Extension and
     Application Repository</literal> (originalmente, PHP Extension and Add-on
-    Repository) é a base de classes PHP, e pode crescer no futuro para ser uma 
-    das formas chaves para distribuir extensões PHP 
+    Repository) é a base de classes PHP, e pode crescer no futuro para ser uma
+    das formas chaves para distribuir extensões PHP
     entre os desenvolvedores.
    </para>
    <para>
     PEAR nasceu em discussões de encontros realizados por desenvolvedores PHP
-    (PDM) realizado em Janeiro de 2000 em Tel Aviv. 
-    Foi criado por Stig S. Bakken, 
+    (PDM) realizado em Janeiro de 2000 em Tel Aviv.
+    Foi criado por Stig S. Bakken,
     e é dedicado à sua primeira filha, Malin Bakken.
    </para>
    <para>
     Desde o início de 2000, PEAR cresceu para ser um grande e significante
-    projeto com um grande número de desenvolvedores 
-    trabalhando em implementar funcionalidades comuns e 
+    projeto com um grande número de desenvolvedores
+    trabalhando em implementar funcionalidades comuns e
     reutilizáveis para benefício
     da comunidade PHP. PEAR hoje inclui uma ampla variedade de
-    classes para acesso ao banco de dados, cache de conteúdo, 
+    classes para acesso ao banco de dados, cache de conteúdo,
     cálculos matemáticos, eCommerce e muito mais.
    </para>
    <para>
@@ -251,14 +251,14 @@
    <title>Iniciativa de Garantia da Qualidade do PHP</title>
    <para>
     O <link xlink:href="&url.php.prerelease;">PHP Quality Assurance
-    Initiative</link> foi criado no verão de 2000, em resposta para 
+    Initiative</link> foi criado no verão de 2000, em resposta para
     críticas que versões do PHP não estavam sendo suficientemente bem testados
-    para o ambiente de produção. 
+    para o ambiente de produção.
     O time agora consiste de um grupo de desenvolvedores
     com um bom entendimento do código base do PHP.
-    Esses desenvolvedores gastam muito de seu tempo localizando e 
-    corrigindo os bugs do PHP. Além de existir muitos outros membros 
-    do time que testam e fornecem feedback de suas correções usando 
+    Esses desenvolvedores gastam muito de seu tempo localizando e
+    corrigindo os bugs do PHP. Além de existir muitos outros membros
+    do time que testam e fornecem feedback de suas correções usando
     uma ampla variedade de plataformas.
    </para>
   </sect2>
@@ -267,17 +267,17 @@
    <title>PHP-GTK</title>
    <para>
     <link xlink:href="&url.php.gtk;">PHP-GTK</link> é a solução PHP para escrever
-    aplicações GUI no lado do cliente. Andrei Zmievski nos recorda o processo de 
+    aplicações GUI no lado do cliente. Andrei Zmievski nos recorda o processo de
     planejamento e criação:
    </para>
    <blockquote>
     <para>
-     Programação GUI foi sempre do meu interesse, e eu achei 
-     o Gtk+ um utilitário muito fácil, exceto que programar com ele em C é 
+     Programação GUI foi sempre do meu interesse, e eu achei
+     o Gtk+ um utilitário muito fácil, exceto que programar com ele em C é
      pouco tedioso.
      Depois de testemunhar aplicações PyGtk e GTK-Perl. Eu decidi ver se o PHP
      poderia fazer uma interface com Gtk+, mesmo que pequena.
-     Iniciei em Agosto de 2000, quando comecei a ter um pouco mais de tempo livre, e 
+     Iniciei em Agosto de 2000, quando comecei a ter um pouco mais de tempo livre, e
      iniciei os experimentos. Minha principal diretriz foi a implementação PyGtk pois possia
      recursos bastante completos e uma boa interface de orientação a objetos.
      James Henstridge, o autor de PyGtk, forneceu muitos conselhos úteis durante os estágios
@@ -285,35 +285,35 @@
      </para>
     <para>
      Escrever as interfaces para toda as funções Gtk+ ficou fora de questão,
-     então eu aproveitei a ideia de gerar código, similar 
+     então eu aproveitei a ideia de gerar código, similar
      como o PyGtk tinha feito. O gerador de código é um programa PHP que lê
      um conjunto de arquivos <filename>.defs</filename> contendo as classes Gtk+,
      constantes, e informações de métodos e gera o código C que faz a interface com PHP.
-     O que não pode ser gerado automaticamente pode ser escrito manualmente no arquivo 
+     O que não pode ser gerado automaticamente pode ser escrito manualmente no arquivo
      <filename>.overrides</filename>.
     </para>
     <para>
      Trabalhar em um gerador de código e sua infra-estrutura levou algum tempo,
-     pois eu só podia gastar um pouco tempo em PHP-GTK durante o outono de 2000. 
-     Depois que mostrei o PHP-GTK para Frank Kromann, ele ficou interessado 
+     pois eu só podia gastar um pouco tempo em PHP-GTK durante o outono de 2000.
+     Depois que mostrei o PHP-GTK para Frank Kromann, ele ficou interessado
      e começou ajudando-me com o gerador de código e em implementaçes
      de Win32. Quando nós escrevemos o primeiro programa Hello World e executamos,
-     ficamos muito emocionados. 
+     ficamos muito emocionados.
      Levou dois ou mais meses para começar o projeto
      em uma condição apresentável e a versão inicial foi lançada em 1 de Março de 2001.
-     A história rapidamente chegou ao SlashDot. 
+     A história rapidamente chegou ao SlashDot.
     </para>
     <para>
      Sentindo que PHP-GTK podia ser extensível, montei em separado uma lista de e-mail,
      um repositório CVS para isto e também um website gtk.php.net com a ajuda
      de Colin Viebrock.
-     Também foi preciso montar a documentação e 
+     Também foi preciso montar a documentação e
      James Moore veio a ajudar com isto.
     </para>
     <para>
      Desde seu lançamento, o PHP-GTK foi ganhando popularidae. Nós tivemos
      nosso próprio time de documentação, o manual continua melhorando,
-     pessoas começaram a escrever extensões para o PHP-GTK, e mais 
+     pessoas começaram a escrever extensões para o PHP-GTK, e mais
      aplicações foram feitas com ele.
     </para>
    </blockquote>
@@ -323,16 +323,16 @@
  <sect1 xml:id="history.php.books">
   <title>Livros sobre PHP</title>
   <para>
-   Como o PHP cresceu, começou a ser reconhecido com uma 
+   Como o PHP cresceu, começou a ser reconhecido com uma
    popular plataforma de desenvolvimento web. Um das formas mais interessantes
    de ver esta tendência foi observando os livros sobre PHP
-   que saiu ao longo dos anos. 
+   que saiu ao longo dos anos.
   </para>
   <para>
    Pelo que sabemos, o primeiro livro dedicado para
    PHP foi 'PHP - tvorba interaktivních internetových aplikací'
    (<emphasis>PHP - Criando aplicativos interativos da Internet</emphasis>)
-   um livro checo publicado em 1999, cujo autor foi Jirka Kosek. 
+   um livro checo publicado em 1999, cujo autor foi Jirka Kosek.
    No mês sequinte um livro Alemão, dos autores Egon Schmid, Christian Cartus
    e Richard Blume. O primeiro livro em Inglês sobre PHP foi publicado
    pouco depois, e foi 'Core PHP Programming' de Leon Atkinson. Este livro cobria o
@@ -343,17 +343,17 @@
    seguidos por um grande número de livros de uma série de autores e
    e editores. Existem mais de 400 livros em Inglês, mais de 100 livros
    em Alemão, e mais de 50 livros em Francês ou Espanhol! Além, de poder encontrar
-   livros sobre PHP em muitas outras linguas, incluindo 
+   livros sobre PHP em muitas outras linguas, incluindo
    Coreano, Japonês e Hebraico.
   </para>
   <para>
    Obviamente, este grande número de livros, escrito por diferentes
    autores, publicados por muitas editoras, e sua disponibilidade
-   em tantas línguas - é um forte testemunho do sucesso do PHP 
+   em tantas línguas - é um forte testemunho do sucesso do PHP
    em todo o mundo.
   </para>
  </sect1>
- 
+
  <sect1 xml:id="history.php.publications">
   <title>Publicações sobre PHP</title>
   <para>
@@ -366,7 +366,7 @@
   <para>
    Artigos sobre PHP apareceram no Dr. Dobbs, Linux Enterprise,
    Linux Magazine e muitos outros. Artigos sobre migração de aplicações
-   baseadas em ASP para PHP no Windows tem aparecido até na <acronym>MSDN</acronym> que é da 
+   baseadas em ASP para PHP no Windows tem aparecido até na <acronym>MSDN</acronym> que é da
    <productname>Microsoft</productname> !
   </para>
  </sect1>

--- a/appendices/migration70/new-features.xml
+++ b/appendices/migration70/new-features.xml
@@ -181,7 +181,7 @@ echo "b" <=> "a"; // 1
 
   <para>
    Constantes do tipo <type>array</type> agora podem ser definidas com a função
-   <function>define</function>. No PHP 5.6 elas só poderiam ser definidas com 
+   <function>define</function>. No PHP 5.6 elas só poderiam ser definidas com
    &const;.
   </para>
 
@@ -289,7 +289,7 @@ echo "\u{9999}";
   <title><methodname>Closure::call</methodname></title>
 
   <para>
-   O método <methodname>Closure::call</methodname> é uma forma mais  eficaz
+   O método <methodname>Closure::call</methodname> é uma forma mais eficaz
    e abreviada de associar temporariamente um escopo de objeto a uma closure e invocá-la.
   </para>
 

--- a/appendices/migration72/deprecated.xml
+++ b/appendices/migration72/deprecated.xml
@@ -83,7 +83,7 @@ string(11) "NONEXISTENT"
   <para>
    Dado os problemas de segurança desta função (sendo um wrapper ao redor de
    <function>eval</function>), esta função datada foi depreciada.
-   A alternativa preferida é o uso de  <link linkend="functions.anonymous">funções anônimas</link>.
+   A alternativa preferida é o uso de <link linkend="functions.anonymous">funções anônimas</link>.
   </para>
  </sect2>
 

--- a/appendices/migration73/other-changes.xml
+++ b/appendices/migration73/other-changes.xml
@@ -31,7 +31,7 @@
 
    <para>
     As seguintes diretivas ini foram adicionadas para personalizar o log, se
-    <link linkend="ini.error-log">error_log</link>  for definido como
+    <link linkend="ini.error-log">error_log</link> for definido como
     <literal>syslog</literal>:
     <variablelist>
      <varlistentry>
@@ -223,7 +223,7 @@
   <title>Expressões Regulares (Compatível com Perl)</title>
 
   <para>
-   A  <link linkend="book.pcre">PCRE extension</link> foi atualizada para
+   A <link linkend="book.pcre">PCRE extension</link> foi atualizada para
    PCRE2, o que pode causar pequenas alterações comportamentais (por exemplo, intervalos de
    caracteres em classes agora são interpretados com mais rigor) e aumenta a
    sintaxe de expressão regular existente.

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -249,12 +249,12 @@
    foi suportada e resultou em objetos reflexions corrompidos. Foi explicitamente
    proibido agora.
   </para>
- 
+
   <para>
    Os valores para as constantes das classes <classname>ReflectionClassConstant</classname>,
    <classname>ReflectionMethod</classname> e <classname>ReflectionProperty</classname>
    mudaram.
-  </para>  
+  </para>
  </sect2>
 
  <sect2 xml:id="migration74.incompatible.spl">
@@ -290,14 +290,14 @@
    </listitem>
   </itemizedlist>
   <para>
-   <literal>(array)</literal> casts não são afetadas.  Eles continuarão
+   <literal>(array)</literal> casts não são afetadas. Eles continuarão
    retornando o array agrupado, ou as propriedades <classname>ArrayObject</classname>
    dependendo se a flag <constant>ArrayObject::STD_PROP_LIST</constant>
    é usada.
   </para>
   <para>
    <methodname>SplPriorityQueue::setExtractFlags</methodname> lançará uma exceção
-   se zero for passado.  Antes, isso geraria um erro fatal recuperável
+   se zero for passado. Antes, isso geraria um erro fatal recuperável
    na próxima operação de extração.
   </para>
   <para>

--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -342,7 +342,7 @@ public function __unserialize(array $data): void;
    <para>
     <function>proc_open</function> agora aceita um array em vez de
     uma string para o comando. Nesse caso, o processo será aberto
-    diretamente (sem passar por um shell) e  o PHP cuidará de
+    diretamente (sem passar por um shell) e o PHP cuidará de
     qualquer argumento necessário para escapar.
     <informalexample>
      <programlisting role="php">

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -438,7 +438,7 @@ class MyClass {
     <listitem>
      <para>
       Funções desabilitadas agora são tratadas da mesma forma que funções não existentes. Ao chamar
-      uma função desabilitada será informado que ela é desconhecida, e redefinir uma função desabilitada agora é  possível.
+      uma função desabilitada será informado que ela é desconhecida, e redefinir uma função desabilitada agora é possível.
      </para>
     </listitem>
     <listitem>
@@ -1163,7 +1163,7 @@ $array["key"];
     </para>
     <para>
      <simplelist>
-      <member><code>PDO::query(string $query, ?int $fetchMode  = null, mixed  ...$fetchModeArgs)</code></member>
+      <member><code>PDO::query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs)</code></member>
       <member><code>PDOStatement::setFetchMode(int $mode, mixed ...$args)</code></member>
      </simplelist>
     </para>

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -545,7 +545,7 @@ array_intersect(...$arrays);
   <para>
    <classname>PhpToken</classname> adiciona uma interface baseada em objeto ao tokenizer. Ele fornece uma
    representação mais uniforme e ergonômica, além de ser mais eficiente em termos de memória e mais rápido.
-   <!--  RFC: https://wiki.php.net/rfc/token_as_object -->
+   <!-- RFC: https://wiki.php.net/rfc/token_as_object -->
   </para>
  </sect2>
 

--- a/appendices/migration82/new-features.xml
+++ b/appendices/migration82/new-features.xml
@@ -82,7 +82,7 @@
   <title>cURL</title>
 
   <para>
-   Adicionada a opção  <constant>CURLINFO_EFFECTIVE_METHOD</constant>,
+   Adicionada a opção <constant>CURLINFO_EFFECTIVE_METHOD</constant>,
    que retorna o método <acronym>HTTP</acronym> efetivo no valor de retorno de
    <function>curl_getinfo</function>.
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -205,8 +205,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-range('9', 'A');  // ["9", ":", ";", "<", "=", ">", "?", "@", "A"], a partir do PHP 8.3.0
-range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], antes do PHP 8.3.0
+range('9', 'A'); // ["9", ":", ";", "<", "=", ">", "?", "@", "A"], a partir do PHP 8.3.0
+range('9', 'A'); // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], antes do PHP 8.3.0
 ?>
 ]]>
     </programlisting>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -73,7 +73,7 @@
     <constant>STDIN</constant> não são mais fechados na destruição de resources,
     o que ocorre principalmente quando o CLI termina.
     No entanto, ainda é possível fechar explicitamente esses fluxos usando
-    <function>fclose</function>  e funções semelhantes.
+    <function>fclose</function> e funções semelhantes.
    </para>
   </sect3>
  </sect2>
@@ -284,7 +284,7 @@
    <para>
     A função <function>odbc_autocommit</function> agora aceita &null;
     como valor para o parâmetro <parameter>$enable</parameter>.
-    Passar &null;  tem o mesmo comportamento que passar apenas 1 parâmetro,
+    Passar &null; tem o mesmo comportamento que passar apenas 1 parâmetro,
     ou seja, indica se o recurso de autocommit está habilitado ou não.
    </para>
   </sect3>
@@ -375,7 +375,7 @@
    </para>
 
    <para>
-    Se você estiver usando um array como o parâmetro  <parameter>$command</parameter>
+    Se você estiver usando um array como o parâmetro <parameter>$command</parameter>
     <function>proc_open</function>, ele agora deve ter pelo menos um
     elemento não vazio. Caso contrário, um <classname>ValueError</classname>
     será lançado.

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -158,7 +158,7 @@
     <info><title>Uma Nota sobre os Editores de Texto</title></info>
     <para>
      Há muitos editores de textos e Integrated Development Enviroments (IDEs)
-     que você pode usar para criar, editar e gerenciar arquivos PHP. Uma lista  parcial
+     que você pode usar para criar, editar e gerenciar arquivos PHP. Uma lista parcial
      destas ferramentas pode ser vista na <link xlink:href="&url.phpeditorlist;">Lista de Editores
      para PHP</link>. Se você gostaria de recomendar um editor, por favor visite a
      página acima e peça ao administrador da página para adicionar o editor à lista. Ter

--- a/faq/com.xml
+++ b/faq/com.xml
@@ -22,7 +22,7 @@
      </para>
     </answer>
    </qandaentry>
-   
+
    <qandaentry xml:id="faq.com.q2">
     <question>
      <para>
@@ -40,7 +40,7 @@
      </para>
     </answer>
    </qandaentry>
-  
+
    <qandaentry xml:id="faq.com.q3">
     <question>
      <para>
@@ -56,7 +56,7 @@
      </para>
     </answer>
    </qandaentry>
-  
+
    <qandaentry xml:id="faq.com.q4">
     <question>
      <para>
@@ -69,7 +69,7 @@
      </para>
     </answer>
    </qandaentry>
-  
+
    <qandaentry xml:id="faq.com.q5">
     <question>
      <para>
@@ -84,7 +84,7 @@
      </para>
     </answer>
    </qandaentry>
-  
+
    <qandaentry xml:id="faq.com.q6">
     <question>
      <para>
@@ -97,7 +97,7 @@
      </para>
     </answer>
    </qandaentry>
-  
+
    <qandaentry xml:id="faq.com.q7">
     <question>
      <para>
@@ -127,7 +127,7 @@
      </para>
     </answer>
    </qandaentry>
-    
+
    <qandaentry xml:id="faq.com.q8">
     <question>
      <para>
@@ -146,7 +146,7 @@
      </para>
     </answer>
    </qandaentry>
-   
+
    <qandaentry xml:id="faq.com.q9">
     <question>
      <para>
@@ -160,7 +160,7 @@
      </para>
     </answer>
    </qandaentry>
-   
+
    <qandaentry xml:id="faq.com.q10">
     <question>
      <para>
@@ -208,13 +208,13 @@ $word = new COM("C:\docs\word.doc");
     <answer>
      <para>
       Você pode definir um interceptador de eventos usando
-      <function>com_event_sink</function>.  Você pode usar
+      <function>com_event_sink</function>. Você pode usar
       <function>com_print_typeinfo</function> para que o PHP gere um esqueleto
       para a classe interceptadora de eventos.
      </para>
     </answer>
    </qandaentry>
-   
+
    <qandaentry xml:id="faq.com.q13">
     <question>
      <para>
@@ -229,7 +229,7 @@ $word = new COM("C:\docs\word.doc");
      </para>
     </answer>
    </qandaentry>
-   
+
    <qandaentry xml:id="faq.com.q14">
     <question>
      <para>
@@ -243,7 +243,7 @@ $word = new COM("C:\docs\word.doc");
      </para>
     </answer>
    </qandaentry>
-   
+
    <qandaentry xml:id="faq.com.q15">
     <question>
      <para>
@@ -260,7 +260,7 @@ $word = new COM("C:\docs\word.doc");
      </para>
     </answer>
    </qandaentry>
- 
+
   </qandaset>
  </chapter>
 

--- a/faq/html.xml
+++ b/faq/html.xml
@@ -6,9 +6,9 @@
 
   <para>
    PHP e HTML possuem muita interação: PHP pode gerar HTML, e o HTML
-   pode passar informações para o PHP.  Antes de ler esses faqs, é importante
+   pode passar informações para o PHP. Antes de ler esses faqs, é importante
    que você aprenda como recuperar <link linkend="language.variables.external">
-   variáveis de fontes externas</link>.  A página do manual
+   variáveis de fontes externas</link>. A página do manual
    neste tópico inclui muitos exemplos.
   </para>
 

--- a/faq/obtaining.xml
+++ b/faq/obtaining.xml
@@ -218,7 +218,7 @@
      </para>
      <para>
       Então como eu escolho? Se você escolher rodar PHP como binário CGI, então
-      você não precisa do thread safe, porque o binário  é chamado a cada requisição.
+      você não precisa do thread safe, porque o binário é chamado a cada requisição.
       Para servidores web multithread, como o IIS5 e IIS6, você deve usar a versão thread do PHP.
      </para>
     </answer>

--- a/faq/passwords.xml
+++ b/faq/passwords.xml
@@ -124,7 +124,7 @@
       uma tabela rainbow.
      </para>
      <para>
-      Em termos mais simples, um salt  é um pouco de informação adicional, que faz
+      Em termos mais simples, um salt é um pouco de informação adicional, que faz
       com que seus hashes sejam significativamente mais difíceis de decifrar. Há uma série de
       serviços on-line que fornecem listas extensas de hashes pré-calculado, bem
       como a entrada original para os hashes. O uso de um salt faz com que

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -37,7 +37,7 @@
    copiado para <filename>{PREFIX}/bin/php</filename> durante
    <command>make install</command>, caso contrário o <acronym>CGI</acronym> é colocado
    lá. Assim, por exemplo, se o <option role="configure">--with-apxs </option> está
-   na sua linha de configuração, em seguida, o  &cli; é copiado para  <filename>{PREFIX}/bin/php
+   na sua linha de configuração, em seguida, o &cli; é copiado para <filename>{PREFIX}/bin/php
    </filename> durante o <command>make install</command>. Se você quiser substituir a instalação do
    binário <acronym>CGI</acronym>, use <command>make install-cli</command> depois de
    <command>make install</command>. Alternativamente, você pode especificar
@@ -49,7 +49,7 @@
    <para>
     Porque ambos <option role="configure">--enable-cli</option> e
     <option role="configure">--enable-cgi</option> são ativadas por padrão,
-    ter simplesmente um  <option role="configure">--enable-cli</option> na sua
+    ter simplesmente um <option role="configure">--enable-cli</option> na sua
     linha de configuração não significa necessariamente que o &cli; será copiado para
     <filename>{PREFIX}/bin/php</filename> durante o <command>make install</command>.
    </para>
@@ -475,10 +475,10 @@ php -d max_execution_time=
 string(0) ""
 
 # A diretiva de configudação será configurada para tudo o que estiver depois do sinal de '='
-$  php -d max_execution_time=20
+$ php -d max_execution_time=20
         -r '$foo = ini_get("max_execution_time"); var_dump($foo);'
 string(2) "20"
-$  php
+$ php
         -d max_execution_time=doesntmakesense
         -r '$foo = ini_get("max_execution_time"); var_dump($foo);'
 string(15) "doesntmakesense"

--- a/features/connection-handling.xml
+++ b/features/connection-handling.xml
@@ -29,7 +29,7 @@
    a saída. O comportamento padrão, no entanto, é de seu script ser
    interrompido quando o cliente remoto se desconecta. Esse comportamento pode ser
    configurado através da diretiva ignore_user_abort &php.ini; assim como pela
-   diretiva correspondente <literal>php_value ignore_user_abort</literal> no 
+   diretiva correspondente <literal>php_value ignore_user_abort</literal> no
    &httpd.conf; do Apache ou
    com a função <function>ignore_user_abort</function>. Se você não disser
    para o PHP ignorar o abort do usuário e ele abortar, seu script
@@ -61,8 +61,8 @@
 
   <simpara>
    Uma coisa a ser notada é que ambos os estados ABORTED e TIMEOUT
-   podem estar ligados ao mesmo tempo.  Isso é possível se você disser
-   ao PHP para ignorar o abort do usuário causou.  PHP continuará a perceber o fato que
+   podem estar ligados ao mesmo tempo. Isso é possível se você disser
+   ao PHP para ignorar o abort do usuário causou. PHP continuará a perceber o fato que
    o usuário pode ter quebrado a conexão, mas o script continuará
    executando. Se então ele alcançar o tempo limite, ele será abortado e
    sua função de finalização, se existente, será chamada. Nesse ponto,

--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -525,7 +525,7 @@ PUT /path/filename.html HTTP/1.1
     sobrescrevam qualquer arquivo em seu diretório web. Então, para considerar isso como uma
     requisição é necessário dizer ao seu servidor web que você quer que um determinado
     script PHP cuide dessa requisição. Para fazer isso no Apache utilize
-    a diretiva <emphasis>Script</emphasis>.  Ela pode ser colocada
+    a diretiva <emphasis>Script</emphasis>. Ela pode ser colocada
     quase em qualquer local de seu arquivo de configuração do Apache. Um
     local comum é dentro de um bloco <literal>&lt;Directory&gt;</literal> ou talvez dentro de um bloco <literal>&lt;VirtualHost&gt;</literal>.
     Uma linha como a seguinte deve funcionar:

--- a/features/http-auth.xml
+++ b/features/http-auth.xml
@@ -12,7 +12,7 @@
    <link linkend="reserved.variables">variáveis predefinidas</link>
    <varname>PHP_AUTH_USER</varname>, <varname>PHP_AUTH_PW</varname>,
    e <varname>AUTH_TYPE</varname> para determinar o nome de usuário, senha e
-   tipo da autenticação, respectivamente.  Estas variáveis predefinidas são encontradas
+   tipo da autenticação, respectivamente. Estas variáveis predefinidas são encontradas
    nos arrays <varname>$_SERVER</varname>. <emphasis>Somente</emphasis> os métodos de autenticação "Basic" e "Digest"
    (a partir do PHP 5.1.0) são suportados. Consulte a função
    <function>header</function> para mais informações.

--- a/features/persistent-connections.xml
+++ b/features/persistent-connections.xml
@@ -44,7 +44,7 @@
    O segundo método, e mais popular, é rodar o PHP como um módulo em um
    servidor com multi-processos, que atualmente só inclui o Apache. Um
    servidor com multi-processos tipicamente tem um processo (o pai) que
-   coordena uma série de processos (seus filhos) que  realmente fazem
+   coordena uma série de processos (seus filhos) que realmente fazem
    o trabalho de servir as páginas web. Quando uma requisição chega de um
    cliente, ela é entregue à um dos filhos que já não estiver
    servindo outro cliente. Isso significa que quando o mesmo cliente

--- a/install/fpm/install.xml
+++ b/install/fpm/install.xml
@@ -14,12 +14,12 @@
      <itemizedlist>
       <listitem>
        <para>
-        <literal>--with-fpm-user</literal> - configura o usuário FPM  (padrão - nobody).
+        <literal>--with-fpm-user</literal> - configura o usuário FPM (padrão - nobody).
        </para>
       </listitem>
       <listitem>
        <para>
-        <literal>--with-fpm-group</literal> - configura o grupo FPM  (padrão - nobody).
+        <literal>--with-fpm-group</literal> - configura o grupo FPM (padrão - nobody).
        </para>
       </listitem>
       <listitem>
@@ -29,7 +29,7 @@
       </listitem>
       <listitem>
        <para>
-        <literal>--with-fpm-acl</literal> - Usa  Access Control Lists do POSIX (padrão - no).
+        <literal>--with-fpm-acl</literal> - Usa Access Control Lists do POSIX (padrão - no).
        </para>
       </listitem>
       <listitem>

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -41,7 +41,7 @@
       Uma maneira de modificar o arquivo é usando um editor de texto baseado em Unix no
       Terminal, por exemplo <literal>nano</literal>, e, como o dono do arquivo
       é o <literal>root</literal>, nós usaremos o comando <literal>sudo</literal>
-      para abrí-lo (no usuário <literal>root</literal>)  Digite o seguinte comando na aplicação de
+      para abrí-lo (no usuário <literal>root</literal>) digite o seguinte comando na aplicação de
       <literal>Terminal</literal> (você precisará digitar
       a sua senha):
       <literal>sudo nano /private/etc/apache2/httpd.conf</literal>

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -311,7 +311,7 @@ service httpd restart
 
     <para>
      Seguindo os passos acima você terá um Apache2 rodando com
-     suporte ao PHP como um módulo <literal>SAPI</literal>.  Existem muitas outras
+     suporte ao PHP como um módulo <literal>SAPI</literal>. Existem muitas outras
      opções de configuração disponíveis no Apache e PHP. Para mais
      informações rode <command>./configure --help</command> na código
      fonte correspondente.

--- a/security/cgi-bin.xml
+++ b/security/cgi-bin.xml
@@ -49,7 +49,7 @@
        Action) são usadas para redirecionar requisições para documentos como
        <filename
        role="url">http://my.host/secret/script.php</filename> para o
-       interpretados do PHP.  Dessa maneira, o servidor web primeiro checa
+       interpretados do PHP. Dessa maneira, o servidor web primeiro checa
        as permissões de acesso ao diretório <filename
        role="uri">/secret</filename>, e depois cria a
        requisição redirecionada <filename
@@ -57,7 +57,7 @@
        Infelizmente, se a requisição é dada originalmente nessa forma,
        a checagem de permissão não é feita para o arquivo <filename
        role="uri">/secret/script.php</filename>, mas apenas para o arquivo
-       <filename role="uri">/cgi-bin/php</filename>.  Dessa maneira
+       <filename role="uri">/cgi-bin/php</filename>. Dessa maneira
        qualquer usuário que pode acessar <filename
        role="uri">/cgi-bin/php</filename> pode acessar quaisquer
        documentos protegidos no servidor web.
@@ -155,7 +155,7 @@ AddHandler php-script .php
      diretiva de configuração <link linkend="ini.doc-root">doc_root</link> no
      <link linkend="configuration.file">arquivo de configuração</link>, ou
      você pode criar a variável de ambiente
-     <envar>PHP_DOCUMENT_ROOT</envar>.  Se ela existir, a versão <acronym>CGI</acronym>
+     <envar>PHP_DOCUMENT_ROOT</envar>. Se ela existir, a versão <acronym>CGI</acronym>
      do PHP sempre construirá o nome de arquivo para ser aberto com esse
      <parameter>doc_root</parameter> e a informação de caminho na
      requisição, para assegurar que nenhum script é executado fora desse
@@ -164,7 +164,7 @@ AddHandler php-script .php
     </simpara>
     <simpara>
      Outra opção utilizável é <link
-     linkend="ini.user-dir">user_dir</link>.  Quando user_dir não existir,
+     linkend="ini.user-dir">user_dir</link>. Quando user_dir não existir,
      a única coisa controlando o nome do arquivo aberto é
      <parameter>doc_root</parameter>. Abrir uma URL como <filename
      role="url">http://my.host/~user/doc.php</filename> não resulta
@@ -179,7 +179,7 @@ AddHandler php-script .php
      role="url">http://my.host/~user/doc.php</filename> abrirá
      o arquivo chamado <filename>doc.php</filename> no diretório
      chamado <filename role="dir">public_php</filename> dentro do diretório
-     home do usuário.  Se o home do usuário é <filename
+     home do usuário. Se o home do usuário é <filename
      role="dir">/home/user</filename>, o arquivo executado é
      <filename>/home/user/public_php/doc.php</filename>.
     </simpara>

--- a/security/errors.xml
+++ b/security/errors.xml
@@ -112,7 +112,7 @@
      <programlisting role="php">
 <![CDATA[
 <?php
-if ($username) {  // Not initialized or checked before usage
+if ($username) { // Not initialized or checked before usage
     $good_login = 1;
 }
 if ($good_login == 1) { // If above test fails, not initialized or checked before usage

--- a/security/filesystem.xml
+++ b/security/filesystem.xml
@@ -138,7 +138,7 @@ if (!ctype_alnum($username) || !preg_match('/^(?:[a-z0-9_-]|\.(?!\.))+$/iD', $us
    </para>
    <para>
     Dependendo do sistema operacional, existe uma variedade enorme de arquivos
-    com os quais se preocupar, incluindo dispositivos  (/dev/
+    com os quais se preocupar, incluindo dispositivos (/dev/
     or COM1), arquivos de configuração (arquivos /etc/ e .ini),
     áres de armazenamento conhecidas (/home/, My Documents), etc. Por essa
     razão, normalmente é mais fácil criar uma política onde se proibe
@@ -178,7 +178,7 @@ if (file_exists('/home/wwwrun/'.$file.'.php')) {
      <programlisting role="php">
 <![CDATA[
 <?php
-$file = $_GET['file']; 
+$file = $_GET['file'];
 
 // Whitelisting possible values
 switch ($file) {


### PR DESCRIPTION
Olá,

eu iria enviar a remoção de espaços duplos em alguns arquivos que estava reduzindo, mas percebi que tem vários perdidos no projeto, por isso subi alterações em algumas pastas primeiramente, se fizer sentido.

Removi somente de textos, nos exemplos de código alterei o mínimo possível, para não alterar a lógica ou indentação proposta.

Utilizei a regex `(?<=\S)  (?=\S)` para buscar os espaços duplos.