### PR TITLE
Synx MySQL docs with EN

### DIFF
--- a/reference/mysql/functions/mysql-data-seek.xml
+++ b/reference/mysql/functions/mysql-data-seek.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: dbf319f8b2d859edf2b1342014c4dbdf6333b81c Maintainer: fernandoc Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.mysql-data-seek">
  <refnamediv>
   <refname>mysql_data_seek</refname>
@@ -35,7 +35,7 @@
    <parameter>row_number</parameter> deve ser um valor no intervalo de 0 a
    <function>mysql_num_rows</function> - 1. Entretanto, se o conjunto de reseultados
    for vazio (<function>mysql_num_rows</function> == 0), uma busca para 0 irá
-   falhar com um <link linkend="errorfunc.constants.errorlevels.e-warning">E_WARNING</link> e
+   falhar com um <constant>E_WARNING</constant> e
    <function>mysql_data_seek</function> iá retornar &false;.
   </para>
  </refsect1>

--- a/reference/mysql/functions/mysql-db-name.xml
+++ b/reference/mysql/functions/mysql-db-name.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: 5fabd07880ab15b0ad2cf7eb055c7c2b36d7120f Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-db-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_db_name</refname>
@@ -67,31 +67,6 @@
    Retorna o nome do banco de dados em caso de sucesso, e &false; em caso de falha. Se
    for retornado &false;, utilize <function>mysql_error</function> para determinar a natureza
    do erro.
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.5.0</entry>
-       <entry>
-        A função <function>mysql_list_dbs</function> está obsoleta
-        e emite um aviso de nível <constant>E_DEPRECATED</constant>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/mysql/functions/mysql-fetch-assoc.xml
+++ b/reference/mysql/functions/mysql-fetch-assoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.mysql-fetch-assoc" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+<!-- EN-Revision: ff4017b6334dae2d5353fe99df8089a828795324 Maintainer: fernandoc Status: ready -->
+<refentry xml:id="function.mysql-fetch-assoc" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_fetch_assoc</refname>
   <refpurpose>Obtém uma linha do resultado como um array associativo</refpurpose>
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_fetch_assoc</function></member>
-    <member><methodname phd:args="PDO::FETCH_ASSOC">PDOStatement::fetch</methodname></member>
+    <member>
+     <methodname>PDOStatement::fetch</methodname>
+     com <parameter>mode</parameter> como <constant>PDO::FETCH_ASSOC</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-fetch-lengths.xml
+++ b/reference/mysql/functions/mysql-fetch-lengths.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-fetch-lengths" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_fetch_lengths</refname>
@@ -19,7 +19,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>mysql_fetch_lengths</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>mysql_fetch_lengths</methodname>
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -45,7 +45,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>

--- a/reference/mysql/functions/mysql-fetch-object.xml
+++ b/reference/mysql/functions/mysql-fetch-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41aab5ecacf449e51179886c17f1d41735b0234 Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.mysql-fetch-object" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+<!-- EN-Revision: ff4017b6334dae2d5353fe99df8089a828795324 Maintainer: fernandoc Status: ready -->
+<refentry xml:id="function.mysql-fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_fetch_object</refname>
   <refpurpose>Obtém o resultado de uma linha como um objeto</refpurpose>
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_fetch_object</function></member>
-    <member><methodname phd:args="PDO::FETCH_OBJ">PDOStatement::fetch</methodname></member>
+    <member>
+     <methodname>PDOStatement::fetch</methodname>
+     com <parameter>mode</parameter> como <constant>PDO::FETCH_OBJ</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-fetch-row.xml
+++ b/reference/mysql/functions/mysql-fetch-row.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.mysql-fetch-row" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+<!-- EN-Revision: ff4017b6334dae2d5353fe99df8089a828795324 Maintainer: fernandoc Status: ready -->
+<refentry xml:id="function.mysql-fetch-row" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_fetch_row</refname>
   <refpurpose>Obtém uma linha como um array numérico</refpurpose>
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_fetch_row</function></member>
-    <member><methodname phd:args="PDO::FETCH_NUM">PDOStatement::fetch</methodname></member>
+    <member>
+     <methodname>PDOStatement::fetch</methodname>
+     com <parameter>mode</parameter> como <constant>PDO::FETCH_NUM</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysql/functions/mysql-field-len.xml
+++ b/reference/mysql/functions/mysql-field-len.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-field-len" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_field_len</refname>
@@ -19,7 +19,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>mysql_field_len</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>mysql_field_len</methodname>
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
    <methodparam><type>int</type><parameter>field_offset</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysql/functions/mysql-field-name.xml
+++ b/reference/mysql/functions/mysql-field-name.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-field-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_field_name</refname>
@@ -19,7 +19,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>mysql_field_name</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>mysql_field_name</methodname>
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
    <methodparam><type>int</type><parameter>field_offset</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysql/functions/mysql-get-client-info.xml
+++ b/reference/mysql/functions/mysql-get-client-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.mysql-get-client-info" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+<!-- EN-Revision: ff4017b6334dae2d5353fe99df8089a828795324 Maintainer: fernandoc Status: ready -->
+<refentry xml:id="function.mysql-get-client-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_get_client_info</refname>
   <refpurpose>Obtém informações do cliente MySQL</refpurpose>
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_get_client_info</function></member>
-    <member><methodname phd:args="PDO::ATTR_CLIENT_VERSION">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     com <parameter>attribute</parameter> como <constant>PDO::ATTR_CLIENT_VERSION</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>
@@ -28,13 +31,18 @@
   </para>
  </refsect1>
 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    A versão do cliente MySQL.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysql/functions/mysql-get-host-info.xml
+++ b/reference/mysql/functions/mysql-get-host-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.mysql-get-host-info" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+<!-- EN-Revision: ff4017b6334dae2d5353fe99df8089a828795324 Maintainer: fernandoc Status: ready -->
+<refentry xml:id="function.mysql-get-host-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_get_host_info</refname>
   <refpurpose>Obtém informações do servidor MySQL</refpurpose>
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_get_host_info</function></member>
-    <member><methodname phd:args="PDO::ATTR_CONNECTION_STATUS">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     com <parameter>attribute</parameter> como <constant>PDO::ATTR_CONNECTION_STATUS</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>
@@ -19,7 +22,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>mysql_get_host_info</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>mysql_get_host_info</methodname>
    <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -40,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna uma string descrevendo o tipo da conexão MySQL em uso para a 
+   Retorna uma string descrevendo o tipo da conexão MySQL em uso para a
    conexão&return.falseforfailure;.
   </para>
  </refsect1>

--- a/reference/mysql/functions/mysql-get-proto-info.xml
+++ b/reference/mysql/functions/mysql-get-proto-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-get-proto-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_get_proto_info</refname>
@@ -18,7 +18,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>mysql_get_proto_info</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>mysql_get_proto_info</methodname>
    <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mysql/functions/mysql-get-server-info.xml
+++ b/reference/mysql/functions/mysql-get-server-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.mysql-get-server-info" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+<!-- EN-Revision: ff4017b6334dae2d5353fe99df8089a828795324 Maintainer: fernandoc Status: ready -->
+<refentry xml:id="function.mysql-get-server-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_get_server_info</refname>
   <refpurpose>Obtém informações do servidor MySQL</refpurpose>
@@ -11,7 +11,10 @@
    &mysql.alternative.note;
    <simplelist role="alternatives">
     <member><function>mysqli_get_server_info</function></member>
-    <member><methodname phd:args="PDO::ATTR_SERVER_VERSION">PDO::getAttribute</methodname></member>
+    <member>
+     <methodname>PDO::getAttribute</methodname>
+     com <parameter>attribute</parameter> como <constant>PDO::ATTR_SERVER_VERSION</constant>
+    </member>
    </simplelist>
   </warning>
  </refsynopsisdiv>
@@ -19,7 +22,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>mysql_get_server_info</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>mysql_get_server_info</methodname>
    <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mysql/functions/mysql-insert-id.xml
+++ b/reference/mysql/functions/mysql-insert-id.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-insert-id" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_insert_id</refname>
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   O ID gerado para uma coluna AUTO_INCREMENT pela consulta 
+   O ID gerado para uma coluna AUTO_INCREMENT pela consulta
    anterior em caso de sucesso, <literal>0</literal> se a consulta anterior
    não gerou um valor AUTO_INCREMENT, ou &false; se
    não foi estabelecido conexão com o MySQL.

--- a/reference/mysql/functions/mysql-list-processes.xml
+++ b/reference/mysql/functions/mysql-list-processes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 65e697ff671608989432a6e6bf8ae8128b2be2c7 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-list-processes" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_list_processes</refname>
@@ -18,7 +18,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>mysql_list_processes</methodname>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>mysql_list_processes</methodname>
    <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mysql/functions/mysql-num-fields.xml
+++ b/reference/mysql/functions/mysql-num-fields.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b17322aa6b0b18b1268b137a0152598335836ab8 Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-num-fields" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_num_fields</refname>
@@ -19,7 +19,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>mysql_num_fields</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>mysql_num_fields</methodname>
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -43,7 +43,7 @@
    caso de sucesso&return.falseforfailure;.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/mysql/functions/mysql-num-rows.xml
+++ b/reference/mysql/functions/mysql-num-rows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bcafcd5fd4a0713172bd1cc6b1482aa9ff6f7b4b Maintainer: fernandoc Status: ready -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: fernandoc Status: ready -->
 <refentry xml:id="function.mysql-num-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysql_num_rows</refname>
@@ -20,7 +20,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>mysql_num_rows</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>mysql_num_rows</methodname>
    <methodparam><type>resource</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Please let me know if the Portuguese is incorrect, my motivation here is to get rid of the ``phd:`` XML attributes so that we can start using the standard DocBook schema.