### PR TITLE
Convert MongoDB from set to book

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3628,7 +3628,7 @@ local: {
      </para>
      <note>
       <simpara>
-       Ao avaliar os critérios de consulta, o MongoDB compara os tipos e valores de acordo com suas próprias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">regras de comparação para tipos BSON</link>, que diferem das regras de <link linkend="types.comparisons">comparação</link> e do <link linkend="language.types.type-juggling">malabarismo de tipos</link> do PHP. Ao corresponder a um tipo especial de BSON, os critérios de consulta devem usar a respectiva <link linkend="book.bson">classe BSON</link> (por exemplo, use <classname>MongoDB\BSON\ObjectId</classname> para corresponder a um <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
+       Ao avaliar os critérios de consulta, o MongoDB compara os tipos e valores de acordo com suas próprias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">regras de comparação para tipos BSON</link>, que diferem das regras de <link linkend="types.comparisons">comparação</link> e do <link linkend="language.types.type-juggling">malabarismo de tipos</link> do PHP. Ao corresponder a um tipo especial de BSON, os critérios de consulta devem usar a respectiva <link linkend="mongodb.bson">classe BSON</link> (por exemplo, use <classname>MongoDB\BSON\ObjectId</classname> para corresponder a um <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
       </simpara>
      </note>
     </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 22eb2f39973a06dd565e0030f173f8460d2f2811 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
 
-<book xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Arquitetura do driver e componentes internos</titleabbrev>
  <title>Explica a arquitetura do driver e recursos especiais</title>
 
- <article xml:id="mongodb.overview">
+ <section xml:id="mongodb.overview">
   <titleabbrev>Arquitetura</titleabbrev>
   <title>Visão geral da arquitetura</title>
 
@@ -87,9 +87,9 @@
     </tgroup>
    </table>
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.connection-handling">
+ <section xml:id="mongodb.connection-handling">
   <titleabbrev>Conexões</titleabbrev>
   <title>Manipulação de conexão e persistência</title>
 
@@ -208,9 +208,9 @@ foreach ($managers as $manager) {
     API Streams do PHP.
    </para>
   </section>
- </article>
+ </section>
 
- <article xml:id="mongodb.persistence">
+ <section xml:id="mongodb.persistence">
   <titleabbrev>Dados Persistentes</titleabbrev>
   <title>Serialização e desserialização de variáveis PHP no MongoDB</title>
 
@@ -967,8 +967,8 @@ function bsonUnserialize( array $map )
    </section>
   </section>
 
- </article>
-</book>
+ </section>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
-<set xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Extensão MongoDB</title>
  <titleabbrev>MongoDB</titleabbrev>
 
@@ -16,7 +17,7 @@
     <link linkend="class.mongodb-driver-query">consultas</link>,
     <link linkend="class.mongodb-driver-bulkwrite">gravações</link>,
     <link linkend="class.mongodb-driver-manager">gerenciamento de conexão</link>
-    e <link linkend="book.bson">serialização BSON</link>.
+    e <link linkend="mongodb.bson">serialização BSON</link>.
    </simpara>
    <simpara>
     As bibliotecas Userland PHP que dependem desta extensão podem fornecer APIs de
@@ -33,6 +34,7 @@
  </info>
 
   &reference.mongodb.setup;
+  &reference.mongodb.constants;
   &reference.mongodb.tutorial;
   &reference.mongodb.architecture;
   &reference.mongodb.security;
@@ -41,7 +43,7 @@
   &reference.mongodb.bson;
   &reference.mongodb.monitoring;
   &reference.mongodb.exceptions;
-</set>
+</book>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/bson.xml
+++ b/reference/mongodb/bson.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: dd9038795cefd9b08ce1453b770496cbf132782e Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
- <book xml:id="book.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="pecl" ?>
   <title>Classes e Funções BSON do MongoDB</title>
   <titleabbrev>MongoDB\BSON</titleabbrev>
@@ -44,5 +44,5 @@
   &reference.mongodb.bson.int64;
   &reference.mongodb.bson.symbol;
   &reference.mongodb.bson.undefined;
- </book>
+ </part>
 

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 8c84a7f1fd238b71d31f315cc52b8b7771401fdd Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
-<article xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
  <section xml:id="mongodb.installation.pecl">
@@ -270,7 +270,7 @@ extension=mongodb.so
   </para>
  </section>
 
-</article>
+</section>
 
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 4083e8f9523a60390960c52a7ab810dc7b096d40 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 
- <book xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <titleabbrev>MongoDB\Driver\Exception</titleabbrev>
   <title>Classes de exceção</title>
 
@@ -66,4 +66,4 @@
    </itemizedlist>
   </article>
 
- </book>
+ </part>

--- a/reference/mongodb/ini.xml
+++ b/reference/mongodb/ini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
-<article xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
  <para>
@@ -74,7 +74,7 @@
     </varlistentry>
   </variablelist>
  </para>
-</article>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: dd9038795cefd9b08ce1453b770496cbf132782e Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
- <book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="pecl" ?>
   <title>Classes de Extensão MongoDB</title>
   <titleabbrev>MongoDB\Driver</titleabbrev>
@@ -29,5 +29,5 @@
   &reference.mongodb.mongodb.driver.writeconcernerror;
   &reference.mongodb.mongodb.driver.writeerror;
   &reference.mongodb.mongodb.driver.writeresult;
- </book>
+ </part>
 

--- a/reference/mongodb/monitoring.xml
+++ b/reference/mongodb/monitoring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
- <book xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Classes de monitoramento e funções assinantes</title>
   <titleabbrev>MongoDB\Driver\Monitoring</titleabbrev>
 
@@ -28,5 +28,5 @@
   &reference.mongodb.mongodb.driver.monitoring.logsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.sdamsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.subscriber;
- </book>
+ </part>
 

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 4e0bf229045ff87d5f84469280bf0a6b195bfb8b Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
-<book xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Segurança</title>
 
- <article xml:id="mongodb.security.request_injection">
+ <section xml:id="mongodb.security.request_injection">
   <title>Request Injection Attacks</title>
   <para>
    Se você estiver passando parâmetros <literal>$_GET</literal> (ou <literal>$_POST</literal>)
@@ -44,9 +44,9 @@
    Consulte <link xlink:href="&url.mongodb.dochub.security;">a documentação principal</link>
    para obter mais informações sobre problemas semelhantes à injeção de SQL com o MongoDB.
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.security.script_injection">
+ <section xml:id="mongodb.security.script_injection">
   <title>Ataques de injeção de script</title>
   <para>
    Se você estiver usando JavaScript, certifique-se de que quaisquer variáveis que cruzem o limite
@@ -158,8 +158,8 @@ $r = $m->executeCommand( 'dramio', $cmd );
    xlink:href="&url.mongodb.docs;reference/command/eval/">comando eval</link>
    foi descontinuado desde o MongoDB 3.0 e também deve ser evitado.
   </para>
- </article>
-</book>
+ </section>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/setup.xml
+++ b/reference/mongodb/setup.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
-<book xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <article xml:id="mongodb.requirements">
+ <section xml:id="mongodb.requirements">
   &reftitle.required;
   <para>
    A partir da versão 1.16.0, a extensão requer PHP 7.2 ou superior. Versões
@@ -43,21 +43,20 @@
     inteiro PHP.
    </simpara>
   </note>
- </article>
+ </section>
 
  &reference.mongodb.configure;
  &reference.mongodb.ini;
 <!--
- <article xml:id="mongodb.resources">
+ <section xml:id="mongodb.resources">
   &reftitle.resources;
   <para>
 
   </para>
- </article>
+ </section>
 -->
-  &reference.mongodb.constants;
 
-</book>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/tutorial.xml
+++ b/reference/mongodb/tutorial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 680b85d4cc40065d48ae1f918e7579d8eb244f85 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 
- <book xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <chapter xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Tutoriais</title>
   <titleabbrev>Tutoriais</titleabbrev>
 
@@ -16,7 +16,7 @@
 
   &reference.mongodb.tutorial.library;
   &reference.mongodb.tutorial.apm;
- </book>
+ </chapter>
 
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: af0472588c9f07f2f20533d80dc8b17018b224dd Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 
-<chapter xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Monitoramento de Desempenho de Aplicação (APM)</title>
 
  <para>
@@ -185,7 +185,7 @@ $cursor = $m->executeQuery( 'dramio.whisky', $query );
   </programlisting>
  </section>
 
-</chapter>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 
-<chapter xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Usando a Biblioteca do PHP para o MongoDB (PHPLIB)</title>
 
  <para>
@@ -155,7 +155,7 @@ foreach ($result as $entry) {
    como os valores são convertidos entre PHP e BSON.
   </para>
  </section>
-</chapter>
+</section>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
This PR converts `doc-pt_br`'s MongoDB chapter from a `<set>` to a `<book>` as is done in https://github.com/php/doc-en/pull/3627. This needs the `doc-en` PR and https://github.com/php/doc-base/pull/138 both to work properly.

Also, the revision hashes probably need updating once the `doc-en` changes are merged.