### PR TITLE
Update curl-getinfo() EN-Revision commit hash

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- Reviewed: no -->
+<!-- CREDITS: leonardolara -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_getinfo</refname>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: leonardolara Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: leonardolara -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
This PR updates the `EN-Revision` commit hash to the appropriate value. This update should have been part of my previous PR but was left out due to my not knowing of this requirement. Sorry about the noise.