### PR TITLE
fix: typo at translation

### DIFF
--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -273,7 +273,7 @@ fclose($fp);
    fornecem uma maneira de criar
    arquivos compatíveis com gzip e bz2 no sistema de arquivos local, eles não fornecem um
    meio para compressão generalizada de fluxos de rede, nem fornecem uma
-   maneira de começar com uma fluxo não-comprimida e mudar para uma comprimida.
+   maneira de começar com um fluxo não-comprimido e mudar para um comprimido.
    Para isso, um filtro de compressão pode ser aplicado a qualquer recurso de fluxo em qualquer momento.
   </simpara>
 


### PR DESCRIPTION
I think that `resource` is best to this because sounds more a technical term, but using `fluxo` have a gender agreement, maybe was a problem of search and replace all `resource` by `fluxo`.