### PR TITLE
Convert curl-getinfo() constant list to table

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -28,346 +28,422 @@
      <listitem>
       <para>
        Pode ser uma das seguintes constantes:
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAINFO</constant> - Padrão interno do arquivo de certificado CA
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAPATH</constant> - Padrão interno do diretório de certificados CA
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_EFFECTIVE_URL</constant> - Última URL efetiva
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CODE</constant> - O último código de resposta.
-          A partir do cURL 7.10.8, é um apelido legado de
-          <constant>CURLINFO_RESPONSE_CODE</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME</constant> - Horário remoto do documento obtido, com a constante <constant>CURLOPT_FILETIME</constant> habilitada; se -1 for retornado, o horário do documento é desconhecido
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME</constant> - Tempo total de transação em segundos para a última transferência
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME</constant> - Tempo em segundos até que a resolução de nome foi concluída
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME</constant> - Tempo em segundos para estabelecer a conexão
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME</constant> - Tempo em segundos do início até logo antes de iniciar a transferência de arquivo
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME</constant> - Tempo em segundos até que o primeiro byte está para ser transferido
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_COUNT</constant> - Número de redirecionamentos, com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> habilitada
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME</constant> - Tempo em segundos de todos as etapas de redirecionamento antes do início da transação final, com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> habilitada
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_URL</constant> - Com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> desabilitada: URL de redirecionamento encontrada na última transação, que deverá ser requisitada manualmente na sequência. Com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> desabilitada: isto fica vazio. A URL de redirecionamento neste caso fica disponível em <constant>CURLINFO_EFFECTIVE_URL</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_IP</constant> - Endereço IP da conexão mais recente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_PORT</constant> - Porta de destino da conexão mais recente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_IP</constant> - Endereço IP local (origem) da conexão mais recente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_PORT</constant> - Porta local (origem) da conexão mais recente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD</constant> - Número total de bytes enviados
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD</constant> - Número total de bytes recebidos
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD</constant> - Velocidade média de recepção
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD</constant> - Velocidade média de envio
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_SIZE</constant> - Tamanho total de todos os cabeçalhos recebidos
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_OUT</constant> - A string de requisição enviada. Para que isto
-          funcione, deve-se adicionar a opção <constant>CURLINFO_HEADER_OUT</constant> ao manipulador chamando-se
-          <function>curl_setopt</function>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REFERER</constant> - O cabeçalho do referenciados
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-        <constant>CURLINFO_REQUEST_SIZE</constant> - Tamanho total de requisições emitidas, atualmente apenas para requisições HTTP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RETRY_AFTER</constant> - A informação do cabeçalho <literal>Retry-After:</literal>, ou zero se não houver cabeçalho válido.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_VERIFYRESULT</constant> - Resultado da verificação de certificado SSL requisitada pela habilitação da opção <constant>CURLOPT_SSL_VERIFYPEER</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant> - Tamanho do conteúdo recebido, lido do campo <literal>Content-Length:</literal>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant> - Tamanho especificado do upload
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_TYPE</constant> - <literal>Content-Type:</literal> do documento requisitado. NULL indica que o servidor não enviou o cabeçalho <literal>Content-Type:</literal>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIVATE</constant> - Dados privados associados a este manipulador cURL, previamente configurado com a opção <constant>CURLOPT_PRIVATE</constant> da função <function>curl_setopt</function>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_ERROR</constant> - O código de erro detalhado do proxy (SOCKS) quando a transferência
-          mais recente retorna um erro <constant>CURLE_PROXY</constant>. O valor retornado será exatamente um dos
-          valores <constant>CURLPX_<replaceable>*</replaceable></constant>.
-          O código de erro será <constant>CURLPX_OK</constant> se nenhum
-          código de resposta estiver disponível.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RESPONSE_CODE</constant> - O último código de resposta
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CONNECTCODE</constant> - O código de resposta de CONNECT
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTPAUTH_AVAIL</constant> - Máscara de bits indicando os métodos de autenticação disponíveis de acordo com a resposta anterior
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXYAUTH_AVAIL</constant> - Máscara de bits indicando os métodos de autenticação do proxy disponíveis de acordo com a resposta anterior
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_OS_ERRNO</constant> - Número do erro de uma falha de conexão. O número depende da arquitetura e do sistema operacional.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NUM_CONNECTS</constant> - Número de conexões que curl teve de criar para concluir a transferência anterior
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_ENGINES</constant> - Esquemas de criptografia OpenSSL suportados
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_COOKIELIST</constant> - Todos os cookies conhecidos
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FTP_ENTRY_PATH</constant> - Caminho de entrada no servidor FTP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME</constant> - Tempo em segundos decorrido do início até que a conexão/negociação SSL/SSH ao servidor remoto foi concluída
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CERTINFO</constant> - Cadeia de certificados TLS
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONDITION_UNMET</constant> - Informação sobre condição de tempo não cumprida
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant> - Próximo CSeq do cliente RTSP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CSEQ_RECV</constant> - CSeq recentemente recebido
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SERVER_CSEQ</constant> - Próximo CSeq do servidor RTSP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SESSION_ID</constant> - ID de sessão RTSP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> - O tamanho do conteúdo recebido. Isto é o valor lido do campo <literal>Content-Length:</literal>. -1 se o tamanho for desconhecido
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> - O tamanho especificado do envio. -1 se o tamanho for desconhecido
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_VERSION</constant> - A versão usada na última conexão HTTP. O valor de retorno será uma das constantes <constant>CURL_HTTP_VERSION_*</constant> definidas ou 0 se a versão não puder ser determinada
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROTOCOL</constant> - O protocolo usado na última conexão HTTP. O valor retornado será exatamente uma dos valores <constant>CURLPROTO_*</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant> - O resultado da verificação de certificado que foi requisitada (usando a opção <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Usado apenas para proxy HTTPS
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SCHEME</constant> - O esquema de URL usado para a conexão mais recente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - O número total de bytes recebidos. O número refere-se apenas à última transferência e será redefinido para cada nova transferência
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Número total de bytes enviados
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> - A velocidade média de recebimento em bytes/segundo que curl mediu para todo o recebimento de dados
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - A velocidade média de envio em bytes/segundo que curl mediu para todo o envio de dados
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Tempo em microssegundos decorrido do início até que a conexão/negociação SSL/SSH ao servidor remoto tenha sido concluída
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME_T</constant> - Tempo em microssegundos decorrido do início até que a conexão ao servidor remoto (ou proxy) tenha sido concluída
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME_T</constant> - Horário remoto do documento recebido (em timestamp Unix), como alternativa a <constant>CURLINFO_FILETIME</constant> para permitir que sistemas com variáveis de 32 bit extraiam datas fora da faixa de 32-bits
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> - Tempo em microssegundos do início até que a conclusão da resolução de nome
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME_T</constant> - Tempo decorrido do início até que a transferência de arquivos esteja para iniciar, em microssegundos
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME_T</constant> - Tempo total em microssegundos decorrido para todas as etapas de redirecionamento incluindo pesquisa de nome, conexão, pré-transferência e transferência, antes do início da transação final
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME_T</constant> - Tempo em microssegundos decorrido do início até o recebimento do primeiro byte
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME_T</constant> - Tempo total em microssegundos da transferência anterior, including resolução de nome, conexão TCP etc.
-         </simpara>
-        </listitem>
-       </itemizedlist>
+       <informaltable>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry valign="top">Option</entry>
+           <entry valign="top">&Description;</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry><constant>CURLINFO_CAINFO</constant></entry>
+           <entry>
+            Padrão interno do arquivo de certificado CA
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CAPATH</constant></entry>
+           <entry>
+            Padrão interno do diretório de certificados CA
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_EFFECTIVE_URL</constant></entry>
+           <entry>
+            Última URL efetiva
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CODE</constant></entry>
+           <entry>
+            O último código de resposta.
+            A partir do cURL 7.10.8, é um apelido legado de
+            <constant>CURLINFO_RESPONSE_CODE</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME</constant></entry>
+           <entry>
+            Horário remoto do documento obtido, com a constante <constant>CURLOPT_FILETIME</constant> habilitada; se -1 for retornado, o horário do documento é desconhecido
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME</constant></entry>
+           <entry>
+            Tempo total de transação em segundos para a última transferência
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME</constant></entry>
+           <entry>
+            Tempo em segundos até que a resolução de nome foi concluída
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME</constant></entry>
+           <entry>
+            Tempo em segundos para estabelecer a conexão
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME</constant></entry>
+           <entry>
+            Tempo em segundos do início até logo antes de iniciar a transferência de arquivo
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME</constant></entry>
+           <entry>
+            Tempo em segundos até que o primeiro byte está para ser transferido
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_COUNT</constant></entry>
+           <entry>
+            Número de redirecionamentos, com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> habilitada
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME</constant></entry>
+           <entry>
+            Tempo em segundos de todos as etapas de redirecionamento antes do início da transação final, com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> habilitada
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_URL</constant></entry>
+           <entry>
+            Com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> desabilitada: URL de redirecionamento encontrada na última transação, que deverá ser requisitada manualmente na sequência. Com a opção <constant>CURLOPT_FOLLOWLOCATION</constant> desabilitada: isto fica vazio. A URL de redirecionamento neste caso fica disponível em <constant>CURLINFO_EFFECTIVE_URL</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_IP</constant></entry>
+           <entry>
+            Endereço IP da conexão mais recente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_PORT</constant></entry>
+           <entry>
+            Porta de destino da conexão mais recente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_IP</constant></entry>
+           <entry>
+            Endereço IP local (origem) da conexão mais recente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_PORT</constant></entry>
+           <entry>
+            Porta local (origem) da conexão mais recente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD</constant></entry>
+           <entry>
+            Número total de bytes enviados
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD</constant></entry>
+           <entry>
+            Número total de bytes recebidos
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD</constant></entry>
+           <entry>
+            Velocidade média de recepção
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD</constant></entry>
+           <entry>
+            Velocidade média de envio
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_SIZE</constant></entry>
+           <entry>
+            Tamanho total de todos os cabeçalhos recebidos
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_OUT</constant></entry>
+           <entry>
+            A string de requisição enviada. Para que isto
+            funcione, deve-se adicionar a opção <constant>CURLINFO_HEADER_OUT</constant> ao manipulador chamando-se
+            <function>curl_setopt</function>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REFERER</constant></entry>
+           <entry>
+            O cabeçalho do referenciados
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REQUEST_SIZE</constant></entry>
+           <entry>
+            Tamanho total de requisições emitidas, atualmente apenas para requisições HTTP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RETRY_AFTER</constant></entry>
+           <entry>
+            A informação do cabeçalho <literal>Retry-After:</literal>, ou zero se não houver cabeçalho válido.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            Resultado da verificação de certificado SSL requisitada pela habilitação da opção <constant>CURLOPT_SSL_VERIFYPEER</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant></entry>
+           <entry>
+            Tamanho do conteúdo recebido, lido do campo <literal>Content-Length:</literal>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant></entry>
+           <entry>
+            Tamanho especificado do upload
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_TYPE</constant></entry>
+           <entry>
+            <literal>Content-Type:</literal> do documento requisitado. NULL indica que o servidor não enviou o cabeçalho <literal>Content-Type:</literal>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIVATE</constant></entry>
+           <entry>
+            Dados privados associados a este manipulador cURL, previamente configurado com a opção <constant>CURLOPT_PRIVATE</constant> da função <function>curl_setopt</function>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_ERROR</constant></entry>
+           <entry>
+            O código de erro detalhado do proxy (SOCKS) quando a transferência
+            mais recente retorna um erro <constant>CURLE_PROXY</constant>. O valor retornado será exatamente um dos
+            valores <constant>CURLPX_<replaceable>*</replaceable></constant>.
+            O código de erro será <constant>CURLPX_OK</constant> se nenhum
+            código de resposta estiver disponível.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RESPONSE_CODE</constant></entry>
+           <entry>
+            O último código de resposta
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CONNECTCODE</constant></entry>
+           <entry>
+            O código de resposta de CONNECT
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTPAUTH_AVAIL</constant></entry>
+           <entry>
+            Máscara de bits indicando os métodos de autenticação disponíveis de acordo com a resposta anterior
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXYAUTH_AVAIL</constant></entry>
+           <entry>
+            Máscara de bits indicando os métodos de autenticação do proxy disponíveis de acordo com a resposta anterior
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_OS_ERRNO</constant></entry>
+           <entry>
+            Número do erro de uma falha de conexão. O número depende da arquitetura e do sistema operacional.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NUM_CONNECTS</constant></entry>
+           <entry>
+            Número de conexões que curl teve de criar para concluir a transferência anterior
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_ENGINES</constant></entry>
+           <entry>
+            Esquemas de criptografia OpenSSL suportados
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_COOKIELIST</constant></entry>
+           <entry>
+            Todos os cookies conhecidos
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FTP_ENTRY_PATH</constant></entry>
+           <entry>
+            Caminho de entrada no servidor FTP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME</constant></entry>
+           <entry>
+            Tempo em segundos decorrido do início até que a conexão/negociação SSL/SSH ao servidor remoto foi concluída
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CERTINFO</constant></entry>
+           <entry>
+            Cadeia de certificados TLS
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONDITION_UNMET</constant></entry>
+           <entry>
+            Informação sobre condição de tempo não cumprida
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CLIENT_CSEQ</constant></entry>
+           <entry>
+            Próximo CSeq do cliente RTSP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CSEQ_RECV</constant></entry>
+           <entry>
+            CSeq recentemente recebido
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SERVER_CSEQ</constant></entry>
+           <entry>
+            Próximo CSeq do servidor RTSP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SESSION_ID</constant></entry>
+           <entry>
+            ID de sessão RTSP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant></entry>
+           <entry>
+            O tamanho do conteúdo recebido. Isto é o valor lido do campo <literal>Content-Length:</literal>. -1 se o tamanho for desconhecido
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant></entry>
+           <entry>
+            O tamanho especificado do envio. -1 se o tamanho for desconhecido
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_VERSION</constant></entry>
+           <entry>
+            A versão usada na última conexão HTTP. O valor de retorno será uma das constantes <constant>CURL_HTTP_VERSION_*</constant> definidas ou 0 se a versão não puder ser determinada
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROTOCOL</constant></entry>
+           <entry>
+            O protocolo usado na última conexão HTTP. O valor retornado será exatamente uma dos valores <constant>CURLPROTO_*</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            O resultado da verificação de certificado que foi requisitada (usando a opção <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Usado apenas para proxy HTTPS
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SCHEME</constant></entry>
+           <entry>
+            O esquema de URL usado para a conexão mais recente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD_T</constant></entry>
+           <entry>
+            O número total de bytes recebidos. O número refere-se apenas à última transferência e será redefinido para cada nova transferência
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD_T</constant></entry>
+           <entry>
+            Número total de bytes enviados
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD_T</constant></entry>
+           <entry>
+            A velocidade média de recebimento em bytes/segundo que curl mediu para todo o recebimento de dados
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD_T</constant></entry>
+           <entry>
+            A velocidade média de envio em bytes/segundo que curl mediu para todo o envio de dados
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME_T</constant></entry>
+           <entry>
+            Tempo em microssegundos decorrido do início até que a conexão/negociação SSL/SSH ao servidor remoto tenha sido concluída
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME_T</constant></entry>
+           <entry>
+            Tempo em microssegundos decorrido do início até que a conexão ao servidor remoto (ou proxy) tenha sido concluída
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME_T</constant></entry>
+           <entry>
+            Horário remoto do documento recebido (em timestamp Unix), como alternativa a <constant>CURLINFO_FILETIME</constant> para permitir que sistemas com variáveis de 32 bit extraiam datas fora da faixa de 32-bits
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME_T</constant></entry>
+           <entry>
+            Tempo em microssegundos do início até que a conclusão da resolução de nome
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME_T</constant></entry>
+           <entry>
+            Tempo decorrido do início até que a transferência de arquivos esteja para iniciar, em microssegundos
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME_T</constant></entry>
+           <entry>
+            Tempo total em microssegundos decorrido para todas as etapas de redirecionamento incluindo pesquisa de nome, conexão, pré-transferência e transferência, antes do início da transação final
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME_T</constant></entry>
+           <entry>
+            Tempo em microssegundos decorrido do início até o recebimento do primeiro byte
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME_T</constant></entry>
+           <entry>
+            Tempo total em microssegundos da transferência anterior, including resolução de nome, conexão TCP etc.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </informaltable>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -32,7 +32,7 @@
         <tgroup cols="2">
          <thead>
           <row>
-           <entry valign="top">Option</entry>
+           <entry valign="top">Opção</entry>
            <entry valign="top">&Description;</entry>
           </row>
          </thead>


### PR DESCRIPTION
This PR converts the constant list for the second (`option`) parameter of `curl_getinfo()` to a table (as it was done in `doc-en` [here](https://github.com/php/doc-en/pull/3130)).