### PR TITLE
docs: removed pgsql pipeline related functions from migration83.

### DIFF
--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: f037a94fd276a36a5061b0160fd3c2eafb20d980 Maintainer: marcosmarcolin Status: ready -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: dd5bc4f374d4db6e7ca88fcee40f04e8fcb26393 Maintainer: marcosmarcolin Status: ready -->
 <sect1 xml:id="migration83.new-functions">
  <title>Novas Funções</title>
 
@@ -87,10 +87,6 @@
   <simplelist>
    <member><function>pg_set_error_context_visibility</function>
     (libpq >= 9.6)</member>
-   <member><function>pg_enter_pipeline_mode</function> </member>
-   <member><function>pg_exit_pipeline_mode</function></member>
-   <member><function>pg_pipeline_sync</function></member>
-   <member><function>pg_pipeline_status</function></member>
   </simplelist>
  </sect2>
 


### PR DESCRIPTION
[new-functions.xml](http://doc.php.net/revcheck.php?p=plain&lang=pt_br&hbp=f037a94fd276a36a5061b0160fd3c2eafb20d980&f=appendices/migration83/new-functions.xml&c=off)