### PR TITLE
Bump EN-Revision for reference/uri/uri.whatwg.urlvalidationerrortype.xml

### DIFF
--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 66d06b9c7c95ead73080ea7f0ac25dd11a052f71 Maintainer: lacatoire Status: ready -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 8352249a84d0b91b38c741ff1c256061127dbfbb Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
  <title>A enumeração Uri\WhatWg\UrlValidationErrorType</title>
  <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>


### PR DESCRIPTION
## Summary

Bump of the `EN-Revision` hash for the only file in `TranslatedOld` status according to the [revcheck](https://doc.php.net/revcheck.php?p=files&lang=pt_br).

## Upstream diff

Between `66d06b9c…` and `8352249a…`, the only change in `doc-en` is the addition of the `xmlns:xlink="http://www.w3.org/1999/xlink"` attribute on the `<reference>` element — an attribute that is **already present** in the pt_BR translation. Therefore, this PR only updates the revision hash, with no content changes.

## Verification

- [x] XML remains well-formed (DOM parse OK)
- [x] Single `diff -u`: 1 line changed (`EN-Revision` header)
- [x] File size unchanged (7933 bytes)