### PR TITLE
Alteração na linha 301 de chapters/tutorial.xml

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -298,7 +298,7 @@ Você está usando o Firefox.
     o PHP e busca uma palavra em outra palavra. Neste caso nós estamos
     procurando pelo texto <literal>'Firefox'</literal> dentro de
     <varname>$_SERVER['HTTP_USER_AGENT']</varname>. Se o dado pesquisado
-    não for encontrado na coleção, a função retorna true. Se não, ela
+    for encontrado na coleção, a função retorna &true;. Se não, ela
     retorna &false;. Se ela retornar &true;, o <link
     linkend="control-structures.if">if</link> avalia para &true;
     e o código dentro dos {colchetes} é executado. Caso contrário o código não


### PR DESCRIPTION
A palavra "não" foi apagada pois alterava o sentido da frase, e além disso "&" e ";" foram colocados no _true_ para deixá-lo destacado no texto, do mesmo modo dos outros _trues_ e _falses_ no parágrafo.