### PR TITLE
Sync EN: bump revision hashes on misc files

### DIFF
--- a/appendices/migration84/new-functions.xml
+++ b/appendices/migration84/new-functions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: ceeec43d340a7f0e0910d7eeeb0850af72ab34d9 Maintainer: leonardolara Status: ready -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 30b0c51175bb9bc5a329d7924b0ca5eff1f1f9ad Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration84.new-functions">
  <title>Novas Funções</title>
 
@@ -120,6 +120,7 @@
    <member><function>pcntl_getcpuaffinity</function></member>
    <member><function>pcntl_getqos_class</function></member>
    <member><function>pcntl_setns</function></member>
+   <member><function>pcntl_setqos_class</function></member>
    <member><function>pcntl_waitid</function></member>
   </simplelist>
  </sect2>

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 170b6cda37f29c39b9e08375344c5eb9523b2de3 Maintainer: leonardolara Status: ready --><!-- CREDITS: ae,thiago,AlexAntonio,royopa,lcobucci,fabioluciano,adiel,geekcom,ABDALAZARD,leonardolara -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: lacatoire Status: ready --><!-- CREDITS: ae,thiago,AlexAntonio,royopa,lcobucci,fabioluciano,adiel,geekcom,ABDALAZARD,leonardolara -->
 
  <appendix xml:id="reserved" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Lista de Palavras Reservadas do PHP</title>
@@ -566,6 +566,12 @@
         </entry>
         <entry>
          never (a partir do PHP 8.1)
+        </entry>
+        <entry>
+         array (a partir do PHP 8.5)
+        </entry>
+        <entry>
+         callable (a partir do PHP 8.5)
         </entry>
        </row>
       </tbody>

--- a/extensions.ent
+++ b/extensions.ent
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e2d8231b5d8a3795b365c6770fab288e59e6249 Maintainer: ae Status: ready --><!-- CREDITS: thiago,ae -->
+<!-- EN-Revision: 067e27db0a6f790ee0faaf99aa1f321f88f82cc9 Maintainer: lacatoire Status: ready --><!-- CREDITS: thiago,ae -->
 
 <!--
   Entities for the categorized extension list, so it does not need
   to be translated, and thus it is not going to be outdated.
 -->
 
-<!ENTITY extcat.intro '<title xmlns="http://docbook.org/ns/docbook">Categorização/Lista das Extensões</title><para xmlns="http://docbook.org/ns/docbook">Esse
+<!ENTITY extcat.intro '<title xmlns="http://docbook.org/ns/docbook">Categorização/Lista das Extensões</title><simpara xmlns="http://docbook.org/ns/docbook">Esse
 apêndice categoriza mais de 150 extensões documentadas no manual do
-PHP por vários critérios.</para>'>
+PHP por vários critérios.</simpara>'>
 
 <!ENTITY extcat.alphabetical '<title xmlns="http://docbook.org/ns/docbook">Em ordem alfabética</title>'>
 
@@ -64,33 +64,33 @@ PHP por vários critérios.</para>'>
 
 <!ENTITY extcat.membership '<title xmlns="http://docbook.org/ns/docbook">Classificadas por Pertencimento</title>'>
 
-<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Extensões Principais</title><para xmlns="http://docbook.org/ns/docbook">Essas
+<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Extensões Principais</title><simpara xmlns="http://docbook.org/ns/docbook">Essas
 não são de fato extensões. Eles são parte do núcleo do PHP e não podem ser
-deixadas de fora do binário do PHP através de opções de compilação.</para>'>
+deixadas de fora do binário do PHP através de opções de compilação.</simpara>'>
 
-<!ENTITY extcat.membership.bundled '<title xmlns="http://docbook.org/ns/docbook">Extensões Agregadas</title><para xmlns="http://docbook.org/ns/docbook">Essas
-extensões são distribuídas com o PHP.</para>'>
+<!ENTITY extcat.membership.bundled '<title xmlns="http://docbook.org/ns/docbook">Extensões Agregadas</title><simpara xmlns="http://docbook.org/ns/docbook">Essas
+extensões são distribuídas com o PHP.</simpara>'>
 
-<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">Extensões Externas</title><para xmlns="http://docbook.org/ns/docbook">Para
-compilar essas extensões é preciso ter bibliotecas externas.</para>'>
+<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">Extensões Externas</title><simpara xmlns="http://docbook.org/ns/docbook">Para
+compilar essas extensões é preciso ter bibliotecas externas.</simpara>'>
 
 <!ENTITY extcat.membership.pecl '<title xmlns="http://docbook.org/ns/docbook">Extensões
 PECL</title>
-<para xmlns="http://docbook.org/ns/docbook">Essas extensões estão disponíveis no
+<simpara xmlns="http://docbook.org/ns/docbook">Essas extensões estão disponíveis no
 &link.pecl;. Elas podem requerer bibliotecas externas. Existem outras extensões PECL mas
-elas não estão documentadas no manual do PHP.</para>'>
+elas não estão documentadas no manual do PHP.</simpara>'>
 
 <!-- ======================================================================= -->
 
-<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Classificadas por status de desenvolvimento</title><para xmlns="http://docbook.org/ns/docbook">Essa parte lista as extensões
+<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Classificadas por status de desenvolvimento</title><simpara xmlns="http://docbook.org/ns/docbook">Essa parte lista as extensões
 não destinadas para uso em produção - elas são ou muito antigas (descontinuadas) ou
-muito novas (experimentais).</para>'>
+muito novas (experimentais).</simpara>'>
 
-<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensões Descontinuadas</title><para xmlns="http://docbook.org/ns/docbook">Essas
-extensões tornaram-se descontinuadas normalmente em favor de outras extensões.</para>'>
+<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensões Descontinuadas</title><simpara xmlns="http://docbook.org/ns/docbook">Essas
+extensões tornaram-se descontinuadas normalmente em favor de outras extensões.</simpara>'>
 
-<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensões Experimentais</title><para xmlns="http://docbook.org/ns/docbook">O
+<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensões Experimentais</title><simpara xmlns="http://docbook.org/ns/docbook">O
 comportamento dessas extensões - incluindo os nomes das suas funções e qualquer
 outra coisa documentada sobre essas extensões - pode mudar sem aviso em versões futuras
-do PHP. Use essas funções a seu próprio risco.</para>'>
+do PHP. Use essas funções a seu próprio risco.</simpara>'>
 

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17502ebe0691a84e7d0738c13e8c1061dde98de7 Maintainer: leonardolara Status: ready --><!-- CREDITS: lhsazevedo, leonardolara -->
+<!-- EN-Revision: 840bdb9be79855ee4b2cc66c22cf3e88b781398a Maintainer: lacatoire Status: ready --><!-- CREDITS: lhsazevedo, leonardolara -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -65,7 +65,7 @@ $output = match (true) {
     $age < 2 => "Bebê",
     $age < 13 => "Criança",
     $age <= 19 => "Adolescente",
-    $age >= 40 => "Adulto Meia-idade"
+    $age >= 40 => "Adulto"
     $age > 19 => "Adulto Jovem"
 };
 

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 194d020921b4f2bc7616ac9eacabe362e89752ef Maintainer: leonardolara Status: ready --><!-- CREDITS: everaldofilho,leonardolara -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: lacatoire Status: ready --><!-- CREDITS: everaldofilho,leonardolara -->
 <refentry xml:id="function.class-alias" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>class_alias</refname>
@@ -18,6 +18,9 @@
    com base na classe definida pelo usuário <parameter>class</parameter>.
    A classe com apelido é exatamente igual à classe original.
   </para>
+  <simpara>
+   O apelido da classe não pode ser nenhuma das <link linkend="reserved.other-reserved-words">palavras reservadas</link> do PHP.
+  </simpara>
   <note>
    <simpara>
     A partir do PHP 8.3.0, <function>class_alias</function> também suporta

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,4 +1,4 @@
- <variablelist role="constant_list"><!-- EN-Revision: c9888ac6e5c75d00d50f9c2fd741ae3a82a479ec Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+ <variablelist role="constant_list"><!-- EN-Revision: d7d6dd60085409b295916649e4bd7107742659a2 Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
   <title><function>curl_setopt</function></title>
   <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
    <term>
@@ -239,7 +239,7 @@
    </term>
    <listitem>
     <para>
-     O número de segundos a esperar durante tentativa de conexão. Use 0 para
+     O número de segundos a esperar durante tentativa de conexão. Use <literal>0</literal> para
      esperar indefinidamente.
      Esta opção aceita qualquer valor que possa ser convertido para um <type>int</type> válido.
      O padrão é <literal>300</literal>.

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: leonardolara Status: ready --><!-- CREDITS: fabioluciano, leonardolara -->
+<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: lacatoire Status: ready --><!-- CREDITS: fabioluciano, leonardolara -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::createFromDateString</refname>
@@ -62,7 +62,7 @@
   &reftitle.errors;
   <para>
    Apenas para API orientada a objetos: Se uma string de data/horário inválida for passada,
-   uma exceção <exceptionname>DateMalformedStringException</exceptionname> é lançada.
+   uma exceção <exceptionname>DateMalformedIntervalStringException</exceptionname> é lançada.
   </para>
  </refsect1>
 
@@ -81,7 +81,7 @@
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> agora lança
-       uma exceção <exceptionname>DateMalformedStringException</exceptionname> se uma
+       uma exceção <exceptionname>DateMalformedIntervalStringException</exceptionname> se uma
        string inválida for passada. Anteriormente, retornava <literal>false</literal>
        e um alerta era emitido.
        A função <function>date_interval_create_from_date_string</function> não foi

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a69d8c2c891e70c03c33cbe251a208dd7d185af9 Maintainer: leonardolara Status: ready --><!-- CREDITS: fabioluciano, leonardolara -->
+<!-- EN-Revision: e1e7f1f922033c50c2fd2d33fc5e0512f4e76844 Maintainer: lacatoire Status: ready --><!-- CREDITS: fabioluciano, leonardolara -->
 <reference xml:id="class.datetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>A interface DateTimeInterface</title>
@@ -365,6 +365,13 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         As constantes <constant>DATE_RFC7231</constant> e
+         <constant>DateTimeInterface::RFC7231</constant> foram descontinuadas.
+        </entry>
+       </row>
        <row>
         <entry>8.4.0</entry>
         <entry>As constantes de classe agora são tipadas.</entry>

--- a/reference/intl/collator/set-attribute.xml
+++ b/reference/intl/collator/set-attribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 0194deb3cec8d79ae6b13700f3cd031d14597838 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="collator.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::setAttribute</refname>
@@ -76,13 +76,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$coll = collator_create( 'en_CA' );
-$val  = collator_get_attribute( $coll, Collator::NUMERIC_COLLATION );
-if ($val === false) {
-    // Lida com o erro.
-} elseif ($val === Collator::ON) {
-    // Faz algo útil.
-}
+$coll = collator_create('en_CA');
+collator_set_attribute($coll, Collator::NORMALIZATION_MODE, Collator::ON);
 ?>
 ]]>
     </programlisting>

--- a/reference/network/functions/request-parse-body.xml
+++ b/reference/network/functions/request-parse-body.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 4bf789e981af0836c41daa16e57ef86c21497faa Maintainer: leonardolara Status: ready -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: c78af136d0497e16230218083ce43448f1864272 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.request-parse-body" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>request_parse_body</refname>
@@ -37,8 +37,12 @@
 
   <caution>
    <simpara>
+    O corpo da requisição só pode ser consumido uma vez.
     <function>request_parse_body</function> consome o corpo da requisição sem
     fazer buffer para o fluxo <literal>php://input</literal>.
+    Por outro lado, se o corpo já tiver sido lido (por exemplo, através de
+    <literal>php://input</literal>), <function>request_parse_body</function>
+    retornará dados vazios.
    </simpara>
   </caution>
  </refsect1>

--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1e3ea622e5d4f542cd36eca59a9f22aa0142633 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 47881dcf54038053a6aa70d901e61c14e2c01a06 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.openssl-x509-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_read</refname>
@@ -41,6 +41,13 @@
   <para>
    Retorna um <classname>OpenSSLCertificate</classname> em caso de sucesso&return.falseforfailure;.
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Um <constant>E_WARNING</constant> é emitido se o certificado X.509 não puder ser obtido.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 86d3fb841e0206e2588896ad3c21432333535848 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 581589d2c4d3183f1c0e67214a65cbd181a5edac Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <section xmlns="http://docbook.org/ns/docbook" xml:id="pdo.constants.fetch-modes">
  <title>Modos de Busca</title>
 
@@ -1061,6 +1061,7 @@ while ($stmt->fetch(\PDO::FETCH_BOUND)) {
    <programlisting role="php">
 <![CDATA[
 <?php
+
 class TestEntity
 {
     public $userid;
@@ -1073,10 +1074,12 @@ class TestEntity
 }
 
 $obj = new TestEntity();
-$stmt->setFetchMode(\PDO::FETCH_INTO, $obj);
 
 $stmt = $db->query("SELECT userid, name, country, referred_by_userid FROM users");
+
+$stmt->setFetchMode(\PDO::FETCH_INTO, $obj);
 $result = $stmt->fetch();
+
 var_dump($result);
 ]]>
    </programlisting>

--- a/reference/quickhash/quickhashinthash/set.xml
+++ b/reference/quickhash/quickhashinthash/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 34c7b33526bef25c40c2ab0dcd8709c8948964c5 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 7ac16ce2e1d9a65f4f10a92f3161d95c9e27f053 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="quickhashinthash.set">
  <refnamediv>
   <refname>QuickHashIntHash::set</refname>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>QuickHashIntHash::set</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>QuickHashIntHash::set</methodname>
    <methodparam><type>int</type><parameter>key</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   2 se a entrada foi encontrada e atualizada, 1 se a entrada foi adicionada recentemente ou 0
+   2 se a entrada foi adicionada recentemente, 1 se a entrada foi encontrada e atualizada, ou 0
    se houve um erro.
   </simpara>
  </refsect1>
@@ -61,17 +61,17 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$hash = new QuickHashIntHash( 1024 );
+
+$hash = new QuickHashIntHash(1024);
 
 echo "Define->Adiciona\n";
-var_dump( $hash->get( 46692 ) );
-var_dump( $hash->set( 46692, 16091 ) );
-var_dump( $hash->get( 46692 ) );
+var_dump($hash->get(46692));
+var_dump($hash->set(46692, 16091));
+var_dump($hash->get(46692));
 
-echo "Define->Atualiza\n";
-var_dump( $hash->set( 46692, 29906 ) );
-var_dump( $hash->get( 46692 ) );
-?>
+echo "\n\nDefine->Atualiza\n";
+var_dump($hash->set(46692, 29906));
+var_dump($hash->get(46692));
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -81,6 +81,7 @@ Define->Adiciona
 bool(false)
 int(2)
 int(16091)
+
 Define->Atualiza
 int(1)
 int(29906)

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 6197a68b1e9bc777323fa0df01adbed4d0c743f4 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.intval" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>intval</refname>
@@ -96,6 +96,31 @@
    <link linkend="language.types.integer.casting">conversão para inteiros</link>
    se aplicam.
   </para>
+  <note>
+   <simpara>
+    Strings numéricas que usam notação científica (contendo a letra
+    <literal>e</literal> ou <literal>E</literal>) são primeiro analisadas como
+    números antes de serem convertidas para inteiro.
+   </simpara>
+   <simpara>
+    Como a parte numérica da string é analisada como um todo, o resultado
+    não é simplesmente a parte inteira inicial. Expoentes grandes podem ainda
+    transbordar para <constant>PHP_INT_MAX</constant>:
+   </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo intval('42.42e42'); // 9223372036854775807 em sistemas de 64 bits
+?>
+]]>
+    </programlisting>
+   </informalexample>
+   <simpara>
+    Consulte <link linkend="language.types.numeric-strings">Strings numéricas</link>
+    para detalhes sobre como tais strings são interpretadas.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
First batch of EN syncs picked from https://doc.php.net/revcheck.php?lang=pt_br, focused on mechanical diffs (XML structure changes, signature renames, new entries, formatting tweaks). The pt_br translations of existing prose are kept untouched.

14 files synced; their EN-Revision hash is bumped to current ``php/doc-en`` HEAD and ``Maintainer:`` is set to ``lacatoire``.

Three files from the batch are deliberately left out because their EN diff rewrites prose paragraphs and needs a real translation pass (will be tackled separately):

- ``appendices/ini.core.xml``
- ``features/persistent-connections.xml``
- ``reference/filter/functions/filter-input.xml``
