### PR TITLE
Fix performance related hrtime explanation in microtime page

### DIFF
--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -18,7 +18,7 @@
    a chamada de sistema gettimeofday().
   </para>
   <para>
-   Por questões de performance, utilize <function>hrtime</function>.
+   Para medição de performance é recomendado utilizar <function>hrtime</function>.
   </para>
  </refsect1>
 

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.microtime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>microtime</refname>
-  <refpurpose>Retorna um timestamp Unix com microsegundos</refpurpose>
+  <refpurpose>Retorna o timestamp Unix atual com microssegundos</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
    a chamada de sistema gettimeofday().
   </para>
   <para>
-   Para medição de performance é recomendado utilizar <function>hrtime</function>.
+   Para medições de desempenho, é recomendado utilizar <function>hrtime</function>.
   </para>
  </refsect1>
 
@@ -30,7 +30,7 @@
      <term><parameter>as_float</parameter></term>
      <listitem>
       <para>
-       Se utilizada e definida como &true;, a função <function>microtime</function> retorna um
+       Se utilizada e definida como &true;, a função <function>microtime</function> retornará um
        <type>float</type> em vez de uma <type>string</type>, como descrito na
        seção de valores de retorno a seguir.
       </para>
@@ -45,14 +45,14 @@
   <para>
    Por padrão, a função <function>microtime</function> retorna uma <type>string</type> no
    formato "msec sec", onde <literal>sec</literal> é o número de segundos
-   desde a Unix epoch (0:00:00 January 1,1970 GMT), e <literal>msec</literal>
+   desde a época Unix (1 de Janeiro de 1970, 00:00:00 GMT), e <literal>msec</literal>
    mensura os microssegundos que se passaram desde <literal>sec</literal>
-   e também é expressada em segundos, na forma de frações decimais.
+   e também é expressa em segundos, na forma de fração decimal.
   </para>
   <para>
-   Se o parâmetro opcional <parameter>as_float</parameter> for definido para &true;
-   então a função <function>microtime</function> retornará um <type>float</type>, que
-   representa a hora atual em segundos desde Unix epoch com precisão
+   Se o parâmetro opcional <parameter>as_float</parameter> for definido para &true;,
+   a função <function>microtime</function> retorna um <type>float</type> que
+   representa a hora atual em segundos desde a época Unix com precisão
    de microssegundos.
   </para>
  </refsect1>
@@ -67,13 +67,13 @@
 <?php
 $time_start = microtime(true);
 
-// Sleep for a while
+// Espera um momento
 usleep(100);
 
 $time_end = microtime(true);
 $time = $time_end - $time_start;
 
-echo "Fiz nada em $time segundo(s).\n";
+echo "Nada foi feito em $time segundo(s).\n";
 ?>
 ]]>
     </programlisting>
@@ -83,14 +83,14 @@ echo "Fiz nada em $time segundo(s).\n";
     <programlisting role="php">
 <![CDATA[
 <?php
-// Randomize sleeping time
+// Tempo de espera aleatório
 usleep(mt_rand(100, 10000));
 
 // REQUEST_TIME_FLOAT está disponível no array superglobal $_SERVER.
-// Ele contém o timestamp de início da requisição com precisão de microsegundos.
+// Ele contém o timestamp do início da requisição com precisão de microssegundos.
 $time = microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"];
 
-echo "Fiz nada em $time segundo(s).\n";
+echo "Nada foi feito em $time segundo(s).\n";
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
The original translation is misleading the reader to think that hrtime is faster, when that is not the case. As stated by the English version, hrtime is recommended to be used for performance measurements, and not because it is faster. I suggested adapting the Portuguese version to fix that confusion. 