### PR TITLE
Substitui 'maiores' por 'mais' em translation.xml

### DIFF
--- a/translation.xml
+++ b/translation.xml
@@ -4,7 +4,7 @@
 
  <intro>
   A tradução brasileira da Documentação do PHP é mantida por vários
-  colaboradores. Se você procura maiores informações sobre o grupo
+  colaboradores. Se você procura mais informações sobre o grupo
   de tradução, visite a <a href="https://github.com/php/doc-pt_br">página do projeto</a>
   ou inscreva-se e apresente-se na nossa lista de discussão: doc-pt-br-subscribe@lists.php.net (inscrição),
   doc-pt-br@lists.php.net (postagem).


### PR DESCRIPTION
O termo maior é um comparativo.