### PR TITLE
Updates to outdated pages in reference/gettext and reference/gmp

### DIFF
--- a/reference/gettext/book.xml
+++ b/reference/gettext/book.xml
@@ -1,22 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: felipe Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1634a886415d0ab4df195fe49d18a1c150b70758 Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
 
 <book xml:id="book.gettext" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="bundledexternal" ?>
  <title>Gettext</title>
- 
+
  <!-- {{{ preface -->
  <preface xml:id="intro.gettext">
   &reftitle.intro;
   <simpara>
-   As funções gettext implementa uma API NLS (Native Language Support)
-   que pode ser usada para internacionalizar suas aplicações PHP.
-   Veja a documentação da gettext para seu sistema para uma maior
-   explicação destas funções ou veja a documentação em
+   As funções gettext implementam uma API NLS (Native Language Support)
+   que pode ser usada para internacionalizar aplicações PHP.
+   Consulte a documentação da gettext para seu sistema para uma maior
+   explicação destas funções ou acesse a documentação em
    <link xlink:href="&url.gettext.docs;">&url.gettext.docs;</link>.
   </simpara>
  </preface>
  <!-- }}} -->
- 
+
  &reference.gettext.setup;
  &reference.gettext.constants;
  &reference.gettext.reference;

--- a/reference/gettext/functions/bind-textdomain-codeset.xml
+++ b/reference/gettext/functions/bind-textdomain-codeset.xml
@@ -1,27 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: thomasgm  Status: ready -->
+<!-- EN-Revision: 59e6c121147bd1b203f02a15c8a067c964ae4e99 Maintainer: leonardolara Status: ready --><!-- CREDITS: thomasgm,leonardolara -->
 <refentry xml:id="function.bind-textdomain-codeset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>bind_textdomain_codeset</refname>
-  <refpurpose>Define qual codificação de caractere será retornado 
-   pelas mensagens do catálogo do DOMÍNIO especificado.
-  </refpurpose>
+  <refpurpose>Especifica ou obtém a codificação de caracteres na qual as mensagens do catálogo de mensagens de DOMÍNIO serão retornadas</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>bind_textdomain_codeset</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>bind_textdomain_codeset</methodname>
    <methodparam><type>string</type><parameter>domain</parameter></methodparam>
-   <methodparam><type>string</type><parameter>codeset</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>codeset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Com <function>bind_textdomain_codeset</function>, você pode definir em qual
-   codificação será retornado a mensagem <parameter>domain</parameter> pela
+   <function>bind_textdomain_codeset</function> permite definir ou obter a
+   codificação na qual as mensagens de <parameter>domain</parameter> serão retornadas por
    <function>gettext</function> e funções similares.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -30,7 +28,7 @@
      <term><parameter>domain</parameter></term>
      <listitem>
       <para>
-       O domínio
+       O domínio.
       </para>
      </listitem>
     </varlistentry>
@@ -38,22 +36,55 @@
      <term><parameter>codeset</parameter></term>
      <listitem>
       <para>
-       O conjunto de caracteres
+       O conjunto de caracteres.
+       Se &null;, a codificação atualmente definida é retornada.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Uma <type>string</type> em sucesso.
+   Uma <type>string</type> em caso de sucesso.
   </para>
  </refsect1>
-</refentry>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.3</entry>
+      <entry>
+       <parameter>codeset</parameter> agora pode ser nulo.
+       Anteriormente, não era possível recuperar a codificação definida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    A informação de <function>bind_textdomain_codeset</function> é mantida por processo,
+    não por thread.
+   </para>
+  </note>
+ </refsect1>
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gettext/functions/bindtextdomain.xml
+++ b/reference/gettext/functions/bindtextdomain.xml
@@ -1,24 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: thomasgm  Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f456b5951e08d9c010e9717b2a7f7009a46ae5d8 Maintainer: leonardolara  Status: ready --><!-- CREDITS: thomasgm,leonardolara -->
 <refentry xml:id="function.bindtextdomain" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>bindtextdomain</refname>
-  <refpurpose>Configura o caminho para um domínio</refpurpose>
+  <refpurpose>Define ou obtém o caminho para um domínio</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>bindtextdomain</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>bindtextdomain</methodname>
    <methodparam><type>string</type><parameter>domain</parameter></methodparam>
-   <methodparam><type>string</type><parameter>directory</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
   <para>
-   A função <function>bindtextdomain</function> configura um 
+   A função <function>bindtextdomain</function> define ou obtém um
    caminho para um domínio.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -27,7 +27,7 @@
      <term><parameter>domain</parameter></term>
      <listitem>
       <para>
-       O domínio
+       O domínio.
       </para>
      </listitem>
     </varlistentry>
@@ -35,26 +35,52 @@
      <term><parameter>directory</parameter></term>
      <listitem>
       <para>
-       O caminho do diretório
+       O caminho do diretório.
+       Uma string vazia significa o diretório atual.
+       Se &null;, o diretório definido para o domínio é retornado.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   O caminho completo para o <parameter>domain</parameter> que foi definido.
+   O caminho completo para o domínio definido por <parameter>domain</parameter>,
+   &return.falseforfailure;.
   </para>
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.3</entry>
+      <entry>
+       <parameter>directory</parameter> agora pode ser nulo.
+       Anteriormente, não era possível recuperar o diretório definido para o domínio.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>bindtextdomain</function></title>
+    <title>Exemplo de <function>bindtextdomain</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -74,8 +100,17 @@ echo bindtextdomain($domain, '/usr/share/myapp/locale');
    </example>
   </para>
  </refsect1>
-</refentry>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    A informação de <function>bindtextdomain</function> é mantida por processo,
+    não por thread.
+   </para>
+  </note>
+ </refsect1>
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gettext/functions/ngettext.xml
+++ b/reference/gettext/functions/ngettext.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: b7307a8ed12ac836abafc952d0b5f3f15bf93caf Maintainer: thomasgm  Status: ready --><!-- CREDITS: ae -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ad2b7b45a27512d0e381b79641fecf6c713c4fb4 Maintainer: leonardolara Status: ready --><!-- CREDITS: ae,thomasgm,leonardolara -->
 <refentry xml:id="function.ngettext" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ngettext</refname>
@@ -10,13 +10,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>ngettext</methodname>
-   <methodparam><type>string</type><parameter>msgid1</parameter></methodparam>
-   <methodparam><type>string</type><parameter>msgid2</parameter></methodparam>
-   <methodparam><type>int</type><parameter>n</parameter></methodparam>
+   <methodparam><type>string</type><parameter>singular</parameter></methodparam>
+   <methodparam><type>string</type><parameter>plural</parameter></methodparam>
+   <methodparam><type>int</type><parameter>count</parameter></methodparam>
   </methodsynopsis>
   <para>
-   A versão de plural da <function>gettext</function>. Algumas linguagens
-   tem mais de uma forma para mensagens no plural dependendo da quantidade.
+   A versão plural de <function>gettext</function>. Algumas línguas
+   têm mais de uma forma para mensagens no plural dependendo da quantidade.
   </para>
  </refsect1>
 
@@ -25,23 +25,27 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>msgid1</parameter></term>
+     <term><parameter>singular</parameter></term>
      <listitem>
       <para>
+       O ID da mensagem singular.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>msgid2</parameter></term>
+     <term><parameter>plural</parameter></term>
      <listitem>
       <para>
+       O ID da mensagem plural.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>n</parameter></term>
+     <term><parameter>count</parameter></term>
      <listitem>
       <para>
+       O número (ex.: contagem de itens) para determinar a translação para o
+       respectivo número gramatical.
       </para>
      </listitem>
     </varlistentry>
@@ -52,9 +56,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna a forma plural da mensagem identificada por
-   <parameter>msgid1</parameter> e <parameter>msgid2</parameter>
-   para quantidade <parameter>n</parameter>. 
+   Retorna a forma plural correta da mensagem identificada por
+   <parameter>singular</parameter> e <parameter>plural</parameter>
+   para a quantidade em <parameter>count</parameter>.
   </para>
  </refsect1>
 
@@ -62,7 +66,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>ngettext</function></title>
+    <title>Exemplo de <function>ngettext</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -79,7 +83,6 @@ printf(ngettext("%d window", "%d windows", 5), 5); // 5 oken
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/book.xml
+++ b/reference/gmp/book.xml
@@ -1,53 +1,58 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a35fce69cc4174f61cfa228ad677797c833f9cba Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+
 <book xml:id="book.gmp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>GNU Multiple Precision</title>
+ <?phpdoc extension-membership="bundledexternal" ?>
+ <title>Precisão Múltipla GNU</title>
  <titleabbrev>GMP</titleabbrev>
- 
+
  <!-- {{{ preface -->
  <preface xml:id="intro.gmp">
   &reftitle.intro;
   <simpara>
-   Estas funções permitem a você trabalhar com inteiros de tamanho arbritário
-   usando a biblioteca GNU <acronym>MP</acronym>.
-  </simpara>
-  <simpara>
-   Estas funções foram adicionadas no PHP 4.0.4.
+   Estas funções permitem que inteiros de comprimento arbitrário sejam trabalhados usando
+   a biblioteca GNU <acronym>MP</acronym>.
   </simpara>
   <note>
    <para>
-    A maioria das funções GMP aceitam números GMP comoargumentos, definidos
-    como <literal>resource</literal> abaixo. Entretanto, a maioria destas
-    funções também aceitam argumentos númericos e strings, dado que é possível
-    converter posteriormente para um número. Também, caso houver uma
-    função mais rápida que possa trabalhar com números inteiros, ela
-    será usada ao invés de uma função mais lenta quando os argumentos forem inteiros.
-    Isto é feito de forma transparente, em resumo, você poderá usar
-    inteiros em qualquer função que espere um número GMP.
-    Veja também a função <function>gmp_init</function>.
+    A maioria das funções GMP aceitam números GMP como argumentos. Estes são mostrados nesta
+    documentação como objetos <classname>GMP</classname>. A maioria
+    destas funções também aceitam argumentos númericos e strings, desde que
+    seja possível converter a string para um número. Também, caso houver uma
+    função com melhor desempenho que possa operar nos argumentos (inteiros somente),
+    ela será usada (isso é feito de forma transparente). Consulte também a
+    função <function>gmp_init</function>.
+   </para>
+  </note>
+  <note>
+   <para>
+    A partir do PHP 5.6, os operadores
+    <link linkend="language.operators.arithmetic">aritméticos</link>,
+    <link linkend="language.operators.bitwise">binários</link> e
+    <link linkend="language.operators.comparison">comparativos</link>
+    podem ser usados com objetos <classname>GMP</classname> retornados de
+    <function>gmp_init</function> e de outras funções GMP.
    </para>
   </note>
   <warning>
    <simpara>
-    Se você quiser explicitamente especificar um número inteiro largo,
-    especifique-o como uma string. Se você não fizer isto, o PHP
-    irá interpretar a literal inteira primeiro, possivelmente resultando em
-    perca de precisão, mesmo antes de começar a utilizar o <literal>GMP</literal>.
+    Inteiros grandes devem ser especificados como strings - caso contrário, o PHP irá convertê-los
+    à força para o tipo float, resultando em perda de precisão.
    </simpara>
   </warning>
   <note>
    <simpara>
-    Esta extensão esta disponível na plataforma Windows desde PHP 5.1.0.
+    Esta extensão está disponível em plataformas plataforma Windows.
    </simpara>
   </note>
  </preface>
  <!-- }}} -->
- 
+
  &reference.gmp.setup;
  &reference.gmp.constants;
  &reference.gmp.examples;
  &reference.gmp.reference;
+ &reference.gmp.gmp;
 
 </book>
 

--- a/reference/gmp/configure.xml
+++ b/reference/gmp/configure.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e00851786a94cd00e3c5b36f40bce243e904b307 Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
 <section xml:id="gmp.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  Para ter estas funções disponíveis, você deve compilar o PHP com suporte a
-  <acronym>GMP</acronym> usando a opção de configuração <option
+  Para ter estas funções disponíveis, o PHP deve ser compilado com
+  suporte a <acronym>GMP</acronym> usando a opção de configuração <option
   role="configure">--with-gmp</option>.
  </para>
 </section>

--- a/reference/gmp/constants.xml
+++ b/reference/gmp/constants.xml
@@ -1,43 +1,98 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 5e9500ddad6dbc2f1b01d7da8b53379c8b7c386c Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
 <appendix xml:id="gmp.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
  <variablelist>
-  <varlistentry>
+  <varlistentry xml:id="constant.gmp-round-zero">
    <term>
-    <constant>GMP_ROUND_ZERO</constant> 
-    (<type>integer</type>)
+    <constant>GMP_ROUND_ZERO</constant>
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.gmp-round-plusinf">
    <term>
-    <constant>GMP_ROUND_PLUSINF</constant> 
-    (<type>integer</type>)
+    <constant>GMP_ROUND_PLUSINF</constant>
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.gmp-round-minusinf">
    <term>
-    <constant>GMP_ROUND_MINUSINF</constant> 
-    (<type>integer</type>)
+    <constant>GMP_ROUND_MINUSINF</constant>
+    (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.gmp-msw-first">
+   <term>
+    <constant>GMP_MSW_FIRST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.gmp-lsw-first">
+   <term>
+    <constant>GMP_LSW_FIRST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.gmp-little-endian">
+   <term>
+    <constant>GMP_LITTLE_ENDIAN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.gmp-big-endian">
+   <term>
+    <constant>GMP_BIG_ENDIAN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.gmp-native-endian">
+   <term>
+    <constant>GMP_NATIVE_ENDIAN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.gmp-version">
    <term>
     <constant>GMP_VERSION</constant>
     (<type>string</type>)
@@ -50,7 +105,6 @@
   </varlistentry>
  </variablelist>
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/examples.xml
+++ b/reference/gmp/examples.xml
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: felipe Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9ddd75d72456fb97261c978af4043e90b18802af Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
 <chapter xml:id="gmp.examples">
  &reftitle.examples;
  <para>
   <example>
-   <title>Função factorial usando GMP</title>
+   <title>Função fatorial usando GMP</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-function fact($x) 
+function fact($x)
 {
     $return = 1;
-    for ($i=2; $i < $x; $i++) {
+    for ($i=2; $i <= $x; $i++) {
         $return = gmp_mul($return, $i);
     }
     return $return;
@@ -24,8 +24,8 @@ echo gmp_strval(fact(1000)) . "\n";
   </example>
  </para>
  <para>
-  Isto irá calcular o fatorial de 1000 (um número grande)
-  muito rápido.
+  Este código irá calcular o fatorial de 1000 (um número grande)
+  de forma muito rápida.
  </para>
 </chapter>
 <!-- Keep this comment at the end of the file

--- a/reference/gmp/functions/gmp-abs.xml
+++ b/reference/gmp/functions/gmp-abs.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-abs" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_abs</refname>
-    <refpurpose>Valor absoluto</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-abs" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_abs</refname>
+  <refpurpose>Valor absoluto</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_abs</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Obtém o valor absoluto de um número.
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_abs</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Obtém o valor absoluto de um número.
   </para>
  </refsect1>
 
@@ -22,50 +22,49 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
-    </para>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna o valor absoluto de <parameter>a</parameter>, como um número GMP.
+   Retorna o valor absoluto de <parameter>num</parameter>, como um número GMP.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_abs</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_abs</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $abs1 = gmp_abs("274982683358");
 $abs2 = gmp_abs("-274982683358");
-       
+
 echo gmp_strval($abs1) . "\n";
 echo gmp_strval($abs2) . "\n";
 ?>
 ]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 274982683358
 274982683358
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-  </refentry>
-
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-add.xml
+++ b/reference/gmp/functions/gmp-add.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id="function.gmp-add" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_add</refname>
-    <refpurpose>Adiciona números</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-add" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_add</refname>
+  <refpurpose>Adiciona números</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_add</methodname>
-     <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     <methodparam><type>resource</type><parameter>b</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Adiciona dois números.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_add</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Adiciona dois números.
+  </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       <para>
-       Um número que será adicionado.
+       A primeira parcela.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       <para>
-       Um número que será adicionado.
+       A segunda parcela.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,32 +50,31 @@
    Um número GMP representado a soma dos argumentos.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo <function>gmp_add</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_add</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $sum = gmp_add("123456789012345", "76543210987655");
 echo gmp_strval($sum) . "\n";
 ?>
 ]]>
-     </programlisting>
+    </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
 200000000000000
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-and.xml
+++ b/reference/gmp/functions/gmp-and.xml
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
 <refentry xml:id="function.gmp-and" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_and</refname>
-  <refpurpose>Operador binário AND</refpurpose>
+  <refpurpose>Operação binária AND</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_and</methodname>
-   <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>b</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_and</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
    Faz a operação binária AND de dois números GMP.
@@ -23,15 +23,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,8 +48,8 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemplo da <function>gmp_and</function></title>
-    <programlisting role="php">
+   <title>Exemplo de <function>gmp_and</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $and1 = gmp_and("0xfffffffff4", "0x4");
@@ -68,9 +68,8 @@ echo gmp_strval($and2) . "\n";
    </screen>
   </example>
  </refsect1>
- 
-</refentry>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-cmp.xml
+++ b/reference/gmp/functions/gmp-cmp.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-cmp" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_cmp</refname>
-    <refpurpose>Compara números</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-cmp" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_cmp</refname>
+  <refpurpose>Compara números</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>int</type><methodname>gmp_cmp</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-      <methodparam><type>resource</type><parameter>b</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Compara dois números.
-    </para>
+  <methodsynopsis>
+   <type>int</type><methodname>gmp_cmp</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Compara dois números.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,15 +23,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,38 +41,36 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-     Retorna um valor positivo se <literal>a &gt; b</literal>, zero se
-     <literal>a = b</literal> e um valor negativo se <literal>a &lt;
-     b</literal>.
-    </para>
+   Retorna um valor positivo se <literal>a &gt; b</literal>, zero se
+   <literal>a = b</literal> e um valor negativo se <literal>a &lt;
+   b</literal>.
+  </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
-    <example>
-     <title>Exemplo da <function>gmp_cmp</function></title>
-      <programlisting role="php">
+  <example>
+   <title>Exemplo de <function>gmp_cmp</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-$cmp1 = gmp_cmp("1234", "1000"); // maior do que
-$cmp2 = gmp_cmp("1000", "1234"); // menor do que
-$cmp3 = gmp_cmp("1234", "1234"); // igual a 
-       
+$cmp1 = gmp_cmp("1234", "1000"); // maior que
+$cmp2 = gmp_cmp("1000", "1234"); // menor que
+$cmp3 = gmp_cmp("1234", "1234"); // igual a
+
 echo "$cmp1 $cmp2 $cmp3\n";
 ?>
 ]]>
-      </programlisting>
-     &example.outputs;
-     <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 1 -1 0
 ]]>
-     </screen>
-    </example>
-   </refsect1>
-   
-  </refentry>
-
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-com.xml
+++ b/reference/gmp/functions/gmp-com.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id='function.gmp-com' xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_com</refname>
-    <refpurpose>Calcula o complemento</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-com" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_com</refname>
+  <refpurpose>Calcula o complemento de um</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_com</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Retorna o complemento de <parameter>a</parameter>
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_com</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retorna o complemento de um do valor <parameter>num</parameter>.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,9 +22,9 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -34,33 +34,32 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna o complemento de <parameter>a</parameter>, como um número GMP.
+   Retorna o complemento de um do valor <parameter>num</parameter>, como um número GMP.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-     <example>
-      <title>Exemplo <function>gmp_com</function></title>
-       <programlisting role="php">
+  <example>
+   <title>Exemplo <function>gmp_com</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $com = gmp_com("1234");
 echo gmp_strval($com) . "\n";
 ?>
 ]]>
-       </programlisting>
-       &example.outputs;
-       <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 -1235
 ]]>
-     </screen>
-    </example>
-   </refsect1>
+   </screen>
+  </example>
+ </refsect1>
 
-  </refentry>
-
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-divexact.xml
+++ b/reference/gmp/functions/gmp-divexact.xml
@@ -1,24 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-divexact" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_divexact</refname>
-    <refpurpose>Divisão exata de números</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-divexact" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_divexact</refname>
+  <refpurpose>Divisão exata de números</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_divexact</methodname>
-      <methodparam><type>resource</type><parameter>n</parameter></methodparam>
-      <methodparam><type>resource</type><parameter>d</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Divide <parameter>n</parameter> por <parameter>d</parameter>,
-     usando um algaritimo rápido "exact division". Esta função produz
-     resultados corretos apenas quando sabe anteriormente que
-     <parameter>d</parameter> divide <parameter>n</parameter>.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_divexact</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Divide <parameter>num1</parameter> por <parameter>num2</parameter>,
+   usando um algoritimo rápido de "divisão exata". Esta função produz
+   resultados corretos apenas quando sabe anteriormente que
+   <parameter>num2</parameter> é divisor de <parameter>num1</parameter>.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,21 +26,21 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>n</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       <para>
        O número a ser dividido.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>d</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       <para>
-       O número o qual <parameter>a</parameter> será dividido.
+       O número pelo qual <parameter>num1</parameter> será dividido.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -57,9 +57,9 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo <function>gmp_divexact</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo <function>gmp_divexact</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $div1 = gmp_divexact("10", "2");
@@ -69,20 +69,19 @@ $div2 = gmp_divexact("10", "3"); // resultado errado
 echo gmp_strval($div2) . "\n";
 ?>
 ]]>
-      </programlisting>
-      &example.outputs;
-      <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 5
 2863311534
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-gcd.xml
+++ b/reference/gmp/functions/gmp-gcd.xml
@@ -1,23 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id="function.gmp-gcd" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_gcd</refname>
-    <refpurpose>Calcula o MDC</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-gcd" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_gcd</refname>
+  <refpurpose>Calcula o MDC</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_gcd</methodname>
-     <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     <methodparam><type>resource</type><parameter>b</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Calcula o máximo divisor comum de <parameter>a</parameter> e
-     <parameter>b</parameter>. O resultado é sempre positivo, mesmo que um,
-     ou ambos os argumentos sejam negativos.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_gcd</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Calcula o máximo divisor comum de <parameter>num1</parameter> e
+   <parameter>num2</parameter>. O resultado é sempre positivo, mesmo que um
+   ou ambos os argumentos sejam negativos.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,15 +25,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,36 +43,42 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Um número positivo GMP que divide 
-   <parameter>a</parameter> e <parameter>b</parameter>.
+   Um número positivo GMP divisor de
+   <parameter>num1</parameter> e <parameter>num2</parameter>.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_gcd</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_gcd</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $gcd = gmp_gcd("12", "21");
 echo gmp_strval($gcd) . "\n";
 ?>
 ]]>
-      </programlisting>
-      &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 3
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>gmp_lcm</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-gcdext.xml
+++ b/reference/gmp/functions/gmp-gcdext.xml
@@ -1,29 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready -->
-<refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.gmp-gcdext">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<refentry xml:id="function.gmp-gcdext" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_gcdext</refname>
-  <refpurpose>Calcula GCD e multiplicadores</refpurpose>
+  <refpurpose>Calcula MDC e multiplicadores</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>gmp_gcdext</methodname>
-   <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>b</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcula g, s, e t, como <literal>a*s + b*t = g =
-   gcd(a,b)</literal>, onde gcd é o maior divisor comum. Retorna
-   um array com respectivos elementos g, s e t.
+   Calcula g, s, e t, de forma que <literal>a*s + b*t = g =
+   gcd(a,b)</literal>, onde gcd é o máximo divisor comum (MDC). Retorna
+   um array com os respectivos elementos g, s e t.
   </para>
   <para>
-   Esta função pode ser usada para resolver equações lineares Diophantine em duas
-   variáveis. Esta equação permite somente soluções inteiras e tem a forma:
+   Esta função pode ser usada para resolver equações lineares de Diophantine com duas
+   variáveis. São equações que permitem somente soluções com inteiros e têm a forma:
    <literal>a*x + b*y = c</literal>.
-   Para mais informação, veja <link xlink:href="&url.diophantine-equation;">"Diophantine
-   Equation" na página MathWorld</link>
+   Para mais informações, acesse a página <link xlink:href="&url.diophantine-equation;">"Equação de
+   Diophantine"</link> (em inglês) na MathWorld.
   </para>
  </refsect1>
 
@@ -32,13 +32,13 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       &gmp.parameter;
      </listitem>
@@ -58,12 +58,12 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Resolvendo uma equação linear Diophantine</title>
+    <title>Resolvendo uma equação linear de Diophantine</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// Solve the equation a*s + b*t = g
-// where a = 12, b = 21, g = gcd(12, 21) = 3
+// Soluciona a equação a*s + b*t = g
+// onde a = 12, b = 21, g = MDC(12, 21) = 3
 $a = gmp_init(12);
 $b = gmp_init(21);
 $g = gmp_gcd($a, $b);
@@ -74,14 +74,14 @@ $eq_res = gmp_add(gmp_mul($a, $r['s']), gmp_mul($b, $r['t']));
 $check_res = (gmp_strval($g) == gmp_strval($eq_res));
 
 if ($check_gcd && $check_res) {
-    $fmt = "Solution: %d*%d + %d*%d = %d\n";
+    $fmt = "Solução: %d*%d + %d*%d = %d\n";
     printf($fmt, gmp_strval($a), gmp_strval($r['s']), gmp_strval($b),
     gmp_strval($r['t']), gmp_strval($r['g']));
 } else {
-    echo "Error while solving the equation\n";
+    echo "Erro ao solucionar a equação\n";
 }
 
-// output: Solution: 12*2 + 21*-1 = 3
+// saída: Solução: 12*2 + 21*-1 = 3
 ?>
 ]]>
     </programlisting>
@@ -89,7 +89,6 @@ if ($check_gcd && $check_res) {
   </para>
  </refsect1>
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-hamdist.xml
+++ b/reference/gmp/functions/gmp-hamdist.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gmp-hamdist">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<refentry xml:id="function.gmp-hamdist" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_hamdist</refname>
   <refpurpose>Distância de Hamming</refpurpose>
@@ -10,12 +10,12 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>gmp_hamdist</methodname>
-   <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>b</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retorna a distância de Hamming entre <parameter>a</parameter> e
-   <parameter>b</parameter>. Ambos operandos devem ser positivo.
+   Retorna a distância de Hamming entre <parameter>num1</parameter> e
+   <parameter>num2</parameter>. Ambos argumentos devem ser positivos.
   </para>
  </refsect1>
 
@@ -24,7 +24,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       &gmp.parameter;
       <para>
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       &gmp.parameter;
       <para>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &gmp.return;
+   A distância de Hamming entre <parameter>num1</parameter> e <parameter>num2</parameter>, do tipo <type>int</type>.
   </para>
  </refsect1>
 
@@ -56,7 +56,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_hamdist</function></title>
+    <title>Exemplo de <function>gmp_hamdist</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -64,7 +64,7 @@ $ham1 = gmp_init("1001010011", 2);
 $ham2 = gmp_init("1011111100", 2);
 echo gmp_hamdist($ham1, $ham2) . "\n";
 
-/* hamdist is equivilent to: */
+/* a distância de Hamming é equivalente a : */
 echo gmp_popcount(gmp_xor($ham1, $ham2)) . "\n";
 ?>
 ]]>
@@ -91,7 +91,6 @@ echo gmp_popcount(gmp_xor($ham1, $ham2)) . "\n";
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-intval.xml
+++ b/reference/gmp/functions/gmp-intval.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-intval" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_intval</refname>
-    <refpurpose>Converte um número GMP para um inteiro</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-intval" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_intval</refname>
+  <refpurpose>Converte um número GMP para um inteiro</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>int</type><methodname>gmp_intval</methodname>
-     <methodparam><type>resource</type><parameter>gmpnumber</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Esta função permite converter um número GMP para um inteiro.
-    </para>
+  <methodsynopsis>
+   <type>int</type><methodname>gmp_intval</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Esta função converte um número GMP para um <type>int</type> nativo do PHP.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,11 +22,9 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>gmpnumber</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      <para>
-       Um número GMP.
-      </para>
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,54 +34,53 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Um valor <type>integer</type> de <parameter>gmpnumber</parameter>.
+   Um valor <type>int</type> de <parameter>num</parameter>.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo <function>gmp_intval</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo <function>gmp_intval</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 // Mostra o valor correto
 echo gmp_intval("2147483647") . "\n";
-       
-// Mostra um resultado errado, acima do limite de intero do PHP
+
+// Mostra um resultado errado, acima do limite de inteiro do PHP
 echo gmp_intval("2147483648") . "\n";
-       
+
 // mostra o valor correto
 echo gmp_strval("2147483648") . "\n";
 ?>
 ]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 2147483647
 2147483647
 2147483648
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <warning>
    <simpara>
-    Esta função retorna um resultado útil somente se o número se adequa
-    ao inteiro PHP (i.e., tipo long com sinal). Se você quer somente
-    imprimir o número GMP, use <function>gmp_strval</function>.
+    Esta função retorna um resultado útil somente se o número realmente
+    cabe em um inteiro PHP (isto é, tipo longo com sinal). Para simplemsmente mostrar
+    o número GMP, use <function>gmp_strval</function>.
    </simpara>
   </warning>
  </refsect1>
 
-  </refentry>
-
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-jacobi.xml
+++ b/reference/gmp/functions/gmp-jacobi.xml
@@ -1,24 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id="function.gmp-jacobi" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-   <refnamediv>
-    <refname>gmp_jacobi</refname>
-    <refpurpose>Símbolo de Jacobi</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-jacobi" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>gmp_jacobi</refname>
+  <refpurpose>Símbolo de Jacobi</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>int</type><methodname>gmp_jacobi</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-      <methodparam><type>resource</type><parameter>p</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Computa o <link xlink:href="&url.jacobi;">Símbolo de Jacobi</link> de 
-     <parameter>a</parameter> e
-     <parameter>p</parameter>. <parameter>p</parameter> deve ser
-     ímpar e positivo.
-    </para>
+  <methodsynopsis>
+   <type>int</type><methodname>gmp_jacobi</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Computa o
+   <link xlink:href="&url.jacobi;">Símbolo de Jacobi</link> de <parameter>num1</parameter> e
+   <parameter>num2</parameter>. <parameter>num2</parameter> deve ser ímpar
+   e positivo.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,15 +26,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>p</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
       <para>
        Deve ser ímpar e positivo.
       </para>
@@ -54,29 +54,36 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo <function>gmp_jacobi</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_jacobi</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 echo gmp_jacobi("1", "3") . "\n";
 echo gmp_jacobi("2", "3") . "\n";
 ?>
 ]]>
-      </programlisting>
-      &example.outputs;
-      <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 1
-      
-]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
 
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>gmp_kronecker</function></member>
+   <member><function>gmp_legendre</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-legendre.xml
+++ b/reference/gmp/functions/gmp-legendre.xml
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id="function.gmp-legendre" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-   <refnamediv>
-    <refname>gmp_legendre</refname>
-    <refpurpose>Símbolo de Legendre</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-legendre" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>gmp_legendre</refname>
+  <refpurpose>Símbolo de Legendre</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>int</type><methodname>gmp_legendre</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-      <methodparam><type>resource</type><parameter>p</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Computa o
-     <link xlink:href="&url.symbole-legendre;">
-     Símbolo de Legendre </link> de <parameter>a</parameter> e
-     <parameter>p</parameter>. <parameter>p</parameter> deve ser
-     inteiro e positivo.
-    </para>
+  <methodsynopsis>
+   <type>int</type><methodname>gmp_legendre</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Computa o
+   <link xlink:href="&url.symbole-legendre;">
+   Símbolo de Legendre</link> de <parameter>num1</parameter> e
+   <parameter>num2</parameter>. <parameter>num2</parameter> deve ser ímpar
+   e positivo.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,15 +27,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>p</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
       <para>
        Precisa ser ímpar e positivo.
       </para>
@@ -55,29 +55,36 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-     <example>
-      <title>Exemplo da <function>gmp_legendre</function></title>
-       <programlisting role="php">
+   <example>
+    <title>Exemplo da <function>gmp_legendre</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 echo gmp_legendre("1", "3") . "\n";
 echo gmp_legendre("2", "3") . "\n";
 ?>
 ]]>
-       </programlisting>
-       &example.outputs;
-       <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 1
-       
-]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
 
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>gmp_jacobi</function></member>
+   <member><function>gmp_kronecker</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-mod.xml
+++ b/reference/gmp/functions/gmp-mod.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gmp-mod">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<refentry xml:id="function.gmp-mod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_mod</refname>
   <refpurpose>Operação Módulo</refpurpose>
@@ -9,14 +9,14 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_mod</methodname>
-   <methodparam><type>resource</type><parameter>n</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>d</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_mod</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcula <parameter>n</parameter> módulo
-   <parameter>d</parameter>. O resultado é sempre positivo, o
-   sinal de <parameter>d</parameter> é ignorado.
+   Calcula o resto da divisão de <parameter>num1</parameter>
+   por <parameter>num2</parameter>. O resultado é sempre não-negativo, o
+   sinal de <parameter>num2</parameter> é ignorado.
   </para>
  </refsect1>
 
@@ -25,16 +25,16 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>n</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>d</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       <para>
-       O módulo que será calculado.
+       O resto da divisão (módulo) que será calculado.
       </para>
       &gmp.parameter;
      </listitem>
@@ -54,7 +54,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_mod</function></title>
+    <title>Exemplo de <function>gmp_mod</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -74,7 +74,6 @@ echo gmp_strval($mod) . "\n";
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-mul.xml
+++ b/reference/gmp/functions/gmp-mul.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-mul" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_mul</refname>
-    <refpurpose>Multiplica números</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<refentry xml:id="function.gmp-mul" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_mul</refname>
+  <refpurpose>Multiplica números</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_mul</methodname>
-     <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     <methodparam><type>resource</type><parameter>b</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Multiplica <parameter>a</parameter> por <parameter>b</parameter>
-     e retorna o resultado.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_mul</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Multiplica <parameter>num1</parameter> por <parameter>num2</parameter>
+   e retorna o resultado.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,21 +24,21 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       <para>
-       Um número que será multiplicado por <parameter>b</parameter>.
+       Um número que será multiplicado por <parameter>num2</parameter>.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       <para>
-       Um número que será multiplicado por <parameter>a</parameter>.
+       Um número que será multiplicado por <parameter>num1</parameter>.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -55,28 +55,27 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_mul</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo da <function>gmp_mul</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $mul = gmp_mul("12345678", "2000");
 echo gmp_strval($mul) . "\n";
 ?>
 ]]>
-      </programlisting>
-      &example.outputs;
-      <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 24691356000
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-neg.xml
+++ b/reference/gmp/functions/gmp-neg.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-neg" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_neg</refname>
-    <refpurpose>Nega o número</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-neg" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_neg</refname>
+  <refpurpose>Negativa o número</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_neg</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Retorna o valor negativo de um número.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_neg</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retorna o valor negativo de um número.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,9 +22,9 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -34,16 +34,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna -<parameter>a</parameter>, como um número GMP.
+   Retorna -<parameter>num</parameter>, como um número GMP.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_neg</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_neg</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $neg1 = gmp_neg("1");
@@ -52,20 +52,19 @@ $neg2 = gmp_neg("-1");
 echo gmp_strval($neg2) . "\n";
 ?>
 ]]>
-      </programlisting>
-      &example.outputs;
-      <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 -1
 1
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-nextprime.xml
+++ b/reference/gmp/functions/gmp-nextprime.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gmp-nextprime">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<refentry xml:id="function.gmp-nextprime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_nextprime</refname>
-  <refpurpose>Busca o próximo número primo</refpurpose>
+  <refpurpose>Encontra o próximo número primo</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_nextprime</methodname>
-   <methodparam><type>int</type><parameter>a</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_nextprime</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Busca o próximo número primo
+   Encontra o próximo número primo
   </para>
  </refsect1>
 
@@ -22,7 +22,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
       &gmp.parameter;
      </listitem>
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna o próximo número primo maior que <parameter>a</parameter>,
+   Retorna o próximo número primo maior que <parameter>num</parameter>,
    como um número GMP.
   </para>
  </refsect1>
@@ -43,12 +43,12 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_nextprime</function></title>
+    <title>Exemplo de <function>gmp_nextprime</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
-$prime1 = gmp_nextprime(10); // next prime number greater than 10
-$prime2 = gmp_nextprime(-1000); // next prime number greater than -1000
+$prime1 = gmp_nextprime(10); // o próximo número primo maior que 10
+$prime2 = gmp_nextprime(-1000); // o próximo número primo maior que -1000
 
 echo gmp_strval($prime1) . "\n";
 echo gmp_strval($prime2) . "\n";
@@ -59,7 +59,7 @@ echo gmp_strval($prime2) . "\n";
     <screen>
 <![CDATA[
 11
--997
+2
 ]]>
     </screen>
    </example>
@@ -71,13 +71,12 @@ echo gmp_strval($prime2) . "\n";
   <note>
    <para>
     Esta função usa um algoritmo probabilístico para identificar primos e
-    chances ter um número composto é extremamente pequena.
+    as chances de se obter um número composto é extremamente pequena.
    </para>
   </note>
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-or.xml
+++ b/reference/gmp/functions/gmp-or.xml
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
 <refentry xml:id="function.gmp-or" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_or</refname>
-  <refpurpose>Lógico OR</refpurpose>
+  <refpurpose>Operação binária OR</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_or</methodname>
-   <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>b</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_or</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
    Faz a operação binária inclusiva OR de dois números GMP.
@@ -23,15 +23,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,8 +49,8 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_or</function></title>
-     <programlisting role="php">
+    <title>Exemplo de <function>gmp_or</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $or1 = gmp_or("0xfffffff2", "4");
@@ -70,9 +70,8 @@ fffffff2
    </example>
   </para>
  </refsect1>
- 
-</refentry>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-popcount.xml
+++ b/reference/gmp/functions/gmp-popcount.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-popcount" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_popcount</refname>
-    <refpurpose>Contagem de população</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-popcount" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_popcount</refname>
+  <refpurpose>Contagem de população</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>int</type><methodname>gmp_popcount</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Obtém a contagem de população.
-    </para>
+  <methodsynopsis>
+   <type>int</type><methodname>gmp_popcount</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Obtém a contagem de população.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -22,9 +22,9 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -34,16 +34,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A contagem de população de <parameter>a</parameter>, como um <type>integer</type>.
+   A contagem de população de <parameter>num</parameter>, como um <type>int</type>.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_popcount</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_popcount</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $pop1 = gmp_init("10000101", 2); // 3 1's
@@ -52,20 +52,19 @@ $pop2 = gmp_init("11111110", 2); // 7 1's
 echo gmp_popcount($pop2) . "\n";
 ?>
 ]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 3
 7
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-pow.xml
+++ b/reference/gmp/functions/gmp-pow.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id="function.gmp-pow" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_pow</refname>
-    <refpurpose>Potenciação</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-pow" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_pow</refname>
+  <refpurpose>Elevar o número a uma potência</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_pow</methodname>
-      <methodparam><type>resource</type><parameter>base</parameter></methodparam>
-      <methodparam><type>int</type><parameter>exp</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Eleva <parameter>base</parameter> na potência <parameter>exp</parameter>.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_pow</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+   <methodparam><type>int</type><parameter>exponent</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Eleva <parameter>num</parameter> à potência <parameter>exponent</parameter>.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,19 +23,19 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>base</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
       <para>
        O número da base.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>exp</parameter></term>
+     <term><parameter>exponent</parameter></term>
      <listitem>
       <para>
-       A positiva potência para elevar a <parameter>base</parameter>.
+       A potência positiva à qual <parameter>num</parameter> será elevado.
       </para>
      </listitem>
     </varlistentry>
@@ -46,41 +46,40 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   O novo (elevado) número, como um número GMP. O caso de 
-   <literal>0^0</literal> reproduzir 1.
+   O novo número (exponenciado), como um número GMP. O caso de
+   <literal>0^0</literal> produz 1.
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-     <example>
-      <title>Exemplo <function>gmp_pow</function></title>
-      <programlisting role="php">
+   <example>
+    <title>Exemplo <function>gmp_pow</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $pow1 = gmp_pow("2", 31);
 echo gmp_strval($pow1) . "\n";
 $pow2 = gmp_pow("0", 0);
 echo gmp_strval($pow2) . "\n";
-$pow3 = gmp_pow("2", -1); // Expoente negativo, gera um warning
+$pow3 = gmp_pow("2", -1); // Expoente negativo, gera um alerta
 echo gmp_strval($pow3) . "\n";
 ?>
 ]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 2147483648
 1
 ]]>
-     </screen>
-     </example>
-     </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-powm.xml
+++ b/reference/gmp/functions/gmp-powm.xml
@@ -1,23 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gmp-powm">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<refentry xml:id="function.gmp-powm" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_powm</refname>
-  <refpurpose>Eleva um número a potência com módulo</refpurpose>
+  <refpurpose>Eleva um número a uma potência com módulo</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_powm</methodname>
-   <methodparam><type>resource</type><parameter>base</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>exp</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>mod</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_powm</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>exponent</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>modulus</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcula (<parameter>base</parameter> elevado a potência
-   <parameter>exp</parameter>) módulo <parameter>mod</parameter>. Se
-   <parameter>exp</parameter> é negativo, o resultado é indefinido.
+   Calcula o resto da divisão de (<parameter>num</parameter> elevado à potência
+   <parameter>exponent</parameter>) por <parameter>modulus</parameter>. Se
+   <parameter>exponent</parameter> for negativo, o resultado é indefinido.
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>base</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
       <para>
        O número da base.
@@ -36,19 +36,19 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>exp</parameter></term>
+     <term><parameter>exponent</parameter></term>
      <listitem>
       <para>
-       A potência positiva para elevar a <parameter>base</parameter>.
+       A potência positiva à qual <parameter>num</parameter> será elevado.
       </para>
       &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>mod</parameter></term>
+     <term><parameter>modulus</parameter></term>
      <listitem>
       <para>
-       O módulo.
+       O divisor para obtenção do resto (módulo).
       </para>
       &gmp.parameter;
      </listitem>
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   O novo (elevado) número, como um número GMP.
+   O novo número (exponenciado), como um número GMP.
   </para>
  </refsect1>
 
@@ -68,7 +68,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_powm</function></title>
+    <title>Exemplo de <function>gmp_powm</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -88,7 +88,6 @@ echo gmp_strval($pow1) . "\n";
  </refsect1>
 
 </refentry>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-sign.xml
+++ b/reference/gmp/functions/gmp-sign.xml
@@ -1,18 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-sign" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_sign</refname>
-    <refpurpose>Sinal do número</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a35fce69cc4174f61cfa228ad677797c833f9cba Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-sign" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_sign</refname>
+  <refpurpose>Sinal do número</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>int</type><methodname>gmp_sign</methodname>
-     <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     </methodsynopsis>
-    <para>
+  <methodsynopsis>
+   <type>int</type><methodname>gmp_sign</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
    Verifica o sinal de um número.
   </para>
  </refsect1>
@@ -22,9 +22,13 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      <para>
+       Pode ser um objeto <classname>GMP</classname>, ou uma string
+       numérica desde que seja possível convertê-la para um
+       <type>int</type>.
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,46 +37,55 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-    <para>
-     Retorna 1 se <parameter>a</parameter> é positivo,
-     -1 se <parameter>a</parameter> é negativo,
-     e 0 se <parameter>a</parameter> for zero.
-    </para>
+  <para>
+   Retorna 1 se <parameter>num</parameter> for positivo,
+   -1 se <parameter>num</parameter> for negativo,
+   e 0 se <parameter>num</parameter> for zero.
+  </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_sign</function></title>
-     <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>gmp_sign</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 // positivo
 echo gmp_sign("500") . "\n";
-       
+
 // negativo
 echo gmp_sign("-500") . "\n";
-       
+
 // zero
 echo gmp_sign("0") . "\n";
 ?>
 ]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 1
 -1
-0    
+0
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>gmp_abs</function></member>
+    <member><function>abs</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-sqrt.xml
+++ b/reference/gmp/functions/gmp-sqrt.xml
@@ -1,55 +1,55 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
 <refentry xml:id="function.gmp-sqrt" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_sqrt</refname>
-  <refpurpose>Raíz quadrada</refpurpose>
+  <refpurpose>Calcula a raiz quadrada</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_sqrt</methodname>
-   <methodparam><type>resource</type><parameter>a</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_sqrt</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcula a raiz quadrada de <parameter>a</parameter>.
+   Calcula a raiz quadrada de <parameter>num</parameter>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    A parte inteira da raiz quadrada, como um número GMP.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo <function>gmp_sqrt</function></title>
+    <title>Exemplo de <function>gmp_sqrt</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
 $sqrt1 = gmp_sqrt("9");
 $sqrt2 = gmp_sqrt("7");
 $sqrt3 = gmp_sqrt("1524157875019052100");
-       
+
 echo gmp_strval($sqrt1) . "\n";
 echo gmp_strval($sqrt2) . "\n";
 echo gmp_strval($sqrt3) . "\n";
@@ -67,9 +67,8 @@ echo gmp_strval($sqrt3) . "\n";
    </example>
   </para>
  </refsect1>
- 
-</refentry>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-sqrtrem.xml
+++ b/reference/gmp/functions/gmp-sqrtrem.xml
@@ -1,18 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 2fd3f0c96d9d221fe37109775af4df4cf949d5d8 Maintainer: fernandoc Status: ready -->
-  <refentry xml:id="function.gmp-sqrtrm" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_sqrtrem</refname>
-    <refpurpose>Raíz quadrada com resto</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
+<refentry xml:id="function.gmp-sqrtrem" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_sqrtrem</refname>
+  <refpurpose>Raiz quadrada com resto</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>array</type><methodname>gmp_sqrtrem</methodname>
-      <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     </methodsynopsis>
-    <para>
+  <methodsynopsis>
+   <type>array</type><methodname>gmp_sqrtrem</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <para>
    Calcula a raiz quadrada de um número, com resto.
   </para>
  </refsect1>
@@ -22,12 +22,12 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
       <para>
-       O número a ser calculado a raiz quadrada.
+       O número do qual será calculada a raiz quadrada.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,18 +37,18 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-     Retorna uma matriz onde o primeiro elemento é um inteiro raíz quadrada de
-     <parameter>a</parameter> e o segundo é o resto
-     (a diferença entre <parameter>a</parameter> e o
-     quadrado do primeiro elemento).
-    </para>
-   </refsect1>
+   Retorna um array onde o primeiro elemento é a raiz quadrada inteira de
+   <parameter>num</parameter> e o segundo é o resto
+   (isto é, a diferença entre <parameter>num</parameter> e o
+   quadrado do primeiro elemento).
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_sqrtrem</function></title>
+    <title>Exemplo de <function>gmp_sqrtrem</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -74,8 +74,7 @@ echo gmp_strval($sqrt3) . ", " . gmp_strval($sqrt3rem) . "\n";
   </para>
  </refsect1>
 
-  </refentry>
-
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-strval.xml
+++ b/reference/gmp/functions/gmp-strval.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-strval" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_strval</refname>
-    <refpurpose>Converte um número GMP para uma string</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 43130349a3f4681a2039e7e27fb56082981cdc13 Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-strval" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_strval</refname>
+  <refpurpose>Converte um número GMP para uma string</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>string</type><methodname>gmp_strval</methodname>
-     <methodparam><type>resource</type><parameter>gmpnumber</parameter></methodparam>
-     <methodparam choice="opt"><type>int</type><parameter>base</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Converte o número GMP para a representação de uma string na base
-     <parameter>base</parameter>. A base padrão é 10.
-    </para>
+  <methodsynopsis>
+   <type>string</type><methodname>gmp_strval</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>base</parameter><initializer>10</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Converte o número GMP para uma representação em string na base
+   <parameter>base</parameter>. A base padrão é 10.
+  </para>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,20 +24,20 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>gmpnumber</parameter></term>
+     <term><parameter>num</parameter></term>
      <listitem>
       <para>
        O número GMP que será convertido para uma string.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>base</parameter></term>
      <listitem>
       <para>
-       A base do número retornado. A base padrão é 10. 
-       Valores permitidos para base são de 2 à 36.
+       A base do número retornado. A base padrão é 10.
+       Valores permitidos para base são de 2 à 62 e -2 a -36.
       </para>
      </listitem>
     </varlistentry>
@@ -54,22 +54,21 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
-     <example>
-      <title>Convertendo um número GMP para uma string</title>
-      <programlisting role="php">
+  <para>
+   <example>
+    <title>Convertendo um número GMP para uma string</title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $a = gmp_init("0x41682179fbf5");
 printf("Decimal: %s, 36-based: %s", gmp_strval($a), gmp_strval($a,36));
 ?>
 ]]>
-      </programlisting>
-     </example>
-    </para>
-   </refsect1>
-  </refentry>
-
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-sub.xml
+++ b/reference/gmp/functions/gmp-sub.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-  <refentry xml:id="function.gmp-sub" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>gmp_sub</refname>
-    <refpurpose>Subtrai números</refpurpose>
-   </refnamediv>
- 
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,felipe,leonardolara -->
+<refentry xml:id="function.gmp-sub" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_sub</refname>
+  <refpurpose>Subtrai números</refpurpose>
+ </refnamediv>
+
  <refsect1 role="description">
   &reftitle.description;
-     <methodsynopsis>
-      <type>resource</type><methodname>gmp_sub</methodname>
-     <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-     <methodparam><type>resource</type><parameter>b</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     Subtrai <parameter>b</parameter> de <parameter>a</parameter>
-     e retorna o resultado.
-    </para>
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_sub</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Subtrai <parameter>num2</parameter> de <parameter>num1</parameter>
+   e retorna o resultado.
+  </para>
  </refsect1>
 
 
@@ -25,21 +25,21 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
       <para>
-       The number being subtracted from.
+       O minuendo.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       <para>
-       The number subtracted from <parameter>a</parameter>.
+       O subtraendo, que será subtraído de <parameter>num1</parameter>.
       </para>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -56,28 +56,27 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-    <example>
-     <title>Exemplo da <function>gmp_sub</function></title>
-     <programlisting role="php">
+   <example>
+    <title>Exemplo da <function>gmp_sub</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $sub = gmp_sub("281474976710656", "4294967296"); // 2^48 - 2^32
 echo gmp_strval($sub) . "\n";
 ?>
 ]]>
-     </programlisting>
-     &example.outputs;
-     <screen>
+    </programlisting>
+    &example.outputs;
+    <screen>
 <![CDATA[
 281470681743360
 ]]>
-     </screen>
-    </example>
-    </para>
-   </refsect1>
-   
-  </refentry>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/functions/gmp-xor.xml
+++ b/reference/gmp/functions/gmp-xor.xml
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: fernandoc Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandoc,leonardolara -->
 <refentry xml:id="function.gmp-xor" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_xor</refname>
   <refpurpose>Operação binária XOR</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>gmp_xor</methodname>
-   <methodparam><type>resource</type><parameter>a</parameter></methodparam>
-   <methodparam><type>resource</type><parameter>b</parameter></methodparam>
+   <type>GMP</type><methodname>gmp_xor</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
    Faz a operação binária exclusiva OR (XOR) de dois números GMP.
@@ -23,15 +23,15 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>a</parameter></term>
+     <term><parameter>num1</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>b</parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
-      &gmp.parameter; 
+      &gmp.parameter;
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,15 +49,15 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>gmp_xor</function></title>
+    <title>Exemplo de <function>gmp_xor</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
 $xor1 = gmp_init("1101101110011101", 2);
 $xor2 = gmp_init("0110011001011001", 2);
-       
+
 $xor3 = gmp_xor($xor1, $xor2);
-       
+
 echo gmp_strval($xor3, 2) . "\n";
 ?>
 ]]>
@@ -71,8 +71,8 @@ echo gmp_strval($xor3, 2) . "\n";
    </example>
   </para>
  </refsect1>
-</refentry>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -1,47 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8932dc479ab319693fe984a4eed2b3c768540256 Maintainer: rafaelbernard Status: ready -->
-
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: leonardolara Status: ready --><!-- CREDITS: rafaelbernard,leonardolara -->
 <phpdoc:classref xml:id="class.gmp" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>Classe GMP</title>
+ <title>A classe GMP</title>
  <titleabbrev>GMP</titleabbrev>
 
  <partintro>
   <section xml:id="gmp.intro">
    &reftitle.intro;
    <para>
-    Representa um número GMP. Este objeto suporta operadores
+    Representa um número GMP. Este objeto suporta sobrecarga dos operadores
     <link linkend="language.operators.arithmetic">aritméticos</link>,
-    <link linkend="language.operators.bitwise">bitwise</link> e de
-    <link linkend="language.operators.comparison">comparação</link>.
+    <link linkend="language.operators.bitwise">binários</link> e
+    <link linkend="language.operators.comparison">comparativos</link>.
    </para>
    <note>
     <para>
      Nenhuma interface orientada a objeto é provida para manipular objetos
-     <classname>GMP</classname>. Por favor, use a 
-     <link linkend="book.gmp">API procedural GMP</link>.
+     <classname>GMP</classname>. Para isto, favor usar a
+     <link linkend="book.gmp">API GMP procedural</link>.
     </para>
    </note>
   </section>
 
   <section xml:id="gmp.synopsis">
-   <classsynopsis>
-    <ooclass><classname>GMP</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>GMP</classname>
+    </ooclass>
 
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>GMP</classname>
-     </ooclass>
-     <oointerface>
-      <interfacename>Serializable</interfacename>
-     </oointerface>
-    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])">
+     <xi:fallback/>
+    </xi:include>
    </classsynopsis>
   </section>
  </partintro>
 
-</phpdoc:classref>
+ &reference.gmp.entities.gmp;
 
+</phpdoc:classref>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
O item abaixo refere-se a um erro no manual em inglês.
Aberto o issue `en`#2994 para correção.

qaxml.t: pt_br/reference/gmp/functions/gmp-divexact.xml
* parameter>num1 -5 +4
+ parameter>a