### PR TITLE
Sync EN: bump revision hashes on pgsql function references

### DIFF
--- a/reference/pgsql/functions/pg-escape-bytea.xml
+++ b/reference/pgsql/functions/pg-escape-bytea.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.61 -->
 <refentry xml:id='function.pg-escape-bytea' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_bytea</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_bytea</function> escapa string para
@@ -49,7 +49,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Uma <type>string</type> contendo texto ou dados binários a serem inseridos em uma coluna

--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.61 -->
 <refentry xml:id='function.pg-escape-identifier' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_escape_identifier</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_escape_identifier</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_identifier</function> escapa um identificador
@@ -42,7 +42,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Uma <type>string</type> contendo texto a ser escapado.
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Uma <type>string</type> contendo os dados escapados.
+   Uma <type>string</type> contendo os dados escapados, ou &false; em caso de falha.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-escape-literal.xml
+++ b/reference/pgsql/functions/pg-escape-literal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.61 -->
 <refentry xml:id='function.pg-escape-literal' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_escape_literal</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_escape_literal</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_literal</function> escapa um literal para
@@ -40,7 +40,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Uma <type>string</type> contendo texto a ser escapado.
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Uma <type>string</type> contendo os dados escapados.
+   Uma <type>string</type> contendo os dados escapados, ou &false; em caso de falha.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.61 -->
 <refentry xml:id='function.pg-escape-string' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_string</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_string</function> escapa uma string para consultar
@@ -40,7 +40,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Uma <type>string</type> contendo texto a ser escapado.

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.2 -->
 <refentry xml:id="function.pg-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_execute</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -44,7 +44,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        O nome da instrução preparada a ser executada. se

--- a/reference/pgsql/functions/pg-lo-export.xml
+++ b/reference/pgsql/functions/pg-lo-export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.6 -->
 <refentry xml:id="function.pg-lo-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
    <type>bool</type><methodname>pg_lo_export</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>oid</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_export</function> pega um objeto grande em um
@@ -50,7 +50,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        O caminho completo e o nome do arquivo no qual gravar o

--- a/reference/pgsql/functions/pg-lo-import.xml
+++ b/reference/pgsql/functions/pg-lo-import.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d0ae617680e58bde494f9d58d9c553e0a6944418 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.6 -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.pg-lo-import">
  <refnamediv>
@@ -10,10 +10,10 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int|string|false</type><methodname>pg_lo_import</methodname>
+   <type class="union"><type>int</type><type>string</type><type>false</type></type><methodname>pg_lo_import</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>object_id</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>string</type></type><parameter>oid</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_import</function> cria um novo objeto grande
@@ -42,7 +42,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        O caminho completo e o nome do arquivo no sistema de arquivos do
@@ -51,10 +51,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>object_id</parameter></term>
+     <term><parameter>oid</parameter></term>
      <listitem>
       <para>
-       Se um <parameter>object_id</parameter> for fornecido, a função
+       Se um <parameter>oid</parameter> for fornecido, a função
        tentará criar um objeto grande com este id, caso contrário,
        um id de objeto livre será atribuído pelo servidor. O parâmetro
        depende da funcionalidade que apareceu pela primeira

--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="function.pg-parameter-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_parameter_status</refname>
@@ -9,9 +9,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_parameter_status</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_parameter_status</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>param_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>
     Procura uma configuração de parâmetro atual do servidor.
@@ -44,10 +44,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>param_name</parameter></term>
+     <term><parameter>name</parameter></term>
      <listitem>
         <para>
-         Os possíveis valores de <parameter>param_name</parameter> incluem <literal>server_version</literal>,
+         Os possíveis valores de <parameter>name</parameter> incluem <literal>server_version</literal>,
          <literal>server_encoding</literal>, <literal>client_encoding</literal>,
          <literal>is_superuser</literal>, <literal>session_authorization</literal>,
          <literal>DateStyle</literal>, <literal>TimeZone</literal> e
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>Uma <type>string</type> contendo o valor do parâmetro, &false; em caso de falha ou
-  <parameter>param_name</parameter> inválido.</para>
+  <parameter>name</parameter> inválido.</para>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/pgsql/functions/pg-prepare.xml
+++ b/reference/pgsql/functions/pg-prepare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.2 -->
 <refentry xml:id="function.pg-prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_prepare</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -25,8 +25,8 @@
    sejam analisados e planejados apenas uma vez, em vez de cada vez que forem executados.
   </para>
   <para>
-   A função cria uma instrução preparada chamada <parameter>stmtname</parameter> a partir da string <parameter>query</parameter>,
-   que deve conter um único comando SQL. <parameter>stmtname</parameter> pode ser <literal>""</literal> para
+   A função cria uma instrução preparada chamada <parameter>statement_name</parameter> a partir da string <parameter>query</parameter>,
+   que deve conter um único comando SQL. <parameter>statement_name</parameter> pode ser <literal>""</literal> para
    criar uma instrução sem nome, caso em que qualquer instrução sem nome pré-existente
    é automaticamente substituída; caso contrário, será um erro se o nome da
    instrução já estiver definido na sessão atual. Se algum parâmetro
@@ -53,7 +53,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        O nome para dar a declaração preparada. Deve ser exclusivo por conexão. Se

--- a/reference/pgsql/functions/pg-put-line.xml
+++ b/reference/pgsql/functions/pg-put-line.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.20 -->
 <refentry xml:id="function.pg-put-line" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>pg_put_line</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_put_line</function> envia uma string terminada em NULL
@@ -57,7 +57,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>query</parameter></term>
      <listitem>
       <para>
        Uma linha de texto a ser enviada diretamente para o backend do PostgreSQL. Um terminador <literal>NULL</literal>

--- a/reference/pgsql/functions/pg-set-error-verbosity.xml
+++ b/reference/pgsql/functions/pg-set-error-verbosity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready --><!-- CREDITS: fernandowobeto -->
 <!-- splitted from ./en/functions/pgsql.xml, last change in rev 1.16 -->
 <refentry xml:id="function.pg-set-error-verbosity" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>pg_set_error_verbosity</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>pg_set_error_verbosity</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>verbosity</parameter></methodparam>
   </methodsynopsis>
@@ -61,7 +61,7 @@
   <para>
    O nível de verbosidade anterior: <constant>PGSQL_ERRORS_TERSE</constant>,
    <constant>PGSQL_ERRORS_DEFAULT</constant>
-   ou <constant>PGSQL_ERRORS_VERBOSE</constant>.
+   ou <constant>PGSQL_ERRORS_VERBOSE</constant>, ou &false; em caso de falha.
   </para>
  </refsect1>
 


### PR DESCRIPTION
EN sync picked from https://doc.php.net/revcheck.php?lang=pt_br for the 11 outdated ``reference/pgsql/functions/*`` files. All EN diffs were mechanical signature refactors (parameter renames, ``string|false`` / ``int|false`` return-type unions, ``methodsynopsis`` adjustments). The portuguese descriptions and examples are kept untouched.

EN-Revision hashes bumped to current ``php/doc-en`` HEAD and ``Maintainer:`` set to ``lacatoire`` on each file.