### PR TITLE
Updates to translation.xml

### DIFF
--- a/translation.xml
+++ b/translation.xml
@@ -42,7 +42,7 @@
   <person name="Thiago Henrique Pojda" email="thiago at php.net" nick="thiago" vcs="yes"/>
   <person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/>
 
-  <!-- Histórico de constribuidores:
+  <!-- Histórico de contribuidores:
   <person name="Alessander P. L. Thomaz" email="kappu at php.net" nick="kappu" vcs="yes"/>
   <person name="Amanda Vale" email="amandavale at php.net" nick="amandavale" vcs="yes"/>
   <person name="Anderson Fortaleza" vcs="yes" email="phaser at php.net" nick="phaser" vcs="yes"/>

--- a/translation.xml
+++ b/translation.xml
@@ -43,7 +43,6 @@
   <person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/>
 
   <!-- Histórico -->
-  <!-- person name="Alessander P. L. Thomaz" email="kappu at php.net" nick="kappu" vcs="yes"/ -->
   <!-- person name="Amanda Vale" email="amandavale at php.net" nick="amandavale" vcs="yes"/ -->
   <!-- person name="Anderson Fortaleza" vcs="yes" email="phaser at php.net" nick="phaser" vcs="yes"/ -->
   <!-- person name="Anderson Ravagnani Mamede" email="none" nick="andersonmamede" vcs="no"/ -->
@@ -54,36 +53,23 @@
   <!-- person name="Daniel Satiro" email="none" nick="danielsatiro" vcs="no"/ -->
   <!-- person name="Diego do Nascimento Feitosa" email="dnfeitosa at php.net" nick="dnfeitosa" vcs="yes"/ -->
   <!-- person name="Diego Pires" email="diegopires at php.net" nick="diegopires" vcs="yes"/ -->
-  <!-- person name="Diogo Galvão" email="diogo86 at gmail.com" nick="diogo" vcs="no"/ -->
   <!-- person name="Er Galvão Abbott" email="galvao at php.net" nick="galvao" vcs="yes"/ -->
   <!-- person name="Ernani Joppert Pontes Martins" email="ernani at php.net" nick="ernani" vcs="yes"/ -->
-  <!-- person name="Fábio Luciano Nogueira de Góis" email="fabio dot naoimporta dot com" nick="fabioluciano" vcs="yes"/ -->
-  <!-- person name="Felipe Nascimento Silva Pena" email="felipe at php.net" nick="felipe" vcs="yes"/ -->
-  <!-- person name="Fernando Correa da Conceição" email="fernando_conceicao at yahoo dot com dot br" nick="fernandoc" vcs="yes"/ -->
   <!-- person name="Jean Segat" email="none" nick="jeansegat" vcs="no"/ -->
   <!-- person name="João Lyma" email="lyma at php.net" nick="lyma" vcs="yes"/ -->
   <!-- person name="João Prado Maia" email="jpm at phpbrasil.com" nick="jpm" vcs="yes"/ -->
-  <!-- person name="Klaus Silveira" email="klaussilveira at php.net" nick="klaussilveira" vcs="yes"/ -->
   <!-- person name="Lucas Nascimento Vieira" email="lucas-nek at hotmail dot com" nick="lucasnascimento" vcs="no"/ -->
   <!-- person name="Lucas Rocha" email="lucasr at php.net" nick="lucasr" vcs="yes"/ -->
   <!-- person name="Luís Otávio Cobucci Oblonczyk" email="lcobucci at php.net" nick="lcobucci" vcs="yes"/ -->
   <!-- person name="Marcel dos Santos" email="none" nick="marcelgsantos" vcs="no"/ -->
-  <!-- person name="Marcelo Pereira Fonseca da Silva" email="marcelo at php.net" nick="marcelo" vcs="yes"/ -->
   <!-- person name="Marcilio Costa" email="marcilio_mcn at yahoo.com.br" nick="marcilio" vcs="no"/ -->
-  <!-- person name="Maurício Meneghini Fauth" email="mauricio at php.net" nick="mauricio" vcs="yes"/ -->
   <!-- person name="Níckolas Daniel da Silva" email="nickolas at phpsp dot org dot br" nick="nawarian" vcs="no"/ -->
   <!-- person name="Paulo Filho" email="paulorcf at cenapad dot unicamp dot br" nick="paulofilho" vcs="no"/ -->
   <!-- person name="Rafael Jaques" email="rafaeljaquestudojunto at gmail.com" nick="rafa" vcs="yes"/ -->
   <!-- person name="Ranulfo Netto" email="rcnetto at yahoo.com" nick="netto" vcs="no"/ -->
-  <!-- person name="Raphael Sales" email="raphael_melo19 at yahoo dot com dot br" nick="narigone" vcs="yes"/ -->
-  <!-- person name="Renato Arruda" email="rla9216 at osfmail.rit.edu" nick="rarruda" vcs="yes"/ -->
   <!-- person name="Ricardo Miranda Santos" email="rikardo dot m dot s at pop dot com dot br" nick="ricardo" vcs="no"/ -->
-  <!-- person name="Rodrigo Prado de Jesus" email="royopa at gmail.com" nick="royopa" vcs="yes"/ -->
-  <!-- person name="Rogerio Prado de Jesus" email="rogeriopradoj at php.net" nick="rogeriopradoj" vcs="yes"/ -->
   <!-- person name="Samir Machado de Oliveira Filho" email="samir_filho at hotmail dot com" nick="samirmachado" vcs="no"/ -->
   <!-- person name="Taniel Franklin" email="taniel at eletroj.ufba.br" nick="surfmax" vcs="yes"/ -->
-  <!-- person name="Thiago Henrique Pojda" email="thiago at php.net" nick="thiago" vcs="yes"/ -->
-  <!-- person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/ -->
 
  </translators>
 

--- a/translation.xml
+++ b/translation.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE translation SYSTEM "../doc-base/phpbook/phpbook-xsml/translation.dtd">
 <translation xmlns="http://docbook.org/ns/docbook">
-
  <intro>
   A tradução brasileira da Documentação do PHP é mantida por vários
   colaboradores. Se você procura maiores informações sobre o grupo
@@ -9,11 +8,9 @@
   ou se inscreva e apresente-se na nossa lista de discussão: doc-pt-br-subscribe@lists.php.net (inscrição),
   doc-pt-br@lists.php.net (postagem).
  </intro>
-
  <work-in-progress>
   <!-- <file name="path or file" person="nick" type="update" date="yyyy-mm-dd"/> -->
  </work-in-progress>
-
  <translators>
   <!-- Ativos -->
   <person name="Adiel Cristo" email="adiel at php.net" nick="adiel" vcs="yes"/>
@@ -42,36 +39,48 @@
   <person name="Thiago Henrique Pojda" email="thiago at php.net" nick="thiago" vcs="yes"/>
   <person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/>
 
-  <!-- Histórico de contribuidores:
-  <person name="Alessander P. L. Thomaz" email="kappu at php.net" nick="kappu" vcs="yes"/>
-  <person name="Amanda Vale" email="amandavale at php.net" nick="amandavale" vcs="yes"/>
-  <person name="Anderson Fortaleza" vcs="yes" email="phaser at php.net" nick="phaser" vcs="yes"/>
-  <person name="Anderson Ravagnani Mamede" email="none" nick="andersonmamede" vcs="no"/>
-  <person name="Anísio Neto" email="neto dot df dot pn at gmail dot com" nick="anineto" vcs="no"/>
-  <person name="Arthur Almeida" email="arthur dot almeidapereira at gmail dot com" nick="arthuralmeidap" vcs="no"/>
-  <person name="Cabral" email="cabral at bysoft.com.br" nick="Cabral" vcs="no"/>
-  <person name="Claudio Pereira" email="cpereira at ig.com.br" nick="cpereira" vcs="yes"/>
-  <person name="Daniel Satiro" email="none" nick="danielsatiro" vcs="no"/>
-  <person name="Diego do Nascimento Feitosa" email="dnfeitosa at php.net" nick="dnfeitosa" vcs="yes"/>
-  <person name="Diego Pires" email="diegopires at php.net" nick="diegopires" vcs="yes"/>
-  <person name="Er Galvão Abbott" email="galvao at php.net" nick="galvao" vcs="yes"/>
-  <person name="Ernani Joppert Pontes Martins" email="ernani at php.net" nick="ernani" vcs="yes"/>
-  <person name="Jean Segat" email="none" nick="jeansegat" vcs="no"/>
-  <person name="João Lyma" email="lyma at php.net" nick="lyma" vcs="yes"/>
-  <person name="João Prado Maia" email="jpm at phpbrasil.com" nick="jpm" vcs="yes"/>
-  <person name="Lucas Nascimento Vieira" email="lucas-nek at hotmail dot com" nick="lucasnascimento" vcs="no"/>
-  <person name="Lucas Rocha" email="lucasr at php.net" nick="lucasr" vcs="yes"/>
-  <person name="Luís Otávio Cobucci Oblonczyk" email="lcobucci at php.net" nick="lcobucci" vcs="yes"/>
-  <person name="Marcel dos Santos" email="none" nick="marcelgsantos" vcs="no"/>
-  <person name="Marcilio Costa" email="marcilio_mcn at yahoo.com.br" nick="marcilio" vcs="no"/>
-  <person name="Níckolas Daniel da Silva" email="nickolas at phpsp dot org dot br" nick="nawarian" vcs="no"/>
-  <person name="Paulo Filho" email="paulorcf at cenapad dot unicamp dot br" nick="paulofilho" vcs="no"/>
-  <person name="Rafael Jaques" email="rafaeljaquestudojunto at gmail.com" nick="rafa" vcs="yes"/>
-  <person name="Ranulfo Netto" email="rcnetto at yahoo.com" nick="netto" vcs="no"/>
-  <person name="Ricardo Miranda Santos" email="rikardo dot m dot s at pop dot com dot br" nick="ricardo" vcs="no"/>
-  <person name="Samir Machado de Oliveira Filho" email="samir_filho at hotmail dot com" nick="samirmachado" vcs="no"/>
-  <person name="Taniel Franklin" email="taniel at eletroj.ufba.br" nick="surfmax" vcs="yes"/>
-  -->
+  <!-- Histórico -->
+  <!-- person name="Alessander P. L. Thomaz" email="kappu at php.net" nick="kappu" vcs="yes"/ -->
+  <!-- person name="Amanda Vale" email="amandavale at php.net" nick="amandavale" vcs="yes"/ -->
+  <!-- person name="Anderson Fortaleza" vcs="yes" email="phaser at php.net" nick="phaser" vcs="yes"/ -->
+  <!-- person name="Anderson Ravagnani Mamede" email="none" nick="andersonmamede" vcs="no"/ -->
+  <!-- person name="Anísio Neto" email="neto dot df dot pn at gmail dot com" nick="anineto" vcs="no"/ -->
+  <!-- person name="Arthur Almeida" email="arthur dot almeidapereira at gmail dot com" nick="arthuralmeidap" vcs="no"/ -->
+  <!-- person name="Cabral" email="cabral at bysoft.com.br" nick="Cabral" vcs="no"/ -->
+  <!-- person name="Claudio Pereira" email="cpereira at ig.com.br" nick="cpereira" vcs="yes"/ -->
+  <!-- person name="Daniel Satiro" email="none" nick="danielsatiro" vcs="no"/ -->
+  <!-- person name="Diego do Nascimento Feitosa" email="dnfeitosa at php.net" nick="dnfeitosa" vcs="yes"/ -->
+  <!-- person name="Diego Pires" email="diegopires at php.net" nick="diegopires" vcs="yes"/ -->
+  <!-- person name="Diogo Galvão" email="diogo86 at gmail.com" nick="diogo" vcs="no"/ -->
+  <!-- person name="Er Galvão Abbott" email="galvao at php.net" nick="galvao" vcs="yes"/ -->
+  <!-- person name="Ernani Joppert Pontes Martins" email="ernani at php.net" nick="ernani" vcs="yes"/ -->
+  <!-- person name="Fábio Luciano Nogueira de Góis" email="fabio dot naoimporta dot com" nick="fabioluciano" vcs="yes"/ -->
+  <!-- person name="Felipe Nascimento Silva Pena" email="felipe at php.net" nick="felipe" vcs="yes"/ -->
+  <!-- person name="Fernando Correa da Conceição" email="fernando_conceicao at yahoo dot com dot br" nick="fernandoc" vcs="yes"/ -->
+  <!-- person name="Jean Segat" email="none" nick="jeansegat" vcs="no"/ -->
+  <!-- person name="João Lyma" email="lyma at php.net" nick="lyma" vcs="yes"/ -->
+  <!-- person name="João Prado Maia" email="jpm at phpbrasil.com" nick="jpm" vcs="yes"/ -->
+  <!-- person name="Klaus Silveira" email="klaussilveira at php.net" nick="klaussilveira" vcs="yes"/ -->
+  <!-- person name="Lucas Nascimento Vieira" email="lucas-nek at hotmail dot com" nick="lucasnascimento" vcs="no"/ -->
+  <!-- person name="Lucas Rocha" email="lucasr at php.net" nick="lucasr" vcs="yes"/ -->
+  <!-- person name="Luís Otávio Cobucci Oblonczyk" email="lcobucci at php.net" nick="lcobucci" vcs="yes"/ -->
+  <!-- person name="Marcel dos Santos" email="none" nick="marcelgsantos" vcs="no"/ -->
+  <!-- person name="Marcelo Pereira Fonseca da Silva" email="marcelo at php.net" nick="marcelo" vcs="yes"/ -->
+  <!-- person name="Marcilio Costa" email="marcilio_mcn at yahoo.com.br" nick="marcilio" vcs="no"/ -->
+  <!-- person name="Maurício Meneghini Fauth" email="mauricio at php.net" nick="mauricio" vcs="yes"/ -->
+  <!-- person name="Níckolas Daniel da Silva" email="nickolas at phpsp dot org dot br" nick="nawarian" vcs="no"/ -->
+  <!-- person name="Paulo Filho" email="paulorcf at cenapad dot unicamp dot br" nick="paulofilho" vcs="no"/ -->
+  <!-- person name="Rafael Jaques" email="rafaeljaquestudojunto at gmail.com" nick="rafa" vcs="yes"/ -->
+  <!-- person name="Ranulfo Netto" email="rcnetto at yahoo.com" nick="netto" vcs="no"/ -->
+  <!-- person name="Raphael Sales" email="raphael_melo19 at yahoo dot com dot br" nick="narigone" vcs="yes"/ -->
+  <!-- person name="Renato Arruda" email="rla9216 at osfmail.rit.edu" nick="rarruda" vcs="yes"/ -->
+  <!-- person name="Ricardo Miranda Santos" email="rikardo dot m dot s at pop dot com dot br" nick="ricardo" vcs="no"/ -->
+  <!-- person name="Rodrigo Prado de Jesus" email="royopa at gmail.com" nick="royopa" vcs="yes"/ -->
+  <!-- person name="Rogerio Prado de Jesus" email="rogeriopradoj at php.net" nick="rogeriopradoj" vcs="yes"/ -->
+  <!-- person name="Samir Machado de Oliveira Filho" email="samir_filho at hotmail dot com" nick="samirmachado" vcs="no"/ -->
+  <!-- person name="Taniel Franklin" email="taniel at eletroj.ufba.br" nick="surfmax" vcs="yes"/ -->
+  <!-- person name="Thiago Henrique Pojda" email="thiago at php.net" nick="thiago" vcs="yes"/ -->
+  <!-- person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/ -->
 
  </translators>
 

--- a/translation.xml
+++ b/translation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE translation SYSTEM "../doc-base/phpbook/phpbook-xsml/translation.dtd">
 <translation xmlns="http://docbook.org/ns/docbook">
- 
+
  <intro>
   A tradução brasileira da Documentação do PHP é mantida por vários
   colaboradores. Se você procura maiores informações sobre o grupo
@@ -9,11 +9,11 @@
   ou se inscreva e apresente-se na nossa lista de discussão: doc-pt-br-subscribe@lists.php.net (inscrição),
   doc-pt-br@lists.php.net (postagem).
  </intro>
- 
+
  <work-in-progress>
   <!-- <file name="path or file" person="nick" type="update" date="yyyy-mm-dd"/> -->
  </work-in-progress>
- 
+
  <translators>
   <!-- Ativos -->
   <person name="Adiel Cristo" email="adiel at php.net" nick="adiel" vcs="yes"/>

--- a/translation.xml
+++ b/translation.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE translation SYSTEM "../doc-base/phpbook/phpbook-xsml/translation.dtd">
 <translation xmlns="http://docbook.org/ns/docbook">
+ 
  <intro>
   A tradução brasileira da Documentação do PHP é mantida por vários
   colaboradores. Se você procura maiores informações sobre o grupo
@@ -8,9 +9,11 @@
   ou se inscreva e apresente-se na nossa lista de discussão: doc-pt-br-subscribe@lists.php.net (inscrição),
   doc-pt-br@lists.php.net (postagem).
  </intro>
+ 
  <work-in-progress>
   <!-- <file name="path or file" person="nick" type="update" date="yyyy-mm-dd"/> -->
  </work-in-progress>
+ 
  <translators>
   <!-- Ativos -->
   <person name="Adiel Cristo" email="adiel at php.net" nick="adiel" vcs="yes"/>

--- a/translation.xml
+++ b/translation.xml
@@ -42,6 +42,37 @@
   <person name="Thiago Henrique Pojda" email="thiago at php.net" nick="thiago" vcs="yes"/>
   <person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/>
 
+  <!-- Histórico de constribuidores:
+  <person name="Alessander P. L. Thomaz" email="kappu at php.net" nick="kappu" vcs="yes"/>
+  <person name="Amanda Vale" email="amandavale at php.net" nick="amandavale" vcs="yes"/>
+  <person name="Anderson Fortaleza" vcs="yes" email="phaser at php.net" nick="phaser" vcs="yes"/>
+  <person name="Anderson Ravagnani Mamede" email="none" nick="andersonmamede" vcs="no"/>
+  <person name="Anísio Neto" email="neto dot df dot pn at gmail dot com" nick="anineto" vcs="no"/>
+  <person name="Arthur Almeida" email="arthur dot almeidapereira at gmail dot com" nick="arthuralmeidap" vcs="no"/>
+  <person name="Cabral" email="cabral at bysoft.com.br" nick="Cabral" vcs="no"/>
+  <person name="Claudio Pereira" email="cpereira at ig.com.br" nick="cpereira" vcs="yes"/>
+  <person name="Daniel Satiro" email="none" nick="danielsatiro" vcs="no"/>
+  <person name="Diego do Nascimento Feitosa" email="dnfeitosa at php.net" nick="dnfeitosa" vcs="yes"/>
+  <person name="Diego Pires" email="diegopires at php.net" nick="diegopires" vcs="yes"/>
+  <person name="Er Galvão Abbott" email="galvao at php.net" nick="galvao" vcs="yes"/>
+  <person name="Ernani Joppert Pontes Martins" email="ernani at php.net" nick="ernani" vcs="yes"/>
+  <person name="Jean Segat" email="none" nick="jeansegat" vcs="no"/>
+  <person name="João Lyma" email="lyma at php.net" nick="lyma" vcs="yes"/>
+  <person name="João Prado Maia" email="jpm at phpbrasil.com" nick="jpm" vcs="yes"/>
+  <person name="Lucas Nascimento Vieira" email="lucas-nek at hotmail dot com" nick="lucasnascimento" vcs="no"/>
+  <person name="Lucas Rocha" email="lucasr at php.net" nick="lucasr" vcs="yes"/>
+  <person name="Luís Otávio Cobucci Oblonczyk" email="lcobucci at php.net" nick="lcobucci" vcs="yes"/>
+  <person name="Marcel dos Santos" email="none" nick="marcelgsantos" vcs="no"/>
+  <person name="Marcilio Costa" email="marcilio_mcn at yahoo.com.br" nick="marcilio" vcs="no"/>
+  <person name="Níckolas Daniel da Silva" email="nickolas at phpsp dot org dot br" nick="nawarian" vcs="no"/>
+  <person name="Paulo Filho" email="paulorcf at cenapad dot unicamp dot br" nick="paulofilho" vcs="no"/>
+  <person name="Rafael Jaques" email="rafaeljaquestudojunto at gmail.com" nick="rafa" vcs="yes"/>
+  <person name="Ranulfo Netto" email="rcnetto at yahoo.com" nick="netto" vcs="no"/>
+  <person name="Ricardo Miranda Santos" email="rikardo dot m dot s at pop dot com dot br" nick="ricardo" vcs="no"/>
+  <person name="Samir Machado de Oliveira Filho" email="samir_filho at hotmail dot com" nick="samirmachado" vcs="no"/>
+  <person name="Taniel Franklin" email="taniel at eletroj.ufba.br" nick="surfmax" vcs="yes"/>
+  -->
+
  </translators>
 
 </translation>

--- a/translation.xml
+++ b/translation.xml
@@ -19,6 +19,7 @@
   <person name="Adiel Cristo" email="adiel at php.net" nick="adiel" vcs="yes"/>
   <person name="André Luis Ferreira da Silva Bacci" email="ae at php.net" nick="ae" vcs="yes"/>
   <person name="Daniel Rodrigues Lima" email="geekcom at php.net" nick="geekcom" vcs="yes"/>
+  <person name="Fernando Wobeto" email="fernandowobeto at gmail dot com" nick="fernandowobeto" vcs="no"/>
   <person name="Leonardo Lara Rodrigues" email="leonardo dot lara dot rodrigues at gmail dot com" nick="leonardolara" vcs="yes"/>
   <person name="Marcos Marcolin" email="marcolindev ar gmail.com" nick="marcosmarcolin" vcs="no"/>
 
@@ -27,44 +28,17 @@
   <person name="(inativos)" email="none" nick="_" vcs="no"/>
 
   <person name="Alessander P. L. Thomaz" email="kappu at php.net" nick="kappu" vcs="yes"/>
-  <person name="Amanda Vale" email="amandavale at php.net" nick="amandavale" vcs="yes"/>
-  <person name="Anderson Fortaleza" vcs="yes" email="phaser at php.net" nick="phaser" vcs="yes"/>
-  <person name="Anderson Ravagnani Mamede" email="none" nick="andersonmamede" vcs="no"/>
-  <person name="Anísio Neto" email="neto dot df dot pn at gmail dot com" nick="anineto" vcs="no"/>
-  <person name="Arthur Almeida" email="arthur dot almeidapereira at gmail dot com" nick="arthuralmeidap" vcs="no"/>
-  <person name="Cabral" email="cabral at bysoft.com.br" nick="Cabral" vcs="no"/>
-  <person name="Claudio Pereira" email="cpereira at ig.com.br" nick="cpereira" vcs="yes"/>
-  <person name="Daniel Satiro" email="none" nick="danielsatiro" vcs="no"/>
-  <person name="Diego do Nascimento Feitosa" email="dnfeitosa at php.net" nick="dnfeitosa" vcs="yes"/>
-  <person name="Diego Pires" email="diegopires at php.net" nick="diegopires" vcs="yes"/>
   <person name="Diogo Galvão" email="diogo86 at gmail.com" nick="diogo" vcs="no"/>
-  <person name="Er Galvão Abbott" email="galvao at php.net" nick="galvao" vcs="yes"/>
-  <person name="Ernani Joppert Pontes Martins" email="ernani at php.net" nick="ernani" vcs="yes"/>
   <person name="Fábio Luciano Nogueira de Góis" email="fabio dot naoimporta dot com" nick="fabioluciano" vcs="yes"/>
   <person name="Felipe Nascimento Silva Pena" email="felipe at php.net" nick="felipe" vcs="yes"/>
   <person name="Fernando Correa da Conceição" email="fernando_conceicao at yahoo dot com dot br" nick="fernandoc" vcs="yes"/>
-  <person name="Jean Segat" email="none" nick="jeansegat" vcs="no"/>
-  <person name="João Lyma" email="lyma at php.net" nick="lyma" vcs="yes"/>
-  <person name="João Prado Maia" email="jpm at phpbrasil.com" nick="jpm" vcs="yes"/>
   <person name="Klaus Silveira" email="klaussilveira at php.net" nick="klaussilveira" vcs="yes"/>
-  <person name="Lucas Nascimento Vieira" email="lucas-nek at hotmail dot com" nick="lucasnascimento" vcs="no"/>
-  <person name="Lucas Rocha" email="lucasr at php.net" nick="lucasr" vcs="yes"/>
-  <person name="Luís Otávio Cobucci Oblonczyk" email="lcobucci at php.net" nick="lcobucci" vcs="yes"/>
-  <person name="Marcel dos Santos" email="none" nick="marcelgsantos" vcs="no"/>
   <person name="Marcelo Pereira Fonseca da Silva" email="marcelo at php.net" nick="marcelo" vcs="yes"/>
-  <person name="Marcilio Costa" email="marcilio_mcn at yahoo.com.br" nick="marcilio" vcs="no"/>
   <person name="Maurício Meneghini Fauth" email="mauricio at php.net" nick="mauricio" vcs="yes"/>
-  <person name="Níckolas Daniel da Silva" email="nickolas at phpsp dot org dot br" nick="nawarian" vcs="no"/>
-  <person name="Paulo Filho" email="paulorcf at cenapad dot unicamp dot br" nick="paulofilho" vcs="no"/>
-  <person name="Rafael Jaques" email="rafaeljaquestudojunto at gmail.com" nick="rafa" vcs="yes"/>
-  <person name="Ranulfo Netto" email="rcnetto at yahoo.com" nick="netto" vcs="no"/>
   <person name="Raphael Sales" email="raphael_melo19 at yahoo dot com dot br" nick="narigone" vcs="yes"/>
   <person name="Renato Arruda" email="rla9216 at osfmail.rit.edu" nick="rarruda" vcs="yes"/>
-  <person name="Ricardo Miranda Santos" email="rikardo dot m dot s at pop dot com dot br" nick="ricardo" vcs="no"/>
   <person name="Rodrigo Prado de Jesus" email="royopa at gmail.com" nick="royopa" vcs="yes"/>
   <person name="Rogerio Prado de Jesus" email="rogeriopradoj at php.net" nick="rogeriopradoj" vcs="yes"/>
-  <person name="Samir Machado de Oliveira Filho" email="samir_filho at hotmail dot com" nick="samirmachado" vcs="no"/>
-  <person name="Taniel Franklin" email="taniel at eletroj.ufba.br" nick="surfmax" vcs="yes"/>
   <person name="Thiago Henrique Pojda" email="thiago at php.net" nick="thiago" vcs="yes"/>
   <person name="Thomas Gonzalez Miranda" email="thomasgm at php.net" nick="thomasgm" vcs="yes"/>
 


### PR DESCRIPTION
Sugestão de edição da lista de tradutores.

Incluído o fernandowobeto.

Podemos remover as referências daqueles que não são mais mantenedores de nenhuma página?
Faz sentido manter estes nomes? Nas outras traduções, a lista é bem mais enxuta e constam basicamente aqueles que têm pelo menos um arquivo em seu nome.