### PR TITLE
Substitui `obsoleto` por `descontinuado` ao traduzir `deprecated`

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -32,7 +32,7 @@
        <entry><link linkend="ini.allow-url-include">allow_url_include</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry>PHP_INI_SYSTEM</entry>
-       <entry>Obsoleto desde o PHP 7.4.0.</entry>
+       <entry>Descontinuado a partir do PHP 7.4.0.</entry>
       </row>
       <row>
        <entry><link linkend="ini.arg-separator.input">arg_separator.input</link></entry>
@@ -649,7 +649,7 @@
        <entry><link linkend="ini.track-errors">track_errors</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry>PHP_INI_ALL</entry>
-       <entry>Obsoleto desde PHP 7.2.0, removido no PHP 8.0.0.</entry>
+       <entry>Descontinuado a partir do PHP 7.2.0, removido no PHP 8.0.0.</entry>
       </row>
       <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
       <row>

--- a/appendices/migration71/deprecated.xml
+++ b/appendices/migration71/deprecated.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 7583c04ddc22338056e87ca972d6b7221af86422 Maintainer: leonardolara Status: ready -->
 
 <sect1 xml:id="migration71.deprecated">
- <title>Funcionalidades obsoletas no PHP 7.1.x</title>
+ <title>Funcionalidades descontinuadas no PHP 7.1.x</title>
 
  <sect2 xml:id="migration71.deprecated.ext-mcrypt">
   <title>ext/mcrypt</title>

--- a/appendices/migration73/deprecated.xml
+++ b/appendices/migration73/deprecated.xml
@@ -14,7 +14,7 @@
     A declaração de constantes que não diferenciam maiúsculas de minúsculas foi descontinuada. Passar
     &true; como o terceiro argumento para <function>define</function> agora gerará um
     aviso de descontinuação. O uso de constantes que não diferenciam maiúsculas de minúsculas com
-    uma maiúscula que difere da declaração também é obsoleto.
+    uma maiúscula que difere da declaração também foi descontinuado.
    </para>
   </sect3>
 
@@ -22,8 +22,8 @@
    <title>assert() com Namespace</title>
 
    <para>
-    A declaração de uma função chamada <literal>assert()</literal> dentro de um namespace
-    está obsoleta. A função <function>assert</function> está sujeita a tratamento especial
+    Declarar uma função chamada <literal>assert()</literal> dentro de um namespace
+    foi descontinuado. A função <function>assert</function> está sujeita a tratamento especial
     pelo mecanismo, o que pode levar a um comportamento inconsistente ao definir
     uma função com namespace com o mesmo nome.
    </para>
@@ -33,7 +33,7 @@
    <title>Pesquisando Strings por Needle não string</title>
 
    <para>
-    Passar um valor não string para funções de pesquisa de string é obsoleto. No futuro,
+    Passar um valor não string para funções de pesquisa de string foi descontinuado. No futuro,
     o valor será interpretado como uma string em vez de um ponto de código
     ASCII. Dependendo do comportamento pretendido, você deve converter explicitamente
     a valor para string ou executar uma chamada explícita para

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -484,7 +484,7 @@ echo $f, "\n";
     </listitem>
     <listitem>
      <para>
-      O suporte para chaves (curly braces) obsoletas para acesso de deslocamento foi removida.
+      O suporte para chaves (curly braces), cujo uso para acesso de deslocamento estava descontinuado, foi removido.
      </para>
      <para>
       <programlisting role="php">
@@ -696,8 +696,8 @@ $array["key"];
    <listitem>
     <para>
      <function>shmop_open</function> irá agora retornar um objeto <classname>Shmop</classname> ao invés de
-     um &resource;. A função <function>shmop_close</function> não tem mais efeitos, e está
-     obsoleta. A instância de <classname>Shmop</classname> será automaticamente destruída quando
+     um &resource;. A função <function>shmop_close</function> não tem mais efeitos, e foi
+     descontinuada. A instância de <classname>Shmop</classname> será automaticamente destruída quando
      não seja mais referenciada.
     </para>
    </listitem>
@@ -882,13 +882,13 @@ $array["key"];
   <itemizedlist>
    <listitem>
     <para>
-     A função obsoleta <function>image2wbmp</function> foi removida.
+     A função descontinuada <function>image2wbmp</function> foi removida.
      <!-- RFC: https://wiki.php.net/rfc/image2wbmp -->
     </para>
    </listitem>
    <listitem>
     <para>
-     As funções obsoletas <function>png2wbmp</function> e <function>jpeg2wbmp</function> foram
+     As funções descontinuadas <function>png2wbmp</function> e <function>jpeg2wbmp</function> foram
      removidas.
      <!-- RFC: https://wiki.php.net/rfc/deprecate-png-jpeg-2wbmp -->
     </para>
@@ -950,13 +950,13 @@ $array["key"];
   <itemizedlist>
    <listitem>
     <para>
-     A constante obsoleta <constant>INTL_IDNA_VARIANT_2003</constant> foi removida.
+     A constante descontinuada <constant>INTL_IDNA_VARIANT_2003</constant> foi removida.
      <!-- RFC: https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003 -->
     </para>
    </listitem>
    <listitem>
     <para>
-     A constante obsoleta <constant>Normalizer::NONE</constant> foi removida.
+     A constante descontinuada <constant>Normalizer::NONE</constant> foi removida.
     </para>
    </listitem>
   </itemizedlist>
@@ -1004,7 +1004,7 @@ $array["key"];
    </listitem>
    <listitem>
     <para>
-     Vários aliases mbregex obsoletos foram removidos. Veja o seguinte
+     Vários aliases mbregex descontinuados foram removidos. Veja a seguinte
      lista para quais funções devem ser usadas:
     </para>
     <para>
@@ -1093,7 +1093,7 @@ $array["key"];
    </listitem>
    <listitem>
     <para>
-     Várias funções de alias foram marcadas como obsoletas.
+     Várias funções de alias foram marcadas como descontinuadas.
     </para>
    </listitem>
    <listitem>
@@ -1198,13 +1198,13 @@ $array["key"];
   <itemizedlist>
    <listitem>
     <para>
-     A sintaxe obsoleta <function>pg_connect</function> usando vários parâmetros em vez de um
-     cadeia de conexão não é mais suportada.
+     A sintaxe descontinuada de <function>pg_connect</function> usando vários parâmetros em vez de uma
+     string de conexão não é mais suportada.
     </para>
    </listitem>
    <listitem>
     <para>
-     As assinaturas obsoletas <function>pg_lo_import</function> e <function>pg_lo_export</function>
+     As assinaturas descontinuadas de <function>pg_lo_import</function> e <function>pg_lo_export</function>
      que passam a conexão como o último argumento não são mais suportadas. A conexão deve ser
      passada como primeiro argumento.
     </para>
@@ -1268,7 +1268,7 @@ $array["key"];
    <listitem>
     <para>
      O método <methodname>ReflectionType::__toString</methodname> agora retornará uma completa representação
-     de depuração do tipo, e não está mais obsoleta. Em particular, o resultado incluirá um
+     de depuração do tipo, e não está mais descontinuada. Em particular, o resultado incluirá um
      indicador de nulidade para tipos anuláveis. O formato do valor de retorno não é estável e pode
      mudar entre as versões do PHP.
     </para>
@@ -1304,7 +1304,7 @@ $array["key"];
   <itemizedlist>
    <listitem>
     <para>
-     As constantes obsoletas <constant>AI_IDN_ALLOW_UNASSIGNED</constant> e
+     As constantes descontinuadas <constant>AI_IDN_ALLOW_UNASSIGNED</constant> e
      <constant>AI_IDN_USE_STD3_ASCII_RULES</constant> <parameter>flags</parameter> para
      <function>socket_addrinfo_lookup</function> foram removidas.
     </para>
@@ -1512,7 +1512,7 @@ $array["key"];
    </listitem>
    <listitem>
     <para>
-     O fallback DES obsoleto em <function>crypt</function> foi removido. Se um desconhecido formato salt
+     O fallback DES descontinuado em <function>crypt</function> foi removido. Se um desconhecido formato salt
      for passado para <function>crypt</function>, a função falhará com <literal>*0</literal>
      em vez de voltar para um hash DES fraco agora.
     </para>

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -140,7 +140,7 @@
 
    <para>
     A extensão enchant agora usa libenchant-2 por padrão quando disponível. libenchant versão 1 ainda é
-    suportada, mas está obsoleta e pode ser removida no futuro.
+    suportada, mas foi descontinuada e pode ser removida no futuro.
    </para>
   </sect3>
 

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: marcosmarcolin Status: ready -->
 <sect1 xml:id="migration83.deprecated">
- <title>Recursos Obsoletos</title>
+ <title>Recursos Descontinuados</title>
 
  <sect2 xml:id="migration83.deprecated.core">
-  <title>PHP Core</title>
+  <title>Núcleo do PHP</title>
 
   <sect3 xml:id="migration83.deprecated.core.saner-inc-dec-operators">
    <title>Operadores de incremento/decremento mais seguros</title>
@@ -11,8 +11,8 @@
    <para>
     O uso do operador de <link linkend="language.operators.increment">incremento</link>
     (<literal>++</literal>) em strings vazias, não numéricas
-    ou não alfanuméricas está agora obsoleto.
-    Além disso, o incremento de strings não numéricas é considerado obsoleto suave.
+    ou não alfanuméricas foi agora descontinuado.
+    Além disso, o incremento de strings não numéricas é considerado quase descontinuado.
     Isso significa que nenhum diagnóstico de <constant>E_DEPRECATED</constant> é emitido,
     mas esse recurso não deve ser usado ao criar novo código.
     Em vez disso, deve ser usado a nova função <function>str_increment</function>.
@@ -20,7 +20,7 @@
 
    <para>
     O uso do operador de <link linkend="language.operators.increment">decremento</link>
-    (<literal>--</literal>) em strings vazias ou não numéricas está agora obsoleto.
+    (<literal>--</literal>) em strings vazias ou não numéricas foi agora descontinuado.
    </para>
    <!-- RFC: https://wiki.php.net/rfc/saner-inc-dec-operators -->
   </sect3>
@@ -30,7 +30,7 @@
 
    <para>
     Chamar <function>get_class</function> e <function>get_parent_class</function>
-    sem argumentos está agora obsoleto.
+    sem argumentos foi agora descontinuado.
    </para>
   </sect3>
  </sect2>
@@ -40,7 +40,7 @@
 
   <para>
    Chamar <function>dba_fetch</function> com <parameter>$dba</parameter> como o
-   terceiro argumento está agora obsoleto.
+   terceiro argumento foi agora descontinuado.
   </para>
  </sect2>
 
@@ -49,7 +49,7 @@
 
   <para>
    Chamar <methodname>FFI::cast</methodname>, <methodname>FFI::new</methodname> e
-   <methodname>FFI::type</methodname> de forma estática está agora obsoleto.
+   <methodname>FFI::type</methodname> de forma estática foi agora descontinuado.
   </para>
  </sect2>
 
@@ -58,12 +58,12 @@
 
   <para>
    A constante <constant>U_MULTIPLE_DECIMAL_SEP*E*RATORS</constant>
-   foi obsoleta, recomenda-se usar a constante
+   foi descontinuada, recomenda-se usar a constante
    <constant>U_MULTIPLE_DECIMAL_SEP*A*RATORS</constant>
    em seu lugar.
   </para>
   <para>
-   A constante <constant>NumberFormatter::TYPE_CURRENCY</constant>foi obsoleta.
+   A constante <constant>NumberFormatter::TYPE_CURRENCY</constant> foi descontinuada.
   </para>
  </sect2>
 
@@ -72,8 +72,8 @@
 
   <para>
    Chamar <function>ldap_connect</function> com <parameter>$hostname</parameter> e
-   <parameter>$port</parameter> separados está
-   obsoleto.
+   <parameter>$port</parameter> separados foi
+   descontinuado.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
   </para>
  </sect2>
@@ -83,7 +83,7 @@
 
   <para>
    Passar um valor negativo para <parameter>$width</parameter> em
-   <function>mb_strimwidth</function> agora está obsoleto.
+   <function>mb_strimwidth</function> agora foi descontinuado.
   </para>
  </sect2>
 
@@ -93,7 +93,7 @@
   <para>
    Chamar <methodname>Phar::setStub</methodname> com um
    <type>resource</type> e um <parameter>$length</parameter>
-   está obsoleto. Tais chamadas devem ser substituídas por:
+   foi descontinuado. Tais chamadas devem ser substituídas por:
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>
  </sect2>
@@ -102,7 +102,7 @@
   <title>Random</title>
 
   <para>
-   A variante <constant>MT_RAND_PHP</constant> Mt19937 está obsoleta.
+   A variante <constant>MT_RAND_PHP</constant> Mt19937 foi descontinuada.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#mt_rand_php -->
   </para>
  </sect2>
@@ -112,7 +112,7 @@
 
   <para>
    Chamar <methodname>ReflectionProperty::setValue</methodname> com apenas um
-   parâmetro está obsoleto.
+   parâmetro foi descontinuado.
    Para definir propriedades estáticas, passe &null; como o primeiro parâmetro.
   </para>
  </sect2>
@@ -121,16 +121,16 @@
   <title>Standard</title>
 
   <para>
-   A função <function>assert_options</function> está agora obsoleta.
+   A função <function>assert_options</function> foi agora descontinuada.
   </para>
   <para>
    As constantes <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>,
    <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>,
-   e <constant>ASSERT_WARNING</constant> estão obsoletas.
+   e <constant>ASSERT_WARNING</constant> foram descontinuadas.
   </para>
 
   <para>
-   As configurações <literal>assert.*</literal> no INI estão obsoletas.
+   As configurações <literal>assert.*</literal> no INI foram descontinuadas.
    Consulte a página
    <link linkend="migration83.other-changes.ini">Alterações no Tratamento de Arquivos INI</link>
    para obter mais detalhes.
@@ -144,7 +144,7 @@
   <para>
    O uso de exceções agora é preferido, e os avisos serão removidos no futuro.
    Chamar <code>SQLite3::enableExceptions(false)</code> desencadeará um
-   aviso de obsolescência nesta versão.
+   aviso de descontinuação nesta versão.
   </para>
  </sect2>
 
@@ -152,7 +152,7 @@
   <title>Zip</title>
 
   <para>
-   A constante <constant>ZipArchive::FL_RECOMPRESS</constant> está obsoleta
+   A constante <constant>ZipArchive::FL_RECOMPRESS</constant> foi descontinuada
    e será removida em uma versão futura do libzip.
   </para>
  </sect2>

--- a/extensions.ent
+++ b/extensions.ent
@@ -83,11 +83,11 @@ elas não estão documentadas no manual do PHP.</para>'>
 <!-- ======================================================================= -->
 
 <!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Estado</title><para xmlns="http://docbook.org/ns/docbook">Essa parte lista as extensões
-não destinadas para uso de produção - elas são ou muito velhas (obsoletas) ou
+não destinadas para uso de produção - elas são ou muito velhas (descontinuadas) ou
 muito novas (experimentais).</para>'>
 
-<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensões Obsoletas</title><para xmlns="http://docbook.org/ns/docbook">Essas
-extensões tornaram-se normalmente obsoletas em favor de outras extensões.</para>'>
+<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensões Descontinuadas</title><para xmlns="http://docbook.org/ns/docbook">Essas
+extensões tornaram-se descontinuadas normalmente em favor de outras extensões.</para>'>
 
 <!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensões Experimentais</title><para xmlns="http://docbook.org/ns/docbook">O
 comportamento dessas extensões - incluindo os nomes das suas funções e qualquer

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -121,7 +121,7 @@ define("__FOO__", "alguma coisa");
     Se uma constante indefinida for usada, um erro <classname>Error</classname> será lançado.
     Antes do PHP 8.0.0, constantes indefinidas eram interpretadas como uma simples
     <type>string</type>, ou seja, CONSTANTE vs. "CONSTANTE".
-    Esse mecanismo alternativo tornou-se obsoleto a partir do PHP 7.2.0 e um alerta de nível
+    Esse mecanismo alternativo foi descontinuado a partir do PHP 7.2.0 e um alerta de nível
     <constant>E_WARNING</constant> será lançado quando isso acontecer.
     Antes do PHP 7.2.0, um erro de nível
     <link linkend="ref.errorfunc">E_NOTICE</link> era lançado.

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -53,7 +53,7 @@ class SimpleClass
     <para>
      Chamar um método não estático de maneira estática lança um
      <classname>Error</classname>.
-     Anteriormente ao PHP 8.0.0, isto iria gerar um aviso de chamada obsoleta,
+     Anteriormente ao PHP 8.0.0, isto iria gerar um aviso de descontinuação,
      e <varname>$this</varname> estaria indefinido.
     </para>
     <example xml:id="language.oop5.basic.class.this">

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -76,7 +76,7 @@
      <row>
       <entry>7.2.0</entry>
       <entry>
-       Defasado: a função <function>__autoload</function> tornou-se obsoleta em
+       Descontinuado: a função <function>__autoload</function> foi descontinuada em
        favor da função <function>spl_autoload_register</function>.
       </entry>
      </row>

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -102,10 +102,10 @@ $p3 = new Point(y: 5, x: 4);
     pode ser omitido.
    </para>
    <sect3>
-    <title>Construtores obsoletos</title>
+    <title>Construtores em estilo antigo</title>
     <para>
      Anteriormente ao PHP 8.0.0 as classes no namespace global interpretam um método com o mesmo nome
-     da classe como sendo um construtor válido. Essa sintaxe é obsoleta,
+     da classe como sendo um construtor válido. Essa sintaxe foi descontinuada,
      e gerará um erro <constant>E_DEPRECATED</constant> embora ainda continue funcionando como um construtor.
      Se ambos o <link linkend="object.construct">__construct()</link> e um método homônimo da classe
      estiverem definidos, <link linkend="object.construct">__construct()</link> que será chamado.

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -337,7 +337,7 @@ $test->obj = new stdClass;
 
    <warning>
     <simpara>
-     Propriedades dinâmicas estão obsoletas a partir do PHP 8.2.0.
+     Propriedades dinâmicas foram descontinuadas a partir do PHP 8.2.0.
      É recomendado declarar todas as propriedades previamente.
      Para suportar nomes de propriedades arbitrárias, a classe deve implementar os métodos
      mágicos <link linkend="object.get">__get()</link> e

--- a/language/oop5/static.xml
+++ b/language/oop5/static.xml
@@ -37,7 +37,7 @@
      Chamar métodos não estáticos, estaticamente, lança um <classname>Error</classname>.
     </para>
     <para>
-     Anteriormente ao PHP 8.0.0, chamar um método não estático estaticamente estava obsoleto, e
+     Anteriormente ao PHP 8.0.0, chamar um método não estático estaticamente estava descontinuado, e
      gerava um aviso <constant>E_DEPRECATED</constant>.
     </para>
    </warning>

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -370,8 +370,8 @@ class MyHelloWorld {
    </para>
    <note>
     <para>
-     A partir do PHP 8.1.0, chamar um métod estático, ou acessar uma propriedade estática diretamente em uma Trait tornou-se obsoleto.
-     Métods estáticos e propriedades somente devem ser acessados em uma classe utilizando a Trait.
+     A partir do PHP 8.1.0, chamar um método estático, ou acessar uma propriedade estática diretamente em uma Trait foi descontinuado.
+     Métodos estáticos e propriedades somente devem ser acessados em uma classe utilizando a Trait.
     </para>
    </note>
    <example xml:id="language.oop5.traits.static.ex1">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -404,8 +404,8 @@ if (empty($_POST['action'])) {
     expressão é menos óbvia, comparada a outras linguagesn.
     Antes do PHP 8.0.0, os operadores ternários eram avaliados com associatividade à esquerda,
     em vez de associatividade à direta, como na maioria de outras linguagens.
-    Depender da associatividade à esquerda está obsoleta desde o PHP 7.4.0.
-    Desde o PHP 8.0.0, o operador ternário é não associativo.
+    Depender da associatividade à esquerda foi descontinuado a partir do PHP 7.4.0.
+    A partir do PHP 8.0.0, o operador ternário é não associativo.
     <example>
      <title>Comportamento não óbvio do ternário</title>
      <programlisting role="php">

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -393,14 +393,14 @@ x menos um é igual a 3, ou assim eu espero
        Depender da precedência da concatenação de strings (<literal>.</literal>) em relação
        à adição/subtração (<literal>+</literal> ou <literal>-</literal>) ou
        shift de bits a esquerda/direta (<literal>&lt;&lt;</literal> ou <literal>&gt;&gt;</literal>),
-       ou seja, os usar numa mesma expressão, está obsoleto.
+       ou seja, os usar numa mesma expressão, foi descontinuado.
       </entry>
      </row>
      <row>
       <entry>7.4.0</entry>
       <entry>
        Depender da associatividade à esquerda do operador ternário (<literal>? :</literal>),
-       ou seja, o utilizar em várias expressões sem parênteses, está obsoleto.
+       ou seja, o utilizar em várias expressões sem parênteses, foi descontinuado.
       </entry>
      </row>
     </tbody>

--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -33,9 +33,9 @@
   <section>
    &reftitle.examples;
    <para>
-    As propriedades dinâmicas estão obsoletas a partir do PHP 8.2.0,
+    As propriedades dinâmicas foram descontinuadas a partir do PHP 8.2.0,
     portanto, usá-las sem marcar a classe com este atributo emitirá
-    um aviso de obsolescência.
+    um aviso de descontinuação.
    </para>
    <example>
     <programlisting role="php">

--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -8,13 +8,13 @@
   <section xml:id="returntypewillchange.intro">
    &reftitle.intro;
    <para>
-    A maioria dos métodos internos non-final agora precisam de métodos de overriding para declarar
-    um tipo de retorno compatível, caso contrário, um aviso obsoleto é emitido durante
+    A maioria dos métodos internos não finais agora requerem que os métodos substitutos declarem
+    um tipo de retorno compatível, caso contrário, um aviso de descontinuação é emitido durante
     a validação da herança.
-    Caso o tipo de retorno não possa ser declarado para um método de overriding devido
-    a problemas de compatibilidade entre versões do PHP,
+    Caso o tipo de retorno não possa ser declarado para um método substituto devido
+    a preocupação com compatibilidade entre versões do PHP,
     um atributo <code>#[\ReturnTypeWillChange]</code> pode ser adicionado para silenciar
-    o aviso de obsolescência.
+    o aviso de descontinuação.
    </para>
   </section>
 

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -27,7 +27,7 @@
 
    <warning>
     <para>
-     A partir do PHP 8.1.0, uma classe que implemente <interfacename>Serializable</interfacename> sem implementar <link linkend="object.serialize">__serialize()</link> e <link linkend="object.unserialize">__unserialize()</link> gerará um aviso de obsolescência.
+     A partir do PHP 8.1.0, uma classe que implemente <interfacename>Serializable</interfacename> sem implementar <link linkend="object.serialize">__serialize()</link> e <link linkend="object.unserialize">__unserialize()</link> gerará um aviso de descontinuação.
     </para>
    </warning>
   </section>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -361,7 +361,7 @@ string(3) "foo"
      Anteriormente ao PHP 8.0.0, chaves e colchetes podiam ser utilizados
      para acessar elementos de um array (por exemplo, <literal>$array[42]</literal> e <literal>$array{42}</literal> irão
      fazer a mesma coisa que o exemplo anterior).
-     O acesso por chaves está obsoleto desde o PHP 7.4.0 e não é mais suportado no PHP 8.0.0.
+     O acesso por chaves foi descontinuado a partir do PHP 7.4.0 e não é mais suportado a partir do PHP 8.0.0.
     </para>
    </note>
 
@@ -437,7 +437,7 @@ $arr[] = <replaceable>valor</replaceable>;
    </note>
    <note>
     <simpara>
-     A partir do PHP 8.1.0, criar um novo array a partir de &false; está obsoleto.
+     A partir do PHP 8.1.0, criar um novo array a partir do valor &false; foi descontinuado.
      Crir um array a partir de &null; e valores indefinidos ainda é permitido.
     </simpara>
    </note>
@@ -756,7 +756,7 @@ echo $foo[bar];
     <simpara>
      O fallback que trata uma constante indefinida como uma string lança um erro
      do nível <constant>E_NOTICE</constant>.
-     Isso está obsoleto desde o PHP 7.2.0, e lança um erro
+     Isso foi descontinuado desde o PHP 7.2.0, e lança um erro
      do nível <constant>E_WARNING</constant>.
      A partir do PHP 8.0.0, esse fallback foi removido e agora lança uma
      exceção <classname>Error</classname>.

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -106,7 +106,7 @@ class B extends A {
     }
 }
 
-call_user_func(array('B', 'parent::quem')); // A, obsoleto a partir do PHP 8.2.0
+call_user_func(array('B', 'parent::quem')); // A, descontinuado a partir do PHP 8.2.0
 
 // Type 6: Objetos que implementam __invoke podem ser utilizados como callables
 class C {

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -71,7 +71,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       Retornar por referência de uma função <type>void</type> agora está obsoleto.
+       Retornar por referência de uma função <type>void</type> agora foi descontinuado.
       </entry>
      </row>
      <row>
@@ -181,7 +181,7 @@ Stack trace:
    <title>void</title>
    <note>
     <para>
-     Retornar por referência de uma função <type>void</type> está obsoleto a partir do PHP 8.1.0,
+     Retornar por referência de uma função <type>void</type> foi descontinuado a partir do PHP 8.1.0,
      porque tal função é contraditória.
      Anteriormente, ele já emitia o seguinte
      <constant>E_NOTICE</constant> quando chamado:

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -998,7 +998,7 @@ echo "I'd like an {${beers::$ale}}\n";
     <simpara>
      Anteriormente ao PHP 8.0.0, <type>string</type>s também poderiam ser usados utilizandos chaves, por exemplo
      <varname>$str{42}</varname>.
-     Essa sintaxe por chaves está obsoleta desde o PHP 7.4.0 e não é mais suportadada a partir do PHP 8.0.0.
+     Essa sintaxe por chaves foi descontinuada desde o PHP 7.4.0 e não é mais suportadada a partir do PHP 8.0.0.
     </simpara>
    </note>
 
@@ -1118,7 +1118,7 @@ bool(false)
    <note>
     <para>
      Acessar caracteres em strings utilizando a sintax por
-     <literal>{}</literal> está obsoleta desde o PHP 7.4,
+     <literal>{}</literal> foi descontinuada desde o PHP 7.4,
      e não existe no PHP 8.0.
     </para>
    </note>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -158,7 +158,7 @@
    <simpara>
     <link linkend="functions.internal">Funções internas</link>
     convertem automaticamente &null; para tipos escalares, mas
-    mas esse comportamento é <emphasis>OBSOLETO</emphasis> desde o PHP 8.1.0.
+    mas esse comportamento foi <emphasis>DESCONTINUADO</emphasis> desde o PHP 8.1.0.
    </simpara>
   </warning>
 
@@ -327,13 +327,13 @@ $bar = (bool) $foo;  // $bar é bool
 
   <warning>
    <simpara>
-    O cast <literal>(real)</literal> está obsoleto desde o PHP 8.0.0.
+    O cast <literal>(real)</literal> foi descontinuado desde o PHP 8.0.0.
    </simpara>
   </warning>
 
   <warning>
    <simpara>
-    O cast <literal>(unset)</literal> está obsoleto desde o PHP 7.2.0.
+    O cast <literal>(unset)</literal> foi descontinuado desde o PHP 7.2.0.
     Note que o cast <literal>(unset)</literal> tem o mesmo efeito que
     informar o valor <type>NULL</type> para a variável ou chamada de função.
     O cast <literal>(unset)</literal> foi removido no PHP 8.0.0.

--- a/language/wrappers/compression.xml
+++ b/language/wrappers/compression.xml
@@ -16,7 +16,7 @@
   <simpara>
    <filename>zlib:</filename> funciona como <function>gzopen</function>, exceto que
    o stream pode ser usado com <function>fread</function> e outras
-   funções do sistema de arquivos.  Isso é obsoleto devido
+   funções do sistema de arquivos.  Isso foi descontinuado devido
    a ambiguidades com nomes de arquivos contendo caracteres ':'; use
    <filename>compress.zlib://</filename> em vez disso.
   </simpara>

--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1837,7 +1837,7 @@
    </term>
    <listitem>
     <simpara>
-     A partir de cURL 7.10.8 este é um apelido obsoleto de
+     A partir de cURL 7.10.8 este é um apelido legado de
      <constant>CURLINFO_RESPONSE_CODE</constant>
     </simpara>
    </listitem>
@@ -2757,7 +2757,7 @@
    <listitem>
     <simpara>
      Negociação auth é suportada.
-     Disponível a partir do PHP 7.3.0 e cURL 7.10.6 (obsoleto a partir do cURL 7.38.0)
+     Disponível a partir do PHP 7.3.0 e cURL 7.10.6 (descontinuado a partir do cURL 7.38.0)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -30,7 +30,7 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    Esta variante do construtor está obsoleta, use
+    Esta variante do construtor foi descontinuada, use
     o método <methodname>DatePeriod::createFromISO8601String</methodname>.
    </simpara>
   </warning>

--- a/reference/datetime/datetimezone/listidentifiers.xml
+++ b/reference/datetime/datetimezone/listidentifiers.xml
@@ -55,8 +55,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna o array de identificadores de fuso horário. Apenas itens não obsoletos são
-   retornados. Para obter todos, incluindo identificadores obsoletos, use
+   Retorna o array de identificadores de fuso horário. Apenas itens não desatualizados são
+   retornados. Para obter todos, incluindo identificadores desatualizados, use
    <literal>DateTimeZone::ALL_WITH_BC</literal> no valor de
    <parameter>timezoneGroup</parameter>.
   </para>

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -9,7 +9,7 @@
  <refsynopsisdiv>
   <warning>
    <para>
-    Esta função ficou <emphasis>OBSOLETA</emphasis> desde o PHP 8.1.0.
+    Esta função foi <emphasis>DESCONTINUADA</emphasis> desde o PHP 8.1.0.
     Confiar nesta função é altamente desencorajado. Use
     <function>date_sun_info</function> no lugar.
    </para>
@@ -186,7 +186,7 @@
       <row>
        <entry>8.1.0</entry>
        <entry>
-        Esta função ficou obsoleta em favor de <function>date_sun_info</function>.
+        Esta função foi descontinuada em favor de <function>date_sun_info</function>.
        </entry>
       </row>
       <row>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -11,7 +11,7 @@
  <refsynopsisdiv>
   <warning>
    <para>
-    Esta função está <emphasis>OBSOLETA</emphasis> desde o PHP 8.1.0.
+    Esta função foi <emphasis>DESCONTINUADA</emphasis> desde o PHP 8.1.0.
     Confiar nesta função é altamente desencorajado. Use
     <function>date_sun_info</function> no lugar.
    </para>
@@ -188,7 +188,7 @@
       <row>
        <entry>8.1.0</entry>
        <entry>
-        Esta função ficou obsoleta em favor de <function>date_sun_info</function>.
+        Esta função foi descontinuada em favor de <function>date_sun_info</function>.
        </entry>
       </row>
       <row>

--- a/reference/datetime/functions/strptime.xml
+++ b/reference/datetime/functions/strptime.xml
@@ -138,7 +138,7 @@
       <row>
        <entry>8.1.0</entry>
        <entry>
-        Esta função está obsoleta.
+        Esta função foi descontinuada.
         Use <function>date_parse_from_format</function> no lugar (para análise independente de localidade),
         ou <methodname>IntlDateFormatter::parse</methodname> (para análise dependente de localidade).
        </entry>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -576,7 +576,7 @@
    <listitem>
     <simpara>
      Requer scheme no filtro "validate_url".
-     (Obsoleto a partir do PHP 7.3.0 e removido a partir do PHP 8.0.0, por já estar implícito no filtro em outro filtro)
+     (Descontinuado a partir do PHP 7.3.0 e removido a partir do PHP 8.0.0, por já estar implícito no filtro.)
     </simpara>
    </listitem>
   </varlistentry>
@@ -588,7 +588,7 @@
    <listitem>
     <simpara>
      Requer host no filtro "validate_url".
-     (Descontinuado a partir do PHP 7.3.0 e removido a partir do PHP 8.0.0, já que está implementado no filtro.)
+     (Descontinuado a partir do PHP 7.3.0 e removido a partir do PHP 8.0.0, por já estar implícito no filtro.)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -301,7 +301,7 @@
         <entry></entry>
         <entry>
          Aplica <function>addslashes</function>
-         (<emphasis>OBSOLETO</emphasis> no PHP 7.3.0 e
+         (<emphasis>DESCONTINUADO</emphasis> no PHP 7.3.0 e
          <emphasis>REMOVIDO</emphasis> no PHP 8.0.0,
          utilize <constant>FILTER_SANITIZE_ADD_SLASHES</constant>).
         </entry>
@@ -378,7 +378,7 @@
          Remove tags e codifica aspas duplas e simples no estilo HTML, opcionalmente remove
          ou codifica caracteres HTML especiais. Codificar aspas pode ser
          desligado ao ativar <constant>FILTER_FLAG_NO_ENCODE_QUOTES</constant>
-         (<emphasis>Obsoleto</emphasis> desde o PHP 8.1.0,
+         (<emphasis>Descontinuado</emphasis> desde o PHP 8.1.0,
          utilize <function>htmlspecialchars</function>).
         </entry>
        </row>
@@ -388,7 +388,7 @@
         <entry></entry>
         <entry>
          Alias do filtro "string"
-         (<emphasis>Obsoleto</emphasis> desde o PHP 8.1.0,
+         (<emphasis>Descontinuado</emphasis> desde o PHP 8.1.0,
          utilize <function>htmlspecialchars</function>).
         </entry>
        </row>
@@ -455,7 +455,7 @@ filter.default_flags = 0
         <entry>8.1.0</entry>
         <entry>
          <constant>FILTER_SANITIZE_STRING</constant> e
-         <constant>FILTER_SANITIZE_STRIPPED</constant> estão obsoletos.
+         <constant>FILTER_SANITIZE_STRIPPED</constant> foram descontinuadas.
         </entry>
        </row>
        <row>
@@ -474,7 +474,7 @@ filter.default_flags = 0
        <row>
         <entry>7.3.0</entry>
         <entry>
-         <constant>FILTER_SANITIZE_MAGIC_QUOTES</constant> ficou obsoleto.
+         <constant>FILTER_SANITIZE_MAGIC_QUOTES</constant> foi descontinuado.
         </entry>
        </row>
       </tbody>
@@ -843,7 +843,7 @@ filter.default_flags = 0
         <entry>7.3.0</entry>
         <entry>
          O uso explícito de <constant>FILTER_FLAG_SCHEME_REQUIRED</constant>
-         e <constant>FILTER_FLAG_HOST_REQUIRED</constant> tornou-se obsoleta.
+         e <constant>FILTER_FLAG_HOST_REQUIRED</constant> foi descontinuado.
         </entry>
        </row>
        <row>

--- a/reference/filter/ini.xml
+++ b/reference/filter/ini.xml
@@ -20,7 +20,7 @@
       <entry><link linkend="ini.filter.default">filter.default</link></entry>
       <entry>"unsafe_raw"</entry>
       <entry>PHP_INI_PERDIR</entry>
-      <entry>Obsoleto desde o PHP 8.1.0.</entry>
+      <entry>Descontinuado desde o PHP 8.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.filter.default-flags">filter.default_flags</link></entry>

--- a/reference/iconv/ini.xml
+++ b/reference/iconv/ini.xml
@@ -21,19 +21,19 @@
       <entry><link linkend="ini.iconv.input-encoding">iconv.input_encoding</link></entry>
       <entry>""</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Obsoleto no PHP 5.6.0.</entry>
+      <entry>Descontinuado no PHP 5.6.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.iconv.output-encoding">iconv.output_encoding</link></entry>
       <entry>""</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Obsoleto no PHP 5.6.0.</entry>
+      <entry>Descontinuado no PHP 5.6.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.iconv.internal-encoding">iconv.internal_encoding</link></entry>
       <entry>""</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Obsoleto no PHP 5.6.0.</entry>
+      <entry>Descontinuado no PHP 5.6.0.</entry>
      </row>
    </tbody>
   </tgroup>

--- a/reference/image/functions/imagedashedline.old
+++ b/reference/image/functions/imagedashedline.old
@@ -17,7 +17,7 @@
       <methodparam><type>int</type><parameter>color</parameter></methodparam>
      </methodsynopsis>
     <para>
-     Esta função está obsoleta. Ao invés use uma 
+     Esta função está descontinuada. Ao invés use uma
      combinação de <function>imagesetstyle</function> e <function>imageline</function>.
     </para>
    </refsect1>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -82,7 +82,7 @@
         e retorna &true; imediatamente.
        </entry>
        <entry>
-        Desencorajado desde o PHP 8.3.0.
+        Descontinuado desde o PHP 8.3.0.
        </entry>
       </row>
       <row>
@@ -108,7 +108,7 @@
          <methodparam><type>string</type><parameter>assertion</parameter></methodparam>
          <methodparam choice="opt"><type>string</type><parameter>description</parameter></methodparam>
         </methodsynopsis>
-        Desencorajado desde o PHP 8.3.0.
+        Descontinuado desde o PHP 8.3.0.
        </entry>
       </row>
       <row>
@@ -119,7 +119,7 @@
         da expectativa não ser válida.
        </entry>
        <entry>
-        Desencorajado desde o PHP 8.3.0.
+        Descontinuado desde o PHP 8.3.0.
        </entry>
       </row>
       <row>
@@ -130,7 +130,7 @@
         caso a expectativa não seja válida.
        </entry>
        <entry>
-        Desencorajado desde o PHP 8.3.0.
+        Descontinuado desde o PHP 8.3.0.
        </entry>
       </row>
       <row>
@@ -143,7 +143,7 @@
         esteja ativo.
        </entry>
        <entry>
-        Desencorajado desde o PHP 8.3.0.
+        Descontinuado desde o PHP 8.3.0.
        </entry>
       </row>
      </tbody>
@@ -170,7 +170,7 @@
         <type>string</type> ela era interpretada como código PHP e executada via
         <function>eval</function>.
         A string era passada para o argumento do callback no terceiro argumento.
-        Este comportamento está <emphasis>OBSOLETO</emphasis> desde o PHP 7.2.0,
+        Este comportamento está <emphasis>DESCONTINUADO</emphasis> desde o PHP 7.2.0,
         e foi <emphasis>REMOVIDO</emphasis> no PHP 8.0.0.
        </para>
       </warning>
@@ -295,14 +295,14 @@
        <entry>7.3.0</entry>
        <entry>
         Declarar uma função chamada <literal>assert()</literal> dentro de um namespace
-        se tornou obsoleto. Uma declaração assim emite um <constant>E_DEPRECATED</constant>.
+        foi descontinuado. Uma declaração assim emite um <constant>E_DEPRECATED</constant>.
        </entry>
       </row>
       <row>
        <entry>7.2.0</entry>
        <entry>
         Uso de <type>string</type>s no argumento <parameter>assertion</parameter>
-        se tornou obsoleto. Isto agora emite um aviso <constant>E_DEPRECATED</constant>
+        foi descontinuado. Isto agora emite um aviso <constant>E_DEPRECATED</constant>
         quando ambos <link linkend="ini.assert.active">assert.active</link>
         e <link linkend="ini.zend.assertions">zend.assertions</link> estão configurados
         para <literal>1</literal>.

--- a/reference/info/functions/get-magic-quotes-runtime.xml
+++ b/reference/info/functions/get-magic-quotes-runtime.xml
@@ -48,7 +48,7 @@
       <row>
        <entry>7.4.0</entry>
        <entry>
-        Esta função está obsoleta.
+        Esta função foi descontinuada.
        </entry>
       </row>
      </tbody>

--- a/reference/mbstring/functions/mb-strimwidth.xml
+++ b/reference/mbstring/functions/mb-strimwidth.xml
@@ -55,7 +55,7 @@
        Se uma largura negativa for especificada, conta a partir do final da string.
        <note>
         <para>
-         A passagem de um width negativo está obsoleta a partir do PHP 8.3.0.
+         Passar uma largura negativa foi descontinuado a partir do PHP 8.3.0.
         </para>
        </note>
       </para>
@@ -103,7 +103,7 @@
       <entry>8.3.0</entry>
       <entry>
        Passar uma largura negativa <parameter>width</parameter> para
-       <function>mb_strimwidth</function> agora está obsoleta.
+       <function>mb_strimwidth</function> agora foi descontinuado.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mysql/functions/mysql-create-db.xml
+++ b/reference/mysql/functions/mysql-create-db.xml
@@ -60,7 +60,7 @@
    <example>
     <title>Exemplo alternativo de <function>mysql_create_db</function></title>
     <para>
-     A função <function>mysql_create_db</function> está obsoleta. É
+     A função <function>mysql_create_db</function> foi descontinuada. É
      preferível usar a função <function>mysql_query</function> para executar
      o comando <literal>CREATE DATABASE</literal>.
     </para>

--- a/reference/mysql/functions/mysql-drop-db.xml
+++ b/reference/mysql/functions/mysql-drop-db.xml
@@ -25,7 +25,7 @@
   <para>
    <function>mysql_drop_db</function> tenta executar um drop (remover) todo um
    banco de dados do servidor associado ao identificador de
-   conexão especificado. Esta função está obsoleta, é preferível usar
+   conexão especificado. Esta função foi descontinuada, é preferível usar
    <function>mysql_query</function> para realilar um comando
    <literal>DROP DATABASE</literal>.
   </para>

--- a/reference/mysql/functions/mysql-escape-string.xml
+++ b/reference/mysql/functions/mysql-escape-string.xml
@@ -25,7 +25,7 @@
   <para>
    Esta função escapará a string <parameter>unescaped_string</parameter>,
    de modo que seja seguro usá-la em uma função <function>mysql_query</function>.
-   Esta função está obsoleta.
+   Esta função foi descontinuada.
   </para>
   <para>
    Esta função é idêntica a <function>mysql_real_escape_string</function>

--- a/reference/mysql/functions/mysql-list-fields.xml
+++ b/reference/mysql/functions/mysql-list-fields.xml
@@ -27,7 +27,7 @@
    Obtém informações sobre a tabela informada.
   </para>
   <para>
-   Esta função está obsoleta. É preferrível usar
+   Esta função foi descontinuada. É preferrível usar
    <function>mysql_query</function> para realizar uma consulta SQL <literal>SHOW COLUMNS FROM
    table [LIKE 'name']</literal>.
   </para>
@@ -76,7 +76,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Alternativa para a obsoleta <function>mysql_list_fields</function></title>
+    <title>Alternativa para a função descontinuada <function>mysql_list_fields</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mysql/functions/mysql-list-tables.old
+++ b/reference/mysql/functions/mysql-list-tables.old
@@ -17,8 +17,8 @@
    Obtém uma lista dos nomes das tabelas de um banco de dados MySQL.
   </para>
   <para>
-   Esta função esta obsoleta. É preferrível usar 
-   <function>mysql_query</function> para fazer uma consulta SQL <literal>SHOW TABLES 
+   Esta função foi descontinuada. É preferrível usar
+   <function>mysql_query</function> para fazer uma consulta SQL <literal>SHOW TABLES
    [FROM db_name] [LIKE 'pattern']</literal> ao invés.
   </para>
  </refsect1>

--- a/reference/mysql/functions/mysql-select-db.old
+++ b/reference/mysql/functions/mysql-select-db.old
@@ -58,7 +58,7 @@ if (!$db_selected) {
     </para>
     <para>
      Para compatibilidade com versões anteriores <function>mysql_selectdb</function>
-     também pode ser usada. Esta função esta obsoleta.
+     também pode ser usada. Esta função foi descontinuada.
     </para>
    </refsect1>
   </refentry>

--- a/reference/mysqli/functions/mysqli-execute.xml
+++ b/reference/mysqli/functions/mysqli-execute.xml
@@ -17,7 +17,7 @@
   &reftitle.notes;
   <note>
    <para>
-    <function>mysqli_execute</function> esta obsoleta e será removida.
+    <function>mysqli_execute</function> foi descontinuada e será removida.
    </para>
   </note>
  </refsect1>

--- a/reference/mysqli/reference.xml
+++ b/reference/mysqli/reference.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: felipe Status: ready -->
 
 <reference xml:id="ref.mysqli">
- <title>Apelidos e &Functions; obsoletas da Mysqli</title>
+ <title>Apelidos e &Functions; descontinuadas da Mysqli</title>
 
  &reference.mysqli.entities.functions;
 </reference>

--- a/reference/oci8/constants.xml
+++ b/reference/oci8/constants.xml
@@ -95,7 +95,7 @@
            Modo de execução de instruções para
            <function>oci_execute</function>. A instrução não é efetivada automaticamente
            nesse modo (modo sem commit). Para a legibilidade de
-           em código, utilize esse valor ao invés da constante obsoleta
+           em código, utilize esse valor ao invés da constante antiga equivalente
            <constant>OCI_DEFAULT</constant>.
          </entry>
        </row>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -569,7 +569,7 @@
       já foi armazenado em cache quando <function>file_exists</function>,
       <function>is_file</function> e <function>is_readable</function> são
       chamados. Isso pode aumentar o desempenho em aplicativos que verificam
-      a existência e legibilidade de scripts PHP, mas corre o risco de retornar dados obsoletos
+      a existência e legibilidade de scripts PHP, mas corre o risco de retornar dados desatualizados
       se
       <link linkend="ini.opcache.validate-timestamps">opcache.validate_timestamps</link>
       estiver desabilitado.

--- a/reference/pgsql/functions/pg-connect.old
+++ b/reference/pgsql/functions/pg-connect.old
@@ -49,7 +49,7 @@ $bdcon4 = pg_connect($con_string);
      <parameter>connection_string</parameter> incluem
      <parameter>host</parameter>, <parameter>port</parameter>,
      <parameter>tty</parameter>, <parameter>options</parameter>,
-     <parameter>dbname</parameter>, <parameter>user</parameter> e 
+     <parameter>dbname</parameter>, <parameter>user</parameter> e
      <parameter>password</parameter>.
     </para>
     <para>
@@ -62,7 +62,7 @@ $bdcon4 = pg_connect($con_string);
     <para>
      A sintaxe antiga com parâmetros múltiplos
      <command>$con = pg_connect("host", "port", "options", "tty", "dbname")
-     </command> se tornou obsoleta.
+     </command> foi descontinuada.
     </para>
     <para>
      Veja também <function>pg_pconnect</function>,

--- a/reference/reflection/reflectionfunction.xml
+++ b/reference/reflection/reflectionfunction.xml
@@ -71,7 +71,7 @@
       <term><constant>ReflectionFunction::IS_DEPRECATED</constant></term>
       <listitem>
        <para>
-        Indica funções obsoletas.
+        Indica funções descontinuadas.
        </para>
       </listitem>
      </varlistentry>

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -222,8 +222,8 @@
    <para>
     <function>session_regenerate_id</function> <emphasis>não</emphasis>
     apaga sessão antiga por padrão.
-    Uma sessão antiga e autenticada pode estar disponível para uso.
-    Os desenvolvedores devem impedir que sessões obsoletas sejam utilizadas por qualquer pessoa.
+    Uma sessão obsoleta e autenticada pode estar disponível para uso.
+    Os desenvolvedores devem impedir que sessões desatualizadas sejam utilizadas por qualquer pessoa.
     Eles devem impedir acesso acesso aos dados de sessões obsoletas por conta própria utilizando timestamps.
    </para>
 
@@ -295,7 +295,7 @@
 
    <para>
     Configure e gerencie um timestamp de expiração na $_SESSION.
-    Bloqueie os acessos aos dados de sessões obsoletas.
+    Bloqueie os acessos aos dados de sessões desatualizadas.
     Quando um acesso aos dados de uma sessão obsoleta for detectado,
     é aconselhável remover todos os status de autenticação das sessões dos usuários
     e forçá-los a refazer a autenticação. O acesso aos dados de uma sessão obsoleta pode ser

--- a/reference/soap/soapclient/call.xml
+++ b/reference/soap/soapclient/call.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="soapclient.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__call</refname>
-  <refpurpose>Chama uma função SOAP (obsoleta)</refpurpose>
+  <refpurpose>Chama uma função SOAP (descontinuada)</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>array</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Atualmente, chamar este método diretamente não é de todo recomendável, pois o mesmo se encontra obsoleto. Em vez disso, recomenda-se a utilização das funções SOAP
+   Chamar este método diretamente foi descontinuado. Em vez disso, recomenda-se a utilização das funções SOAP
    como métodos do objeto <classname>SoapClient</classname>. No entanto, em alguns casos pode ser necessário utilizar opções adicionais ou chamar funções
    com nomes dinâmicos, e nesses casos é recomendado utilizar o método <methodname>SoapClient::__soapCall</methodname>.
    Este último permite um controle mais detalhado sobre a chamada da função, incluindo a especificação do nome da função como uma string.

--- a/reference/strings/functions/money-format.xml
+++ b/reference/strings/functions/money-format.xml
@@ -248,7 +248,7 @@
       <row>
        <entry>7.4.0</entry>
        <entry>
-        Esta função está obsoleta. Utilize
+        Esta função foi descontinuada. Utilize
         <methodname>NumberFormatter::formatCurrency</methodname>.
        </entry>
       </row>

--- a/reference/strings/functions/parse-str.xml
+++ b/reference/strings/functions/parse-str.xml
@@ -43,7 +43,7 @@
       <warning>
        <para>
         Utilizar esta função sem o parâmetro <parameter>result</parameter> é altamente
-        <emphasis>DESENCORAJADO</emphasis> E <emphasis>OBSOLETO</emphasis> a partir do PHP 7.2.
+        <emphasis>DESENCORAJADO</emphasis> e foi <emphasis>DESCONTINUADO</emphasis> a partir do PHP 7.2.
         Desde o 8.0.0, o parâmetro <parameter>result</parameter> é <emphasis>obrigatório</emphasis>.
        </para>
       </warning>

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -58,7 +58,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Esta função está obsoleta, em relação a API orientada a objetos,
+        Esta função foi descontinuada em favor da API orientada a objetos,
         veja <methodname>ZipArchive::close</methodname>.
        </entry>
       </row>

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -58,7 +58,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Esta função está obsoleta, em relação a API orientada a objetos.
+        Esta função foi descontinuada em favor da API orientada a objetos.
        </entry>
       </row>
      </tbody>

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -58,7 +58,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Esta função está obsoleta, em relação a API orientada a objetos,
+        Esta função foi descontinuada em favor da API orientada a objetos,
         veja <methodname>ZipArchive::statIndex</methodname>.
        </entry>
       </row>

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -59,7 +59,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Esta função está obsoleta, em relação a API orientada a objetos,
+        Esta função foi descontinuada em favor da API orientada a objetos,
         veja <methodname>ZipArchive::statIndex</methodname>.
        </entry>
       </row>

--- a/reference/zip/reference.xml
+++ b/reference/zip/reference.xml
@@ -6,8 +6,8 @@
  <partintro>
   <warning>
    <simpara>
-    A API plana está obsoleta desde o PHP 8.0.0.
-    <classname>ZipArchive</classname> deve ser utilizado.
+    A API procedural foi descontinuada desde o PHP 8.0.0.
+    A classe <classname>ZipArchive</classname> deve ser usada em seu lugar.
    </simpara>
   </warning>
  </partintro>

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -674,7 +674,7 @@
      <varlistentry xml:id="zmq.constants.mode-noblock">
       <term><constant>ZMQ::MODE_NOBLOCK</constant></term>
       <listitem>
-       <para>Define a operação como não bloqueante. Constante obsoleta, use ZMQ::MODE_DONTWAIT</para>
+       <para>Define a operação como não bloqueante. Constante descontinuada, use ZMQ::MODE_DONTWAIT em seu lugar</para>
       </listitem>
      </varlistentry>
 


### PR DESCRIPTION
Substitui `obsoleto` por `descontinuado` ao traduzir `deprecated`.

Relacionado ao issue #313.

Método de busca:
Todas as palavras `obsole*` no manual `pt_BR` que estavam traduzindo `depreca*` do manual `en`.

Mais alguns ajustes de tradução que encontrei durante a busca.

Favor avaliar e conferir, por gentileza.