### PR TITLE
Remove authors section

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -26,63 +26,6 @@
    </simpara>
   </legalnotice>
 
-  <authorgroup>
-   <author>
-    <personname>Adiel Cristo</personname>
-   </author>
-   <author>
-    <personname>André Luis Ferreira da Silva Bacci</personname>
-   </author>
-   <author>
-    <personname>Daniel Rodrigues Lima</personname>
-   </author>
-   <author>
-    <personname>Diogo Galvão</personname>
-   </author>
-   <author>
-    <personname>Fábio Luciano Nogueira de Góis</personname>
-   </author>
-   <author>
-    <personname>Felipe Nascimento Silva Pena</personname>
-   </author>
-   <author>
-    <personname>Fernando Correa da Conceição</personname>
-   </author>
-   <author>
-    <personname>Fernando Wobeto</personname>
-   </author>
-   <author>
-    <personname>Klaus Silveira</personname>
-   </author>
-   <author>
-    <personname>Leonardo Lara Rodrigues</personname>
-   </author>
-   <author>
-    <personname>Marcos Marcolin</personname>
-   </author>
-   <author>
-    <personname>Maurício Meneghini Fauth</personname>
-   </author>
-   <author>
-    <personname>Raphael Melo de Oliveira Bastos Sales</personname>
-   </author>
-   <author>
-    <personname>Renato Arruda</personname>
-   </author>
-   <author>
-    <personname>Rodrigo Prado de Jesus</personname>
-   </author>
-   <author>
-    <personname>Rogerio Prado de Jesus</personname>
-   </author>
-   <author>
-    <personname>Thiago Henrique Pojda</personname>
-   </author>
-   <author>
-    <personname>Thomas Gonzalez Miranda</personname>
-   </author>
-  </authorgroup>
-
  </info>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Seguindo o que está no original em inglês, proponho a remoção da seção de "authors" na página principal, que além de ficar na frente (acima) do próprio conteúdo do manual, exige manutenção de tempos em tempos e não contribui em informação relevante para o usuário do manual.

As versões em inglês e em japonês já não apresentam mais os autores na página principal.

A lista de [tradutores](http://doc.php.net/revcheck.php?p=translators&lang=pt_br) continua presente na página de tradução do manual.

Se alguém se opuser, podemos manter, mas gostaria de pelo menos mudar o local em relação à página (poderia ficar ao final).