### PR TITLE
Replace depreciado with descontinuado

### DIFF
--- a/appendices/migration70.xml
+++ b/appendices/migration70.xml
@@ -20,10 +20,10 @@
 
  <sect1 annotations="chunk:false" xml:id="migration70.intro">
   <para>
-   Apesar do fato do PHP 7.0 ser uma versão superior, esforços foram feitos
+   Apesar do fato do PHP 7.0 ser uma nova versão principal, esforços foram feitos
    para que a migração seja feita da forma mais simples possível. Essa versão
-   foca principalmente na remoção de funcionalidades depreciadas em versões
-   anteriores e na melhoria da consistênciada da linguagem.
+   foca na remoção de funcionalidades descontinuadas em versões
+   anteriores e na melhoria da consistência da linguagem.
   </para>
   <para>
    Existem <link linkend="migration70.incompatible">algumas incompatibilidades</link>

--- a/appendices/migration70/deprecated.xml
+++ b/appendices/migration70/deprecated.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: a8599f426e5178777f7256002979482d9a810387 Maintainer: fabioluciano Status: ready --><!-- CREDITS: fabioluciano -->
 
 <sect1 xml:id="migration70.deprecated">
- <title>Recursos depreciados no PHP 7.0.x</title>
+ <title>Recursos descontinuados no PHP 7.0.x</title>
 
 <!-- password_hash() salt option, PHP4-style constructors etc -->
 
@@ -19,8 +19,8 @@
   <title>Construtores ao estilo PHP 4</title>
 
   <para>
-   Construtores ao estilo PHP 4 (métodos que têm o mesmo nome que a classe onde
-   estão definidos) estão depreciados, e será removido no futuro. O PHP 7
+   Construtores ao estilo PHP 4 (métodos com o mesmo nome que a classe onde
+   estão definidos) estão descontinuados, e serão removidos no futuro. O PHP 7
    emitirá <constant>E_DEPRECATED</constant> se um construtor do PHP 4 for o
    único construtor definido na classe. Classes que implementam o
    método <function>__construct</function> não são afetadas.
@@ -52,7 +52,7 @@ Deprecated: Methods with the same name as their class will not be constructors i
 
   <para>
    Chamadas <link linkend="language.oop5.static">estáticas</link> a métodos que
-   não foram declarados como <command>static</command> estão depreciados, e podem
+   não foram declarados como <command>static</command> estão descontinuadas, e podem
    ser removidos no futuro.
   </para>
 
@@ -84,9 +84,9 @@ I am not static!
   <title>Opção salt da função <function>password_hash</function></title>
 
   <para>
-   A opção salt da função <function>password_hash</function> foi depreciada
-   para evitar que desenvolvedores gerem seus próprios salts(geralmente
-   inseguro). A função gerará um salt criptográfico seguro quando um salt não
+   A opção salt da função <function>password_hash</function> foi descontinuada
+   para evitar que desenvolvedores gerem seus próprios salts (geralmente
+   inseguros). A função gerará um salt criptográfico seguro quando um salt não
    for fornecido pelo desenvolvedor - portanto a geração customizada de salts não
    é necessária.
   </para>
@@ -97,15 +97,15 @@ I am not static!
 
   <para>
    A opção de contexto SSL <literal>capture_session_meta</literal> foi
-   depreciada. Metadados SSL agora estão disponíveis através da
+   descontinuada. Metadados SSL agora estão disponíveis através da
    função <function>stream_get_meta_data</function>.
   </para>
  </sect2>
 
  <sect2 xml:id="migration70.deprecated.ldap">
-  <title>Depreciações no <link linkend="book.ldap">LDAP</link></title>
+  <title>Descontinuações no <link linkend="book.ldap">LDAP</link></title>
    <simpara>
-    As funções a seguir foram depreciadas:
+    As funções a seguir foram descontinuadas:
    </simpara>
 
    <itemizedlist>

--- a/appendices/migration70/incompatible/other.xml
+++ b/appendices/migration70/incompatible/other.xml
@@ -70,7 +70,7 @@ Parse error: syntax error, unexpected 'new' (T_NEW) in /tmp/test.php on line 3
   <para>
    Além disso, os seguintes nomes não devem ser usados. Embora eles não geram
    um erro no PHP 7.0, eles são reservados para uso futuro e devem ser
-   considerados depreciados.
+   considerados descontinuados.
   </para>
 
   <itemizedlist>
@@ -128,10 +128,10 @@ Parse error: syntax error, unexpected 'new' (T_NEW) in /tmp/test.php on line 3
   <title>Chamadas de contextos incompatíveis foram removidas</title>
 
   <para>
-   <link linkend="migration56.deprecated.incompatible-context">Anteriormente depreciadas no PHP 5.6</link>,
+   <link linkend="migration56.deprecated.incompatible-context">Anteriormente descontinuadas no PHP 5.6</link>,
    chamadas estáticas feitas a métodos não-estáticos com um contexto incompatível agora
    resultarão no método chamado tendo uma variável
-   <literal>$this</literal> indefinida e um aviso de depreciação será emitido.
+   <literal>$this</literal> indefinida e um aviso de descontinuação será emitido.
   </para>
 
   <informalexample>

--- a/appendices/migration70/incompatible/removed-functions.xml
+++ b/appendices/migration70/incompatible/removed-functions.xml
@@ -11,7 +11,7 @@
   </title>
 
   <para>
-   Estas funções foram depreciadas no PHP 4.1.0 em favor de
+   Estas funções foram descontinuadas no PHP 4.1.0 em favor de
    <function>call_user_func</function> e
    <function>call_user_func_array</function>. Você também pode considerar
    o uso de
@@ -36,12 +36,12 @@
   <title>Sinônimos do <link linkend="book.mcrypt">mcrypt</link></title>
 
   <para>
-   A função depreciada <function>mcrypt_generic_end</function> foi
+   A função descontinuada <function>mcrypt_generic_end</function> foi
    removida em favor de <function>mcrypt_generic_deinit</function>.
   </para>
 
   <para>
-   Além disso, as funções depreciadas <function>mcrypt_ecb</function>,
+   Além disso, as funções descontinuadas <function>mcrypt_ecb</function>,
    <function>mcrypt_cbc</function>, <function>mcrypt_cfb</function> e
    <function>mcrypt_ofb</function> foram removidas em favor do
    uso da função <function>mcrypt_decrypt</function> com a constante
@@ -79,7 +79,7 @@
   <title>Sinônimos de <link linkend="book.intl">intl</link></title>
 
   <para>
-   Os sinônimos depreciados <function>datefmt_set_timezone_id</function> e
+   Os sinônimos descontinuados <function>datefmt_set_timezone_id</function> e
    <methodname>IntlDateFormatter::setTimeZoneID</methodname> foram
    removidos em favor de <function>datefmt_set_timezone</function> e
    <methodname>IntlDateFormatter::setTimeZone</methodname>, respectivamente.
@@ -92,7 +92,7 @@
   <para>
    <function>set_magic_quotes_runtime</function>, juntamente com seu sinônimo
    <function>magic_quotes_runtime</function>, foram removidos. Eles foram
-   depreciados no PHP 5.3.0 e se tornaram efetivamente não funcionais com
+   descontinuados no PHP 5.3.0 e se tornaram efetivamente não funcionais com
    a remoção das magic quotes no PHP 5.4.0.
   </para>
  </sect3>
@@ -101,7 +101,7 @@
   <title><function>set_socket_blocking</function></title>
 
   <para>
-   O sinônimo depreciado <function>set_socket_blocking</function> foi
+   O sinônimo descontinuado <function>set_socket_blocking</function> foi
    removido em favor de <function>stream_set_blocking</function>.
   </para>
  </sect3>

--- a/appendices/migration72/deprecated.xml
+++ b/appendices/migration72/deprecated.xml
@@ -36,7 +36,7 @@ string(11) "NONEXISTENT"
 
   <para>
    As funções <function>png2wbmp</function> e <function>jpeg2wbmp</function>
-   da extensão GD foram depreciadas e serão removidas
+   da extensão GD foram descontinuadas e serão removidas
    na próxima versão maior do PHP.
   </para>
  </sect2>
@@ -45,7 +45,7 @@ string(11) "NONEXISTENT"
   <title><constant>INTL_IDNA_VARIANT_2003</constant> variante</title>
 
   <para>
-   A extensão Intl depreciou a variante
+   A extensão Intl descontinuou a variante
    <constant>INTL_IDNA_VARIANT_2003</constant>, que está sendo usada atualmente
    como padrão para <function>idn_to_ascii</function> e
    <function>idn_to_utf8</function>. PHP 7.4 irá mudar esses padrões para
@@ -58,7 +58,7 @@ string(11) "NONEXISTENT"
   <title><function>__autoload</function> metódo</title>
 
   <para>
-   O método <function>__autoload</function> foi depreciado porque é
+   O método <function>__autoload</function> foi descontinuado porque é
    inferior ao <function>spl_autoload_register</function> (devido a não ser
    permitido encadear autoloaders), e não há interoperabilidade entre os dois
    estilos de autoloading.
@@ -73,7 +73,7 @@ string(11) "NONEXISTENT"
    variável <literal>$php_errormsg</literal> é criada no escopo local quando
    um erro não fatal ocorre. Dado que a maneira preferida de recuperar tais
    informações de erro é usando <function>error_get_last</function>, este
-   recurso foi depreciado.
+   recurso foi descontinuado.
   </para>
  </sect2>
 
@@ -82,7 +82,7 @@ string(11) "NONEXISTENT"
 
   <para>
    Dado os problemas de segurança desta função (sendo um wrapper ao redor de
-   <function>eval</function>), esta função datada foi depreciada.
+   <function>eval</function>), esta função datada foi descontinuada.
    A alternativa preferida é o uso de <link linkend="functions.anonymous">funções anônimas</link>.
   </para>
  </sect2>
@@ -101,7 +101,7 @@ string(11) "NONEXISTENT"
 
   <para>
    Convertendo qualquer expressão para este tipo sempre resultará em &null;, e então
-   esta conversão de tipo supérflua foi depreciada.
+   esta conversão de tipo supérflua foi descontinuada.
   </para>
  </sect2>
 
@@ -113,7 +113,7 @@ string(11) "NONEXISTENT"
    string de consulta preenchiam a tabela de símbolos local.
    Dado as implicações de segurança disto, usar
    <function>parse_str</function> sem um segundo parâmetro foi
-   depreciado. A função deve sempre ser usada com dois argumentos, como o
+   descontinuado. A função deve sempre ser usada com dois argumentos, como o
    segundo argumento faz com que a string de consulta seja analisada em um array.
   </para>
  </sect2>
@@ -122,10 +122,10 @@ string(11) "NONEXISTENT"
   <title>Função <function>gmp_random</function></title>
 
   <para>
-   Esta função gera um numero aleatório baseado em um intervalo que é
+   Esta função gera um número aleatório baseado em um intervalo
    calculado por um tamanho de membro específico da plataforma não exposto. Por isso, esta
-   função foi depreciada. A maneira preferida de gerar um
-   número aleatório usando a extesão GMP é com
+   função foi descontinuada. A maneira preferida de gerar um
+   número aleatório usando a extensão GMP é com
    <function>gmp_random_bits</function> e
    <function>gmp_random_range</function>.
   </para>
@@ -137,7 +137,7 @@ string(11) "NONEXISTENT"
   <para>
    Esta função é muito mais lenta na iteração do que um
    <literal>foreach</literal> normal, e causa problemas de implementações para algumas
-   mudanças da linguagem. Portanto, ela foi depreciada.
+   mudanças da linguagem. Portanto, ela foi descontinuada.
   </para>
  </sect2>
 
@@ -146,9 +146,9 @@ string(11) "NONEXISTENT"
 
   <para>
    Usar <function>assert</function> com um argumento string requer que a string
-   seja <function>eval</function>'iada. Dado o potencial para a execução de
+   seja passada para <function>eval</function>. Dado o potencial para a execução de
    código remoto, usar <function>assert</function> com um argumento string foi
-   depreciada em favor de usar expressão booleanas.
+   descontinuado em favor de usar expressões booleanas.
   </para>
  </sect2>
 
@@ -156,9 +156,9 @@ string(11) "NONEXISTENT"
   <title><literal>$errcontext</literal> argumento para manipuladores de erros</title>
 
   <para>
-   O <literal>$errcontext</literal> argumento contém todas as variáveis locais
+   O argumento <literal>$errcontext</literal> contém todas as variáveis locais
    de erro do site. Dado a raridade do uso, e os problemas causados com as
-   otimizações interncas, ele foi depreciado.
+   otimizações internas, ele foi descontinuado.
    Ao invés disto, um debugger deve ser usado para recuperar
    informações nas variáveis locais de erro do site.
   </para>
@@ -168,7 +168,7 @@ string(11) "NONEXISTENT"
   <title>Função <function>read_exif_data</function></title>
 
   <para>
-   O atalho <function>read_exif_data</function> foi depreciado.
+   O atalho <function>read_exif_data</function> foi descontinuado.
    A função <function>exif_read_data</function> deve ser usada no lugar.
   </para>
  </sect2>

--- a/appendices/migration73/deprecated.xml
+++ b/appendices/migration73/deprecated.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 47d0c1e6dac50e364dedc76a1c7b14f951408142 Maintainer: marcosmarcolin Status: ready --><!-- CREDITS: marcosmarcolin -->
 
 <sect1 xml:id="migration73.deprecated">
- <title>Recursos depreciados</title>
+ <title>Recursos descontinuados</title>
 
  <sect2 xml:id="migration73.deprecated.core">
   <title>PHP Core</title>
@@ -73,7 +73,7 @@
    <para>
     A função <function>fgetss</function> e o filtro de stream <link
     linkend="filters.string">string.strip_tags</link> foram
-    depreciados. Isso também afeta o método
+    descontinuados. Isso também afeta o método
     <methodname>SplFileObject::fgetss</methodname>
     e a função <function>gzgetss</function>.
    </para>
@@ -87,7 +87,7 @@
   <para>
    O uso explícito das constantes
    <constant>FILTER_FLAG_SCHEME_REQUIRED</constant> e
-   <constant>FILTER_FLAG_HOST_REQUIRED</constant> agora está depreciado; ambos estão
+   <constant>FILTER_FLAG_HOST_REQUIRED</constant> agora está descontinuado; ambos estão
    implícitos para <constant>FILTER_VALIDATE_URL</constant> de qualquer maneira.
   </para>
  </sect2>
@@ -96,7 +96,7 @@
   <title>Processamento de Imagem e GD</title>
 
   <para>
-   <function>image2wbmp</function> foi depreciado.
+   <function>image2wbmp</function> foi descontinuada.
   </para>
  </sect2>
 
@@ -114,7 +114,7 @@
 
   <para>
    Os seguintes aliases <literal>mbereg_*()</literal> não documentados
-   foram depreciados. Em vez disso, use as variantes <literal>mb_ereg_*()</literal>
+   foram descontinuados. Em vez disso, use as variantes <literal>mb_ereg_*()</literal>
    correspondentes.
    <itemizedlist>
     <listitem>
@@ -169,7 +169,7 @@
   <para>
    A configuração <link
    linkend="ini.pdo-odbc.db2-instance-name">pdo_odbc.db2_instance_name</link>
-   foi formalmente depreciada. Está obsoleto na documentação a
+   foi formalmente descontinuada. Está descontinuada na documentação a
    partir do PHP 5.1.1.
   </para>
  </sect2>

--- a/appendices/migration73/other-changes.xml
+++ b/appendices/migration73/other-changes.xml
@@ -154,7 +154,7 @@
   <title>Funções de Internacionalização</title>
 
   <para>
-   <constant>Normalizer::NONE</constant> está depreciado, quando o PHP está vinculado com
+   <constant>Normalizer::NONE</constant> está descontinuada, quando o PHP está vinculado com
    ICU ≥ 56.
   </para>
 

--- a/appendices/migration74/deprecated.xml
+++ b/appendices/migration74/deprecated.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 4642b715f374b4220884fa110b6529ac948799b5 Maintainer: ae Status: ready --><!-- CREDITS: geekcom,ae -->
 
 <sect1 xml:id="migration74.deprecated">
- <title>Recursos depreciados</title>
+ <title>Recursos descontinuados</title>
 
  <sect2 xml:id="migration74.deprecated.core">
   <title>PHP Core</title>
@@ -19,7 +19,7 @@
      <programlisting role="php">
 <![CDATA[
 <?php
-1 ? 2 : 3 ? 4 : 5;   // depreciado
+1 ? 2 : 3 ? 4 : 5;   // descontinuado
 (1 ? 2 : 3) ? 4 : 5; // ok
 1 ? 2 : (3 ? 4 : 5); // ok
 ?>
@@ -45,7 +45,7 @@
 
    <para>
     O acesso a valor de string e array usando a sintaxe de chaves está
-    depreciado. Use <literal>$var[$idx]</literal> ao invés de
+    descontinuado. Use <literal>$var[$idx]</literal> ao invés de
     <literal>$var{$idx}</literal>.
    </para>
   </sect3>
@@ -54,11 +54,11 @@
    <title>A conversão (real) e a função <function>is_real</function></title>
 
    <para>
-    A conversão <literal>(real)</literal> está depreciada,
+    A conversão <literal>(real)</literal> está descontinuada,
     use <literal>(float)</literal> em seu lugar.
    </para>
    <para>
-    A função <function>is_real</function> também está depreciada,
+    A função <function>is_real</function> também está descontinuada,
     use <function>is_float</function> em seu lugar.
    </para>
   </sect3>
@@ -68,7 +68,7 @@
 
    <para>
     Desvincular <literal>$this</literal> de uma closure não estática
-    que usa <literal>$this</literal> está depreciado.
+    que usa <literal>$this</literal> está descontinuado.
    </para>
   </sect3>
 
@@ -77,7 +77,7 @@
 
    <para>
     Usar a palavra chave <literal>parent</literal> dentro de uma classe sem parent
-    está depreciado, e lançará um erro em tempo de compilação no futuro.
+    está descontinuado, e lançará um erro em tempo de compilação no futuro.
     Atualmente um erro será gerado apenas se/quando o parent for
     acessado em tempo de execução.
    </para>
@@ -88,8 +88,8 @@
 
    <para>
     A diretiva <link linkend="ini.allow-url-include">allow_url_include</link>
-    está depreciada. Ativá-la gerará
-    um aviso de depreciação na inicialização.
+    está descontinuada. Ativá-la gerará
+    um aviso de descontinuação na inicialização.
    </para>
   </sect3>
 
@@ -99,7 +99,7 @@
    <para>
     Passar caracteres inválidos para as funções: <function>base_convert</function>,
     <function>bindec</function>, <function>octdec</function> and
-    <function>hexdec</function>agora gerará um aviso de depreciação.
+    <function>hexdec</function>agora gerará um aviso de descontinuação.
     O resultado ainda será calculado como se os caracteres inválidos não existissem.
     Os espaços em branco à esquerda e à direita, bem como os prefixos do tipo 0x (dependendo da base)
     continuam sendo permitidos.
@@ -110,7 +110,7 @@
    <title>Usando <function>array_key_exists</function> em objetos</title>
 
    <para>
-    O uso de <function>array_key_exists</function> em objetos está depreciado.
+    O uso de <function>array_key_exists</function> em objetos está descontinuado.
     Em vez disso <function>isset</function> ou <function>property_exists</function>
     deve ser usado.
    </para>
@@ -121,7 +121,7 @@
 
    <para>
     As funções <function>get_magic_quotes_gpc</function> e <function>get_magic_quotes_runtime</function>
-    estão depreciadas. Elas sempre retornam &false;.
+    estão descontinuadas. Elas sempre retornam &false;.
    </para>
   </sect3>
 
@@ -129,7 +129,7 @@
    <title>Função <function>hebrevc</function></title>
 
    <para>
-    A função <function>hebrevc</function> está depreciada.
+    A função <function>hebrevc</function> está descontinuada.
     Ela pode ser substituída por <literal>nl2br(hebrev($str))</literal> ou,
     preferencialmente, pelo uso do suporte Unicode RTL.
    </para>
@@ -139,7 +139,7 @@
    <title>Função <function>convert_cyr_string</function></title>
 
    <para>
-    A função <function>convert_cyr_string</function> está depreciada.
+    A função <function>convert_cyr_string</function> está descontinuada.
     Pode ser substituída por um dos <function>mb_convert_string</function>,
     <function>iconv</function> ou <classname>UConverter</classname>.
    </para>
@@ -149,7 +149,7 @@
    <title>Função <function>money_format</function></title>
 
    <para>
-    A função <function>money_format</function> está depreciada.
+    A função <function>money_format</function> está descontinuada.
     Ela pode ser substituída pela funcionalidade intl <classname>NumberFormatter</classname>.
    </para>
   </sect3>
@@ -158,7 +158,7 @@
    <title>Função <function>ezmlm_hash</function></title>
 
    <para>
-    A função <function>ezmlm_hash</function> está depreciada.
+    A função <function>ezmlm_hash</function> está descontinuada.
    </para>
   </sect3>
 
@@ -166,8 +166,8 @@
    <title>Função <function>restore_include_path</function></title>
 
    <para>
-    A função <function>restore_include_path</function> está depreciada.
-    Pode ser sbstituída por <literal>ini_restore('include_path')</literal>.
+    A função <function>restore_include_path</function> está descontinuada.
+    Pode ser substituída por <literal>ini_restore('include_path')</literal>.
    </para>
   </sect3>
 
@@ -176,7 +176,7 @@
 
    <para>
     A passagem de parâmetros para a função <function>implode</function> na ordem reversa
-    está depreciada, use <literal>implode($glue, $parts)</literal>
+    está descontinuada, use <literal>implode($glue, $parts)</literal>
     em vez de <literal>implode($parts, $glue)</literal>.
    </para>
   </sect3>
@@ -188,7 +188,7 @@
 
   <para>
    A importação de bibliotecas de tipos com registro constante
-   que não diferencia maiúsculas de minúsculas foi depreciado.
+   que não diferencia maiúsculas de minúsculas foi descontinuada.
   </para>
  </sect2>
 
@@ -196,7 +196,7 @@
   <title>Filter</title>
 
   <para>
-   <constant>FILTER_SANITIZE_MAGIC_QUOTES</constant> está depreciado,
+   <constant>FILTER_SANITIZE_MAGIC_QUOTES</constant> está descontinuada,
    use <constant>FILTER_SANITIZE_ADD_SLASHES</constant> em seu lugar.
   </para>
  </sect2>
@@ -206,13 +206,13 @@
 
   <para>
    A passagem de um padrão não-string para a função <function>mb_ereg_replace</function>
-   está depreciado. Atualmente, os padrões não-string são interpretados como
+   está descontinuado. Atualmente, os padrões não-string são interpretados como
    pontos de código ASCII. No PHP 8, o padrão será interpretado como
    uma string.
   </para>
   <para>
    Passar a codificação como terceiro parâmetro para a função <function>mb_strrpos</function>
-   está depreciado. Em vez disso, passe um offset 0 e a codificação como quarto parâmetro.
+   está descontinuado. Em vez disso, passe um offset 0 e a codificação como quarto parâmetro.
   </para>
  </sect2>
 
@@ -221,8 +221,8 @@
 
   <para>
    <function>ldap_control_paged_result_response</function> e
-   <function>ldap_control_paged_result</function> estão depreciados.
-   Os controles de paginação podem ser enviados junto com a função
+   <function>ldap_control_paged_result</function> estão descontinuadas.
+   Os controles de paginação podem ser enviados com a função
    <function>ldap_search</function>.
   </para>
  </sect2>
@@ -232,13 +232,13 @@
 
   <para>
    As chamadas para <methodname>ReflectionType::__toString</methodname> agora geram,
-   um aviso de depreciação. Este método foi depreciado em favor de
+   um aviso de descontinuação. Este método foi descontinuado em favor de
    <methodname>ReflectionNamedType::getName</methodname> na documentação
-   a partir do PHP 7.1, mas não emitiu um aviso de depreciação por motivos técnicos.
+   a partir do PHP 7.1, mas não emitiu um aviso de descontinuação por motivos técnicos.
   </para>
   <para>
    Os métodos <literal>export()</literal> em todas as classes <classname>Reflection</classname>
-   foram depreciados. Construa um objeto <classname>Reflection</classname> e
+   foram descontinuados. Construa um objeto <classname>Reflection</classname> e
    converta-o em string em seu lugar:
    <informalexample>
      <programlisting role="php">
@@ -262,8 +262,8 @@ $str = (string) new ReflectionClass(Foo::class);
   <para>
    <constant>AI_IDN_ALLOW_UNASSIGNED</constant> e
    <constant>AI_IDN_USE_STD3_ASCII_RULES</constant> para
-   <function>socket_addrinfo_lookup</function> foram depreciadas,
-   devido a uma depreciação upstream na glibc.
+   <function>socket_addrinfo_lookup</function> foram descontinuadas,
+   devido a uma descontinuação na própria glibc.
   </para>
  </sect2>
 

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -155,12 +155,12 @@
    gerar uma exceção. Antes, a exceção era lançada apenas na desserialização.
   </para>
   <para>
-   O uso de <constant>CURLPIPE_HTTP1</constant> está depreciado, e não é mais
+   O uso de <constant>CURLPIPE_HTTP1</constant> está descontinuado, e não é mais
    suportado a partir do cURL 7.62.0.
   </para>
   <para>
    O parâmetro <literal>$version</literal> de <function>curl_version</function>
-   está depreciado. Se qualquer valor diferente do padrão <constant>CURLVERSION_NOW</constant>
+   está descontinuado. Se qualquer valor diferente do padrão <constant>CURLVERSION_NOW</constant>
    for passado, um aviso será gerado e o parâmetro será ignorado.
   </para>
  </sect2>
@@ -187,7 +187,7 @@
   <para>
    O valor padrão do parâmetro das funções <function>idn_to_ascii</function> e
    <function>idn_to_utf8</function> agora é <constant>INTL_IDNA_VARIANT_UTS46</constant>
-   em vez de <constant>INTL_IDNA_VARIANT_2003</constant> depreciado.
+   em vez do descontinuado <constant>INTL_IDNA_VARIANT_2003</constant>.
   </para>
  </sect2>
 

--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -396,7 +396,7 @@
    O parâmetro <literal>$mode</literal> padrão de ]
    <function>imagecropauto</function> foi alterado para
    <constant>IMG_CROP_DEFAULT</constant>; passar <literal>-1</literal>
-   agora está depreciado.
+   agora está descontinuado.
   </para>
   <para>
    <function>imagescale</function> agora oferece suporte à proporção preservando
@@ -474,7 +474,7 @@
   <para>
    A instalação do PEAR (incluindo PECL) não é mais habilitada por padrão. Ele
    pode ser ativado explicitamente usando <option role="configure">--with-pear</option>.
-   Esta opção está depreciada e pode ser removida no futuro.
+   Esta opção está descontinuada e pode ser removida no futuro.
   </para>
  </sect2>
 

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: ca9dbbbd2dcac26d56bbbb87539297e4589bd709 Maintainer: ae Status: ready --><!-- CREDITS: geekcom,ae -->
 
 <sect1 xml:id="migration80.deprecated">
- <title>Recursos depreciados</title>
+ <title>Recursos descontinuados</title>
 
  <sect2 xml:id="migration80.deprecated.core">
   <title>PHP Core</title>
@@ -11,7 +11,7 @@
    <listitem>
     <para>
      Se um parâmetro com um valor padrão é seguido por um parâmetro obrigatório, o valor padrão não tem
-     efeito. Essa funcionalidade está depreciada a partir do PHP 8.0.0 e geralmente pode ser resolvido eliminando o
+     efeito. Essa funcionalidade está descontinuada a partir do PHP 8.0.0 e geralmente pode ser resolvido eliminando o
      valor padrão, sem mudança na funcionalidade:
     </para>
     <para>
@@ -43,7 +43,7 @@ function test(?A $a, $b) {}       // Recomendável
    <listitem>
     <para>
      Chamar a função <function>get_defined_functions</function> com o parâmetro <parameter>exclude_disabled</parameter>
-     definido explicitamente como &false; está depreciado e não tem mais efeito.
+     definido explicitamente como &false; está descontinuado e não tem mais efeito.
      A função <function>get_defined_functions</function> nunca incluirá funções desabilitadas.
     </para>
    </listitem>
@@ -58,32 +58,32 @@ function test(?A $a, $b) {}       // Recomendável
     <para>
      <function>enchant_broker_set_dict_path</function> e
      <function>enchant_broker_get_dict_path</function>
-     estão depreciadas, porque essa funcionalidade não está disponível no libenchant &lt; 1.5 nem na
+     estão descontinuadas, porque essa funcionalidade não está disponível no libenchant &lt; 1.5 nem na
      libenchant-2.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_add_to_personal</function> está depreciada; use
+     <function>enchant_dict_add_to_personal</function> está descontinuada; use
      <function>enchant_dict_add</function> em seu lugar.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_is_in_session</function> está depreciada; use
+     <function>enchant_dict_is_in_session</function> está descontinuada; use
      <function>enchant_dict_is_added</function> em seu lugar.
     </para>
    </listitem>
    <listitem>
     <para>
      <function>enchant_broker_free</function> e <function>enchant_broker_free_dict</function> estão
-     depreciadas; em vez disso destrua/unset o objeto.
+     descontinuadas; em vez disso destrua/unset o objeto.
     </para>
    </listitem>
    <listitem>
     <para>
      As constantes <constant>ENCHANT_MYSPELL</constant> e <constant>ENCHANT_ISPELL</constant> estão
-     depreciadas.
+     descontinuadas.
     </para>
    </listitem>
   </itemizedlist>
@@ -93,7 +93,7 @@ function test(?A $a, $b) {}       // Recomendável
   <title>LibXML</title>
 
   <para>
-   A função <function>libxml_disable_entity_loader</function> foi depreciada. Como a libxml 2.9.0 agora é
+   A função <function>libxml_disable_entity_loader</function> foi descontinuada. Como a libxml 2.9.0 agora é
    obrigatória, o carregamento de entidade externa está desabilitado por padrão, e esta função
    não é mais necessária para a proteção contra ataques XXE, a não ser que a (ainda vulnerável).
    <constant>LIBXML_NOENT</constant> for utilizada.
@@ -109,12 +109,12 @@ function test(?A $a, $b) {}       // Recomendável
    <listitem>
     <para>
      A constante <constant>PGSQL_LIBPQ_VERSION_STR</constant> agora tem o mesmo valor que
-     <constant>PGSQL_LIBPQ_VERSION</constant>, portanto, está depreciada.
+     <constant>PGSQL_LIBPQ_VERSION</constant>, portanto, está descontinuada.
     </para>
    </listitem>
    <listitem>
     <para>
-     Os apelidos de função na extensão pgsql foram depreciados.
+     Os apelidos de função na extensão pgsql foram descontinuados.
      Consulte a lista abaixo para saber quais funções devem ser usadas em seu lugar:
     </para>
     <para>
@@ -155,7 +155,7 @@ function test(?A $a, $b) {}       // Recomendável
   <itemizedlist>
    <listitem>
     <para>
-     Funções sort que retornam &true; ou &false; agora lançam um aviso de depreciação, e
+     Funções sort que retornam &true; ou &false; agora lançam um aviso de descontinuação, e
      deve ser substituído por uma implementação que retorna um número inteiro menor, igual ou maior
      que zero.
     </para>
@@ -181,13 +181,13 @@ usort($array, fn($a, $b) => $a <=> $b);
   <itemizedlist>
    <listitem>
     <para>
-     Usar um arquivo vazio como ZipArchive está depreciado. A Libzip 1.6.0 não aceita mais arquivos vazios como
+     Usar um arquivo vazio como ZipArchive está descontinuado. A Libzip 1.6.0 não aceita mais arquivos vazios como
      arquivos zip válidos. A solução alternativa existente será removida na próxima versão.
     </para>
    </listitem>
    <listitem>
     <para>
-     A API procedural do Zip está depreciada. Use <classname>ZipArchive</classname> em seu lugar.
+     A API procedural do Zip está descontinuada. Use <classname>ZipArchive</classname> em seu lugar.
      A iteração em todas as entradas pode ser realizada usando <methodname>ZipArchive::statIndex</methodname>
      e um laço <link linkend="control-structures.for">for</link>:
     </para>
@@ -220,7 +220,7 @@ for ($i = 0; $entry = $zip->statIndex($i); $i++) {
   <itemizedlist>
    <listitem>
     <para>
-     O método <methodname>ReflectionFunction::isDisabled</methodname> está depreciado, pois não é mais
+     O método <methodname>ReflectionFunction::isDisabled</methodname> está descontinuado, pois não é mais
      possível criar uma classe <classname>ReflectionFunction</classname> para uma função desativada. Este
      método agora sempre retorna &false;.
     </para>
@@ -229,7 +229,7 @@ for ($i = 0; $entry = $zip->statIndex($i); $i++) {
     <para>
      <methodname>ReflectionParameter::getClass</methodname>,
      <methodname>ReflectionParameter::isArray</methodname>, e
-     <methodname>ReflectionParameter::isCallable</methodname> estão depreciados.
+     <methodname>ReflectionParameter::isCallable</methodname> estão descontinuados.
      <methodname>ReflectionParameter::getType</methodname> e
      <classname>ReflectionType</classname> devem ser usados em seu lugar.
     </para>

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -673,7 +673,7 @@ $array["key"];
     <para>
      <function>openssl_x509_read</function> e <function>openssl_csr_sign</function> agora retornarão
      um objeto <classname>OpenSSLCertificate</classname> em vez de um &resource;.
-     A função <function>openssl_x509_free</function> está depreciada e não tem mais efeito,
+     A função <function>openssl_x509_free</function> está descontinuada e não tem mais efeito,
      em vez disso a instância <classname>OpenSSLCertificate</classname> é destruída automaticamente se
      não for mais referenciada.
     </para>
@@ -688,7 +688,7 @@ $array["key"];
     <para>
      <function>openssl_pkey_new</function> agora retornará um
      objeto <classname>OpenSSLAsymmetricKey</classname> em vez de um &resource;.
-     A função <function>openssl_pkey_free</function> está depreciada e não tem mais efeito,
+     A função <function>openssl_pkey_free</function> está descontinuada e não tem mais efeito,
      em vez disso a instância <classname>OpenSSLAsymmetricKey</classname> é destruída automaticamente se
      não for mais referenciada.
     </para>

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -100,8 +100,8 @@
     </listitem>
     <listitem>
      <para>
-      A <parameter>version</parameter> depreciada do parâmetro de <function>curl_version</function>
-      foi removida.
+      O parâmetro descontinuado <parameter>version</parameter> de <function>curl_version</function>
+      foi removido.
      </para>
     </listitem>
    </itemizedlist>

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -57,7 +57,7 @@
      <constant>MYSQLI_REFRESH_SLAVE</constant>,
      de acordo com uma mudança vinda do MySQL.
      A constante antiga ainda está disponível por motivos de compatibilidade
-     com versões anteriores, mas pode ser depreciada/removida no futuro.
+     com versões anteriores, mas pode ser descontinuada/removida no futuro.
     </para>
    </listitem>
   </itemizedlist>

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?> <!-- EN-Revision: f164f8c8627d55910084c94e1dcea93b4a57c4a3 Maintainer: ae Status: ready --><!-- CREDITS: lhsazevedo,ae -->
 <sect1 xml:id="migration81.deprecated">
- <title>Funcionalidades depreciadas</title>
+ <title>Funcionalidades descontinuadas</title>
 
  <sect2 xml:id="migration81.deprecated.core">
   <title>PHP Core</title>
@@ -22,7 +22,7 @@
 
    <para>
     Tipos escalares para funções embutidas são anuláveis por padrão.
-    Esse comportamento está depreciado para alinhar com o comportamento de funções definidas
+    Esse comportamento está descontinuado para alinhar com o comportamento de funções definidas
     pelo usuário, onde tipos escalares precisam ser explicitamente marcados como anuláveis.
 
     <informalexample>
@@ -44,7 +44,7 @@ var_dump(str_contains("foobar", null));
 
    <para>
     A conversão implícita de &float; para &integer; que
-    leva a uma perda de precisão agora está depreciada.
+    leva a uma perda de precisão agora está descontinuada.
     Isso afeta chaves de &array;, Declarações do tipo &integer; no modo coercitivo,
     e operadores trabalhando em &integer;s.
 
@@ -53,7 +53,7 @@ var_dump(str_contains("foobar", null));
 <![CDATA[
 <?php
 $a = [];
-$a[15.5]; // depreciado, pois o valor da chave perde o componente de 0.5
+$a[15.5]; // descontinuado, pois o valor da chave perde o componente de 0.5
 $a[15.0]; // ok, pois 15.0 == 15
 ?>
 ]]>
@@ -67,7 +67,7 @@ $a[15.0]; // ok, pois 15.0 == 15
 
    <para>
     Chamar um método <modifier>static</modifier>, ou acessar uma
-    propriedade <modifier>static</modifier> diretamente em um trait está depreciado.
+    propriedade <modifier>static</modifier> diretamente em um trait está descontinuado.
     Métodos e propriedades estáticos devem ser acessados apenas em uma classe usando o trait.
    </para>
   </sect3>
@@ -106,14 +106,14 @@ function &test(): void {}
     Autovivificação é o processo de criar um novo &array; ao
     acrescentar um valor.
     Autovivificação é proibida a partir de valores escalares, &false;, no entanto
-    era uma exceção. Isso está depreciado agora.
+    era uma exceção. Isso está descontinuado agora.
 
     <informalexample>
      <programlisting role="php">
 <![CDATA[
 <?php
 $arr = false;
-$arr[] = 2;   // depreciado
+$arr[] = 2;   // descontinuado
 ?>
 ]]>
      </programlisting>
@@ -149,7 +149,7 @@ $arr[] = 2;
    <title>Verificar argumentos não-string</title>
 
    <para>
-    Passar um argumento não-string está depreciado.
+    Passar um argumento não-string está descontinuado.
     No futuro, o argumento será interpretado como uma string em vez
     de um codepoint ASCII.
     Dependendo do comportamento pretendido, o argumento deve ser
@@ -165,17 +165,17 @@ $arr[] = 2;
 
   <para>
    <function>date_sunrise</function> e <function>date_sunset</function>
-   foram depreciadas em favor de <function>date_sun_info</function>.
+   foram descontinuadas em favor de <function>date_sun_info</function>.
   </para>
 
   <para>
-   <function>strptime</function> foi depreciada.
+   <function>strptime</function> foi descontinuada.
    Use <function>date_parse_from_format</function> em vez dela (para análise independente de localidade),
    ou <methodname>IntlDateFormatter::parse</methodname> (para análise dependente de localidade).
   </para>
 
   <para>
-   <function>strftime</function> e <function>gmstrftime</function> foram depreciadas.
+   <function>strftime</function> e <function>gmstrftime</function> foram descontinuadas.
    Em vez delas, use <function>date</function> (para formatação independente de localidade),
    ou <methodname>IntlDateFormatter::format</methodname> (para formatação dependente de localidade).
   </para>
@@ -186,11 +186,11 @@ $arr[] = 2;
 
   <para>
    Os filtros <constant>FILTER_SANITIZE_STRING</constant> e
-   <constant>FILTER_SANITIZE_STRIPPED</constant> estão depreciados.
+   <constant>FILTER_SANITIZE_STRIPPED</constant> estão descontinuados.
   </para>
   <para>
    A diretiva INI <link linkend="ini.filter.default">filter.default</link>
-   está depreciada.
+   está descontinuada.
    <!-- TODO Check that filter.default_flags -->
   </para>
  </sect2>
@@ -201,7 +201,7 @@ $arr[] = 2;
   <para>
    O <parameter>num_points</parameter> da <function>imagepolygon</function>,
    <function>imageopenpolygon</function> e <function>imagefilledpolygon</function>
-   foi depreciado.
+   foi descontinuado.
   </para>
  </sect2>
 
@@ -213,7 +213,7 @@ $arr[] = 2;
    <function>mhash_keygen_s2k</function>,
    <function>mhash_count</function>,
    <function>mhash_get_block_size</function>,
-   e <function>mhash_get_hash_name</function> foram depreciadas.
+   e <function>mhash_get_hash_name</function> foram descontinuadas.
    Use as funções <literal>hash_*()</literal> em vez delas.
   </para>
  </sect2>
@@ -222,7 +222,7 @@ $arr[] = 2;
   <title>IMAP</title>
 
   <para>
-   A constante <constant>NIL</constant> foi depreciada.
+   A constante <constant>NIL</constant> foi descontinuada.
    Use <literal>0</literal> em vez dela.
   </para>
  </sect2>
@@ -232,7 +232,7 @@ $arr[] = 2;
 
   <para>
    Chamar <methodname>IntlCalendar::roll</methodname> com um
-   argumento &boolean; está depreciado.
+   argumento &boolean; está descontinuado.
    Use <literal>1</literal> e <literal>-1</literal> em vez de
    &true; e &false; respectivamente.
   </para>
@@ -243,7 +243,7 @@ $arr[] = 2;
 
   <para>
    Chamar <function>mb_check_encoding</function> sem argumentos
-   está depreciado.
+   está descontinuado.
   </para>
  </sect2>
 
@@ -252,7 +252,7 @@ $arr[] = 2;
 
   <para>
    A propriedade <property>mysqli_driver::$driver_version</property>
-   foi depreciada.
+   foi descontinuada.
    Ela era sem sentido e desatualizada, use <constant>PHP_VERSION_ID</constant>
    em vez dela.
   </para>
@@ -260,13 +260,13 @@ $arr[] = 2;
   <para>
    Chamar <methodname>mysqli::get_client_info</methodname> ou
    <function>mysqli_get_client_info</function> com o
-   argumento <parameter>mysqli</parameter> foi depreciado.
+   argumento <parameter>mysqli</parameter> foi descontinuado.
    Chame <function>mysqli_get_client_info</function> sem argumentos
    para obter a informação de versão da biblioteca cliente.
   </para>
 
   <para>
-   O método <methodname>mysqli::init</methodname> foi depreciado.
+   O método <methodname>mysqli::init</methodname> foi descontinuado.
    Substitua chamadas para <methodname>parent::init</methodname> por
    <methodname>parent::__construct</methodname>.
   </para>
@@ -277,7 +277,7 @@ $arr[] = 2;
 
   <para>
    A diretiva INI <link linkend="ini.oci8.old-oci-close-semantics">oci8.old_oci_close_semantics</link>
-   está depreciada.
+   está descontinuada.
   </para>
  </sect2>
 
@@ -285,7 +285,7 @@ $arr[] = 2;
   <title>ODBC</title>
 
   <para>
-   <function>odbc_result_all</function> foi depreciada.
+   <function>odbc_result_all</function> foi descontinuada.
   </para>
  </sect2>
 
@@ -293,7 +293,7 @@ $arr[] = 2;
   <title>PDO</title>
 
   <para>
-   O modo de busca <constant>PDO::FETCH_SERIALIZE</constant> foi depreciado.
+   O modo de busca <constant>PDO::FETCH_SERIALIZE</constant> foi descontinuado.
   </para>
  </sect2>
 
@@ -302,7 +302,7 @@ $arr[] = 2;
 
   <para>
    Não passar o argumento de conexão para todas as funções <literal>pgsql_*()</literal>
-   foi depreciado.
+   foi descontinuado.
   </para>
  </sect2>
 
@@ -311,7 +311,7 @@ $arr[] = 2;
 
   <para>
    A opção <literal>ssl_method</literal> do
-   <methodname>SoapClient::__construct</methodname> foi depreciada
+   <methodname>SoapClient::__construct</methodname> foi descontinuada
    em favor das opções de contexto de stream SSL.
    <!-- The direct equivalent would be
     crypto_method, but min_proto_version/max_proto_version are recommended
@@ -326,7 +326,7 @@ $arr[] = 2;
    Chamar <function>key</function>, <function>current</function>,
    <function>next</function>, <function>prev</function>,
    <function>reset</function>, ou <function>end</function>
-   em &object;s está depreciado.
+   em &object;s está descontinuado.
    Primeiro converta o &object; para um &array; utilizando <function>get_mangled_object_vars</function>,
    ou utilize os métodos fornecidos por uma classe que implemente
    <interfacename>Iterator</interfacename>, como por exemplo <classname>ArrayIterator</classname>.
@@ -334,13 +334,13 @@ $arr[] = 2;
 
   <para>
    A diretiva INI <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
-   está depreciada.
+   está descontinuada.
    Se necessário, em vez dela, lide com quebras de linha <literal>"\r"</literal> manualmente.
   </para>
 
   <para>
    As constantes <constant>FILE_BINARY</constant> e
-   <constant>FILE_TEXT</constant> foram depreciadas.
+   <constant>FILE_TEXT</constant> foram descontinuadas.
    Elas nunca tiveram nenhum efeito.
   </para>
  </sect2>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -63,7 +63,7 @@ var_dump(B::counter()); // int(4), anteriormente int(2)
     especificado antes de parâmetros obrigatórios agora é sempre tratado como obrigatório,
     mesmo ao chamar usando
     <link linkend="functions.named-arguments">argumentos nomeados</link>.
-    A partir do PHP 8.0.0, mas antes do PHP 8.1.0, a função abaixo emite uma notícia de depreciação
+    A partir do PHP 8.0.0, mas antes do PHP 8.1.0, a função abaixo emite um aviso de descontinuação
     na definição, mas executa com sucesso quando chamada. A partir do PHP 8.1.0, um erro
     da classe <classname>ArgumentCountError</classname> é lançado, assim como seria lançado ao
     chamar argumentos posicionais.
@@ -117,12 +117,12 @@ ArgumentCountError - fazeriogurte(): Argument #1 ($recepiente) not passed
 
    <para>
     A maioria dos métodos internos não-finais agora obrigam métodos que fazem sobrescrita a declarar
-    um tipo de retorno compatível, do contrário um aviso de depreciação é emitido durante
+    um tipo de retorno compatível, do contrário um aviso de descontinuação é emitido durante
     a validação de herança.
     Caso o tipo de retorno não possa ser declarado para um método que faz sobrescrita devido a
     questões de compatilidade entre versões PHP,
     um atributo <classname>ReturnTypeWillChange</classname> pode ser adicionado para silenciar
-    o aviso de depreciação.
+    o aviso de descontinuação.
    </para>
   </sect3>
 

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -160,7 +160,7 @@
      <member>
       A diretiva INI <link linkend="ini.mysqli.reconnect">mysqli.reconnect</link>
      </member>
-     <member>A constante <constant>MYSQLI_IS_MARIADB</constant> foi depreciada</member>
+     <member>A constante <constant>MYSQLI_IS_MARIADB</constant> foi descontinuada</member>
     </simplelist>
    </para>
   </sect3>

--- a/install/macos/packages.xml
+++ b/install/macos/packages.xml
@@ -45,7 +45,7 @@
      <simpara>
       Liip:
       <link xlink:href="&url.mac.liip;">&url.mac.liip;</link>
-      (PHP 5.3 - PHP 7.3; depreciado)
+      (PHP 5.3 - PHP 7.3; descontinuado)
      </simpara>
     </listitem>
     <listitem>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -435,7 +435,7 @@ Fazendo um(a) tigela de iogurte natural de framboesa.
     </para>
     <para>
      A partir do PHP 8.0.0, declarar argumentos obrigatórios após argumentos opcionais
-     está <emphasis>depreciado</emphasis>. Isso geralmente pode ser resolvido descartando
+     está <emphasis>descontinuado</emphasis>. Isso geralmente pode ser resolvido descartando
      o valor padrão, pois nunca será usado.
      Uma exceção a essa regra são argumentos no formato
      <code>Type $param = null</code>, onde o padrão &null; torna o tipo implicitamente
@@ -446,8 +446,8 @@ Fazendo um(a) tigela de iogurte natural de framboesa.
       <programlisting role="php">
 <![CDATA[
  <?php
- function foo($a = [], $b) {} // Padrão não utilizado; depreciado a partir do PHP 8.0.0
- function foo($a, $b) {}      // Funcionalmente equivalente, sem notícia de depreciação
+ function foo($a = [], $b) {} // Padrão não utilizado; descontinuado a partir do PHP 8.0.0
+ function foo($a, $b) {}      // Funcionalmente equivalente, sem aviso de descontinuação
 
  function bar(A $a = null, $b) {} // Ainda permitido; $a é obrigatório porém anulável
  function bar(?A $a, $b) {}       // Recomendado
@@ -1017,7 +1017,7 @@ $func(); // prints "bar"
     <para>
      Tipos escalares para funções embutidas são anuláveis por padrão no modo coercivo.
      A partir do PHP 8.1.0, passar &null; para um parâmetro de uma função interna que não é declarado anulável
-     é desencorajado e emite uma notícia de depreciação no modo coercitivo para alinhar com o comportamento de funções definidas pelo usuário,
+     é desencorajado e emite um aviso de descontinuação no modo coercitivo para alinhar com o comportamento de funções definidas pelo usuário,
      onde tipos escalares precisam ser marcados como anuláveis explícitamente.
     </para>
 

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -23,7 +23,7 @@
     Antes do PHP 8.0.0. era possível usar <function>__autoload</function>
     para fazer autoload de classes and interfaces. No entanto, ela é uma alternativa menos
     flexível a <function>spl_autoload_register</function> e
-    <function>__autoload</function> está depreciada a partir do PHP 7.2.0, e removida
+    <function>__autoload</function> está descontinuada a partir do PHP 7.2.0, e removida
     a partir do PHP 8.0.0.
    </para>
   </caution>

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -119,14 +119,14 @@ $bar->printPHP();       // Output: 'PHP is great'
    <para>
     A partir do PHP 8.1.0, a maioria dos métodos internos começaram a declarar seu tipo de retorno de forma "experimental",
     nesse caso o tipo de retorno dos métodos deve ser compatível com o pai sendo estendido,
-    do contrário, uma notícia de depreciação é emitida.
+    do contrário, um aviso de descontinuação é emitido.
     Note que a ausência de uma declaração de retorno explícita também é considerada uma incompatibilidade de assinatura
-    e, portanto, resulta no aviso de depreciação.
+    e, portanto, resulta no aviso de descontinuação.
    </para>
 
    <para>
     Se o tipo de retorno não puder ser declarado para um método que sobrepõe devido à preocupações com compatibilidade entre versões PHP,
-    um atributo <classname>ReturnTypeWillChange</classname> pode ser adicionado para silenciar a notícia de depreciação.
+    um atributo <classname>ReturnTypeWillChange</classname> pode ser adicionado para silenciar o aviso de descontinuação.
    </para>
 
    <example>
@@ -162,7 +162,7 @@ class MeuDateTime extends DateTime
    </example>
 
    <example>
-    <title>O método que sobrepõe declara um tipo de retorno errado sem uma notícia de depreciação</title>
+    <title>O método que sobrepõe declara um tipo de retorno errado sem um aviso de descontinuação</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/predefined/variables/phperrormsg.xml
+++ b/language/predefined/variables/phperrormsg.xml
@@ -58,7 +58,7 @@
        <entry>
         A diretiva <link linkend="ini.track-errors">track_errors</link> que
         criava a variável <varname>$php_errormsg</varname> foi
-        depreciado.
+        descontinuada.
        </entry>
       </row>
      </tbody>

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -105,7 +105,7 @@ array_key_exists('first', $search_array);
      Por motivo de retrocompatibilidade, a função <function>array_key_exists</function>
      também retornará &true; se o parâmetro <parameter>key</parameter> for uma propriedade
      definida em um dado <type>object</type> como parâmetro
-     <parameter>array</parameter>. Esse comportamento está depreciado a partir do PHP 7.4.0,
+     <parameter>array</parameter>. Esse comportamento está descontinuado a partir do PHP 7.4.0,
      e removido a partir do PHP 8.0.0.
     </para>
     <para>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -281,7 +281,7 @@
    <listitem>
     <simpara>
      ID do filtro "string".
-     (<emphasis>Depreciado</emphasis> a partir do PHP 8.1.0,
+     (<emphasis>Descontinuado</emphasis> a partir do PHP 8.1.0,
      ao invés, use <function>htmlspecialchars</function>.)
     </simpara>
    </listitem>
@@ -294,7 +294,7 @@
    <listitem>
     <simpara>
      ID do filtro "stripped".
-     (<emphasis>Depreciado</emphasis> a partir do PHP 8.1.0,
+     (<emphasis>Descontinuado</emphasis> a partir do PHP 8.1.0,
      ao invés, use <function>htmlspecialchars</function>.)
     </simpara>
    </listitem>
@@ -373,7 +373,7 @@
    <listitem>
     <simpara>
      ID do filtro "magic_quotes".
-     (<emphasis>DEPRECIADO</emphasis> a partir do PHP 7.3.0 e
+     (<emphasis>DESCONTINUADO</emphasis> a partir do PHP 7.3.0 e
      <emphasis>REMOVIDO</emphasis> a partir do PHP 8.0.0,
      ao invés, use <constant>FILTER_SANITIZE_ADD_SLASHES</constant>.)
     </simpara>
@@ -588,7 +588,7 @@
    <listitem>
     <simpara>
      Requer host no filtro "validate_url".
-     (Depreciado a partir do PHP 7.3.0 e removido a partir do PHP 8.0.0, já que está implementado no filtro.)
+     (Descontinuado a partir do PHP 7.3.0 e removido a partir do PHP 8.0.0, já que está implementado no filtro.)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -76,7 +76,7 @@
      <listitem>
       <para>A versão do driver MySQLi</para>
       <warning><simpara>Esta propriedade
-      foi <emphasis>depreciada</emphasis> a partir do PHP 8.1.0. Confiar nesta
+      foi <emphasis>descontinuada</emphasis> a partir do PHP 8.1.0. Confiar nesta
       propriedade é altamente desencorajado.</simpara></warning>
      </listitem>
     </varlistentry>
@@ -136,7 +136,7 @@
       <row>
        <entry>8.1.0</entry>
        <entry>
-        <property>mysqli_driver::$driver_version</property> foi depreciado.
+        <property>mysqli_driver::$driver_version</property> foi descontinuada.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
- Relacionado com #313

Esse PR substitui a palavra depreciado por descontinuado. A substituição da palavra obsoleto quando usada como tradução de deprecated será feita em outro PR.