### PR TITLE
Sync EN: mongodb BSON top-level classes

### DIFF
--- a/reference/mongodb/bson/binary.xml
+++ b/reference/mongodb/bson/binary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dac7a370d34ddda0a647ea551c28d6e168261613 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-binary" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\BSON\Binary intro -->
   <section xml:id="mongodb-bson-binary.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para dados binários (ou seja, array de bytes). Os valores binários também possuem um
     subtipo, que é usado para indicar que tipo de dados está no array de bytes.
     Os subtipos de zero a 127 são predefinidos ou reservados. Os subtipos de 128 a 255
     são definidos pelo usuário.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -134,101 +134,101 @@
     <varlistentry xml:id="mongodb-bson-binary.constants.type-generic">
      <term><constant>MongoDB\BSON\Binary::TYPE_GENERIC</constant></term>
      <listitem>
-      <para>Dados binários genéricos.</para>
+      <simpara>Dados binários genéricos.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-function">
      <term><constant>MongoDB\BSON\Binary::TYPE_FUNCTION</constant></term>
      <listitem>
-      <para>Função.</para>
+      <simpara>Função.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-old-binary">
      <term><constant>MongoDB\BSON\Binary::TYPE_OLD_BINARY</constant></term>
      <listitem>
-      <para>Dados binários genéricos (preterido em favor de <constant>MongoDB\BSON\Binary::TYPE_GENERIC</constant>).</para>
+      <simpara>Dados binários genéricos (preterido em favor de <constant>MongoDB\BSON\Binary::TYPE_GENERIC</constant>).</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-old-uuid">
      <term><constant>MongoDB\BSON\Binary::TYPE_OLD_UUID</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Identificador único universal (preterido em favor de
        <constant>MongoDB\BSON\Binary::TYPE_UUID</constant>). Ao usar este
        tipo, os dados binários precisam ter 16 bytes de comprimento.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Historicamente, outros drivers codificaram valores com este tipo com base em suas
        convenções de linguagem (ex.: variações little endian / big endian), o que o torna
        não portável. A extensão PHP não aplica nenhuma manipulação especial para codificar
        ou decodificar dados com este tipo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-uuid">
      <term><constant>MongoDB\BSON\Binary::TYPE_UUID</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Identificador único universal. Ao usar este tipo, os dados do binário
        devem ter 16 bytes de comprimento e codificados de acordo com a
        <link xlink:href="&url.rfc;4122">RFC 4122</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-md5">
      <term><constant>MongoDB\BSON\Binary::TYPE_MD5</constant></term>
      <listitem>
-      <para>Hash MD5. Ao usar este tipo, os dados do binário devem ter 16 bytes de comprimento.</para>
+      <simpara>Hash MD5. Ao usar este tipo, os dados do binário devem ter 16 bytes de comprimento.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-encrypted">
      <term><constant>MongoDB\BSON\Binary::TYPE_ENCRYPTED</constant></term>
      <listitem>
-      <para>Valor criptografado. Este subtipo é usado para criptografia do lado do cliente.</para>
+      <simpara>Valor criptografado. Este subtipo é usado para criptografia do lado do cliente.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-column">
      <term><constant>MongoDB\BSON\Binary::TYPE_COLUMN</constant></term>
      <listitem>
-      <para>Dados da coluna. Este subtipo é usado para coleções de séries temporais.</para>
+      <simpara>Dados da coluna. Este subtipo é usado para coleções de séries temporais.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-sensitive">
      <term><constant>MongoDB\BSON\Binary::TYPE_SENSITIVE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Dados confidenciais. Este subtipo é usado para dados confidenciais que devem ser
        excluídos do registro do servidor quando possível.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-vector">
      <term><constant>MongoDB\BSON\Binary::TYPE_VECTOR</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Dados do vetor. Este subtipo é usado para armazenar dados de vetor de forma eficiente para
        uso nas pesquisas de vetor do MongoDB.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-bson-binary.constants.type-user-defined">
      <term><constant>MongoDB\BSON\Binary::TYPE_USER_DEFINED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Tipo definido pelo usuário. Enquanto os tipos entre 0 e 127 são predefinidos ou
        reservados, os tipos entre 128 e 255 são definidos pelo usuário e podem ser usados ​​para
        qualquer coisa.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
@@ -238,66 +238,64 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.2.0</entry>
-        <entry>
-         Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_VECTOR</constant> e também as funções
-         <methodname>MongoDB\BSON\Binary::fromVector</methodname>,
-         <methodname>MongoDB\BSON\Binary::getVectorType</methodname> e
-         <methodname>MongoDB\BSON\Binary::toArray</methodname>.
-        </entry>
-       </row>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.17.0</entry>
-        <entry>
-         Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_SENSITIVE</constant>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         <para>
-          Implementada a interface <interfacename>Stringable</interfacename> para PHP 8.0+.
-         </para>
-         <para>
-          Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_COLUMN</constant>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.7.0</entry>
-        <entry>
-         Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_ENCRYPTED</constant>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementada a interface <interfacename>MongoDB\BSON\BinaryInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementadas as interfaces <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.2.0</entry>
+       <entry>
+        Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_VECTOR</constant> e também as funções
+        <methodname>MongoDB\BSON\Binary::fromVector</methodname>,
+        <methodname>MongoDB\BSON\Binary::getVectorType</methodname> e
+        <methodname>MongoDB\BSON\Binary::toArray</methodname>.
+       </entry>
+      </row>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.17.0</entry>
+       <entry>
+        Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_SENSITIVE</constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        <simpara>
+         Implementada a interface <interfacename>Stringable</interfacename> para PHP 8.0+.
+        </simpara>
+        <simpara>
+         Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_COLUMN</constant>.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        Adicionada a constante <constant>MongoDB\BSON\Binary::TYPE_ENCRYPTED</constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementada a interface <interfacename>MongoDB\BSON\BinaryInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementadas as interfaces <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/binaryinterface.xml
+++ b/reference/mongodb/bson/binaryinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-binaryinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,10 +9,10 @@
  <partintro>
   <section xml:id="mongodb-bson-binaryinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por <classname>MongoDB\BSON\Binary</classname>
     para ser usada como um parâmetro, um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-binaryinterface.synopsis">
@@ -31,22 +31,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/dbpointer.xml
+++ b/reference/mongodb/bson/dbpointer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-dbpointer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\BSON\DBPointer intro -->
   <section xml:id="mongodb-bson-dbpointer.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para o tipo "DBPointer". Este tipo BSON está preterido e esta
     classe não pode ser instanciada. Ele será criado a partir de um tipo BSON
     DBPointer durante a conversão de BSON para PHP e também pode ser convertida de volta para
     BSON durante o armazenamento de documentos no banco de dados.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -57,27 +57,25 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/decimal128.xml
+++ b/reference/mongodb/bson/decimal128.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-decimal128" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,19 +11,19 @@
 <!-- {{{ MongoDB\BSON\Decimal128 intro -->
   <section xml:id="mongodb-bson-decimal128.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para o
     <link xlink:href="&url.mongodb.wiki.decimal128;">formato de ponto flutuante Decimal128</link>,
     que suporta números com até 34 dígitos decimais (ou seja, dígitos
     significativos) e um intervalo de expoentes de -6143 a +6144.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Ao contrário do tipo BSON "double" (ou seja, <type>float</type> em PHP), que armazena
     apenas uma aproximação dos valores decimais, o tipo de dados decimal armazena
     o valor exato. Por exemplo, <literal>MongoDB\BSON\Decimal128('9.99')</literal>
     tem um valor preciso de 9.99, onde um "double" 9.99 teria um valor aproximado
     de 9.990000000000002131628….
-   </para>
+   </simpara>
    &mongodb.note.decimal128;
   </section>
 <!-- }}} -->
@@ -69,40 +69,38 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\Decimal128Interface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\Decimal128Interface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/decimal128interface.xml
+++ b/reference/mongodb/bson/decimal128interface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-decimal128interface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,11 +9,11 @@
  <partintro>
   <section xml:id="mongodb-bson-decimal128interface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por
     <classname>MongoDB\BSON\Decimal128</classname> para ser usada como um parâmetro,
     um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-decimal128interface.synopsis">
@@ -31,22 +31,20 @@
   </section>
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/document.xml
+++ b/reference/mongodb/bson/document.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\BSON\Document intro -->
   <section xml:id="mongodb-bson-document.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Representa um documento BSON. Esta classe é usada ao ler dados como BSON bruto
     e não pode ser modificada.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -55,27 +55,25 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.17.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\Type</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.17.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\Type</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/int64.xml
+++ b/reference/mongodb/bson/int64.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-int64" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,15 +11,15 @@
 <!-- {{{ MongoDB\BSON\Int64 intro -->
   <section xml:id="mongodb-bson-int64.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para um número inteiro de 64 bits. Ao decodificar dados BSON para PHP, esta classe
     é usada quando um número inteiro de 64 bits não pode ser representado como um número inteiro PHP em
     plataformas de 32 bits. Esses objetos suportam operadores sobrecarregados
     <link linkend="language.operators.arithmetic">aritméticos</link>,
     <link linkend="language.operators.bitwise">binários</link> e
     <link linkend="language.operators.comparison">comparativos</link>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Ao trabalhar com dados BSON brutos através das classes
     <classname>MongoDB\BSON\Document</classname>,
     <classname>MongoDB\BSON\PackedArray</classname> e
@@ -27,12 +27,12 @@
     será retornado como uma instância desta classe, independentemente da plataforma e
     se o valor pode ser representado como um número inteiro PHP. Isso garante que
     os valores possam ser percorridos sem alterar o tipo.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Durante a codificação BSON, os objetos desta classe serão convertidos novamente para
     um tipo inteiro de 64 bits, mesmo se o valor couber em um número inteiro de 32 bits. Isso
     permite armazenar valores como inteiros de 64 bits explicitamente no BSON.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -73,34 +73,32 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.16.0</entry>
-        <entry>
-         A classe agora pode ser instanciada em todas as plataformas. Adicionado suporte para
-         operadores sobrecarregados aritméticos, binários e comparativos.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.16.0</entry>
+       <entry>
+        A classe agora pode ser instanciada em todas as plataformas. Adicionado suporte para
+        operadores sobrecarregados aritméticos, binários e comparativos.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/iterator.xml
+++ b/reference/mongodb/bson/iterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-iterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\BSON\Iterator intro -->
   <section xml:id="mongodb-bson-iterator.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Iterador usado para iterar sobre um documento ou array BSON.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/bson/javascript.xml
+++ b/reference/mongodb/bson/javascript.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-javascript" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
 <!-- {{{ MongoDB\BSON\Javascript intro -->
   <section xml:id="mongodb-bson-javascript.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para código Javascript. Um documento de escopo opcional pode ser especificado
     para mapear identificadores para valores e definir o escopo no qual o código
     deve ser avaliado pelo servidor.
-   </para>
+   </simpara>
    <note>
     <simpara>
      Este tipo BSON é usado principalmente ao executar comandos de banco de dados que usam uma
@@ -67,40 +67,38 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\JavascriptInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\JavascriptInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/javascriptinterface.xml
+++ b/reference/mongodb/bson/javascriptinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-javascriptinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,11 +9,11 @@
  <partintro>
   <section xml:id="mongodb-bson-javascriptinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por
     <classname>MongoDB\BSON\Javascript</classname> para ser usada como um parâmetro,
     um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-javascriptinterface.synopsis">
@@ -32,22 +32,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/maxkey.xml
+++ b/reference/mongodb/bson/maxkey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-maxkey" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\BSON\MaxKey intro -->
   <section xml:id="mongodb-bson-maxkey.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON especial que compara valores superiores a todos os outros valores de elemento
     BSON possíveis.
-   </para>
+   </simpara>
    <note>
     <simpara>
      Este é um tipo interno do MongoDB usado para indexação e fragmentação.
@@ -60,34 +60,32 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\MaxKeyInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\MaxKeyInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/maxkeyinterface.xml
+++ b/reference/mongodb/bson/maxkeyinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-maxkeyinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,10 +9,10 @@
  <partintro>
   <section xml:id="mongodb-bson-maxkeyinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por <classname>MongoDB\BSON\MaxKey</classname>
     para ser usada como um parâmetro, um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-maxkeyinterface.synopsis">
@@ -26,9 +26,9 @@
     </classsynopsisinfo>
    </classsynopsis>
 
-   <para>
+   <simpara>
     Esta interface não tem métodos.
-   </para>
+   </simpara>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/minkey.xml
+++ b/reference/mongodb/bson/minkey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-minkey" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\BSON\MinKey intro -->
   <section xml:id="mongodb-bson-minkey.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON especial que compara valores inferiores a todos os outros valores de elemento
     BSON possíveis.
-   </para>
+   </simpara>
    <note>
     <simpara>
      Este é um tipo interno do MongoDB usado para indexação e fragmentação.
@@ -60,34 +60,32 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\MinKeyInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\MinKeyInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/minkeyinterface.xml
+++ b/reference/mongodb/bson/minkeyinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-minkeyinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,10 +9,10 @@
  <partintro>
   <section xml:id="mongodb-bson-minkeyinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por <classname>MongoDB\BSON\MinKey</classname>
     para ser usada como um parâmetro, um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-minkeyinterface.synopsis">
@@ -26,9 +26,9 @@
     </classsynopsisinfo>
    </classsynopsis>
 
-   <para>
+   <simpara>
     Esta interface não tem métodos.
-   </para>
+   </simpara>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/objectid.xml
+++ b/reference/mongodb/bson/objectid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-objectid" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,27 +11,27 @@
 <!-- {{{ MongoDB\BSON\ObjectId intro -->
   <section xml:id="mongodb-bson-objectid.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para um
     <link xlink:href="&url.mongodb.docs.bson;#objectid">ObjectId</link>. O
     valor consiste em 12 bytes, onde os primeiros quatro bytes são um timestamp
     que reflete a criação do ObjectId. Especificamente, o valor consiste em:
-   </para>
+   </simpara>
    <itemizedlist>
     <listitem><simpara>um valor de 4 bytes que representa os segundos desde a época Unix,</simpara></listitem>
     <listitem><simpara>um número aleatório de 5 bytes único para um equipamento e um processo, e</simpara></listitem>
     <listitem><simpara>um contador de 3 bytes, começando com um valor aleatório.</simpara></listitem>
    </itemizedlist>
-   <para>
+   <simpara>
     No MongoDB, cada documento armazenado em uma coleção requer um campo
     <literal>_id</literal> exclusivo que atua como chave primária. Se um documento
     inserido omitir o campo <literal>_id</literal>, a extensão gera automaticamente
     um ObjectId para o campo <literal>_id</literal>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Usar ObjectIds para o campo <literal>_id</literal> fornece os seguintes
     benefícios adicionais:
-   </para>
+   </simpara>
    <itemizedlist>
     <listitem><simpara>O horário de criação do ObjectId pode ser acessado usando o método <methodname>MongoDB\BSON\ObjectId::getTimestamp</methodname>.</simpara></listitem>
     <listitem><simpara>A classificação em um campo <literal>_id</literal> que armazena valores ObjectId é aproximadamente equivalente à classificação por horário de criação.</simpara></listitem>
@@ -80,46 +80,44 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         <para>
-          Renomeado de <literal>MongoDB\BSON\ObjectID</literal> para
-          <literal>MongoDB\BSON\ObjectId</literal>.
-         </para>
-         <para>
-          Implementa <interfacename>MongoDB\BSON\ObjectIdInterface</interfacename>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        <simpara>
+         Renomeado de <literal>MongoDB\BSON\ObjectID</literal> para
+         <literal>MongoDB\BSON\ObjectId</literal>.
+        </simpara>
+        <simpara>
+         Implementa <interfacename>MongoDB\BSON\ObjectIdInterface</interfacename>.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/objectidinterface.xml
+++ b/reference/mongodb/bson/objectidinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-objectidinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,11 +9,11 @@
  <partintro>
   <section xml:id="mongodb-bson-objectidinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por
     <classname>MongoDB\BSON\ObjectId</classname> para ser usada como um parâmetro,
     um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-objectidinterface.synopsis">
@@ -32,22 +32,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/packedarray.xml
+++ b/reference/mongodb/bson/packedarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-packedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\BSON\PackedArray intro -->
   <section xml:id="mongodb-bson-packedarray.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Representa um array BSON. Esta classe é usada ao ler dados como BSON bruto
     e não pode ser modificada.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -55,35 +55,33 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.17.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\Type</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.17.0</entry>
-        <entry>
-         <classname>MongoDB\BSON\PackedArray</classname> não pode ser serializado
-         em contextos onde um documento BSON é esperado. Nas versões anteriores,
-         o array BSON teria sido convertido em um documento.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.17.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\Type</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.17.0</entry>
+       <entry>
+        <classname>MongoDB\BSON\PackedArray</classname> não pode ser serializado
+        em contextos onde um documento BSON é esperado. Nas versões anteriores,
+        o array BSON teria sido convertido em um documento.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/persistable.xml
+++ b/reference/mongodb/bson/persistable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-persistable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,7 +11,7 @@
 <!-- {{{ MongoDB\BSON\Persistable intro -->
   <section xml:id="mongodb-bson-persistable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     As classes podem implementar esta interface para aproveitar o comportamento automático
     do ODM (mapeamento de documento de objeto) na extensão. Durante a serialização,
     a extensão injetará uma propriedade <property>__pclass</property>
@@ -24,7 +24,7 @@
     <function>MongoDB\BSON\Unserializable::bsonUnserialize</function> ser
     invocada. Consulte <xref linkend="mongodb.persistence"/> para obter
     informações adicionais.
-   </para>
+   </simpara>
    <note>
     <simpara>
      Mesmo que <function>MongoDB\BSON\Serializable::bsonSerialize</function> retorne

--- a/reference/mongodb/bson/regex.xml
+++ b/reference/mongodb/bson/regex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-regex" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\BSON\Regex intro -->
   <section xml:id="mongodb-bson-regex.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para um padrão de expressão regular e
     <link xlink:href="&url.mongodb.docs.regex;#op._S_options">opções</link> adicionais.
-   </para>
+   </simpara>
    <note>
     <simpara>
      Este tipo BSON é usado principalmente ao consultar o banco de dados. Alternativamente,
@@ -67,40 +67,38 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\RegexInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\RegexInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/regexinterface.xml
+++ b/reference/mongodb/bson/regexinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-regexinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,10 +9,10 @@
  <partintro>
   <section xml:id="mongodb-bson-regexinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por <classname>MongoDB\BSON\Regex</classname>
     para ser usada como um parâmetro, um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-regexinterface.synopsis">
@@ -31,22 +31,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/serializable.xml
+++ b/reference/mongodb/bson/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\BSON\Serializable intro -->
   <section xml:id="mongodb-bson-serializable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     As classes que implementam esta interface podem retornar dados para serem serializados como um
     array ou documento BSON no lugar das propriedades públicas do objeto.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -46,22 +46,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/symbol.xml
+++ b/reference/mongodb/bson/symbol.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-symbol" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\BSON\Symbol intro -->
   <section xml:id="mongodb-bson-symbol.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para o tipo "Símbolo". Este tipo BSON está preterido e esta
     classe não pode ser instanciada. Ele será criado a partir de um tipo de símbolo
     BSON durante a conversão de BSON para PHP e também pode ser convertido novamente em
     BSON durante o armazenamento de documentos no banco de dados.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -57,27 +57,25 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/timestamp.xml
+++ b/reference/mongodb/bson/timestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-timestamp" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\BSON\Timestamp intro -->
   <section xml:id="mongodb-bson-timestamp.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Representa um
     <link xlink:href="&url.mongodb.docs.bson;#timestamps">timestamp BSON</link>.
     O valor consiste em um timestamp de 4 bytes (ou seja, segundos desde a época)
     e um incremento de 4 bytes.
-   </para>
+   </simpara>
    <note>
     <simpara>
      Este é um tipo interno do MongoDB usado para replicação e fragmentação. Não se
@@ -68,40 +68,38 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\TimestampInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\TimestampInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/timestampinterface.xml
+++ b/reference/mongodb/bson/timestampinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-timestampinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,11 +9,11 @@
  <partintro>
   <section xml:id="mongodb-bson-timestampinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por
     <classname>MongoDB\BSON\Timestamp</classname> para ser usada como um parâmetro,
     um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-timestampinterface.synopsis">
@@ -32,22 +32,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/type.xml
+++ b/reference/mongodb/bson/type.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-type" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\BSON\Type intro -->
   <section xml:id="mongodb-bson-type.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Interface base abstrata que não deve ser implementada diretamente.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -35,10 +35,10 @@
    </classsynopsis>
 <!-- }}} -->
 
-   <para>
+   <simpara>
     Esta interface não tem métodos. Seu único propósito é ser a interface base
     para todas as classes do tipo BSON.
-   </para>
+   </simpara>
 
   </section>
 

--- a/reference/mongodb/bson/undefined.xml
+++ b/reference/mongodb/bson/undefined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-undefined" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\BSON\Undefined intro -->
   <section xml:id="mongodb-bson-undefined.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Tipo BSON para o tipo "Undefined". Este tipo BSON está preterido e esta
     classe não pode ser instanciada. Ele será criado a partir de um tipo indefinido
     BSON durante a conversão de BSON para PHP e também pode ser convertido novamente em
     BSON durante o armazenamento de documentos no banco de dados.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -57,27 +57,25 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/unserializable.xml
+++ b/reference/mongodb/bson/unserializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-unserializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
 <!-- {{{ MongoDB\BSON\Unserializable intro -->
   <section xml:id="mongodb-bson-unserializable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     As classes que implementam esta interface podem ser especificadas em um
     <link linkend="mongodb.persistence.typemaps">mapa de tipos</link> para
     desserializar arrays e documentos BSON (nativos e incorporados).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -43,22 +43,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/utcdatetime.xml
+++ b/reference/mongodb/bson/utcdatetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-utcdatetime" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\BSON\UTCDatetime intro -->
   <section xml:id="mongodb-bson-utcdatetime.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Representa uma
     <link xlink:href="&url.mongodb.docs.bson;#date">data BSON</link>. O valor
     é um número inteiro de 64 bits que representa o número de milissegundos desde a
     época Unix (1º de janeiro de 1970). Valores negativos representam datas anteriores a 1970.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -61,40 +61,38 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.serializable-interface-removed;
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.3.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\BSON\UTCDateTimeInterface</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename> e
-         <interfacename>JsonSerializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.serializable-interface-removed;
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\BSON\UTCDateTimeInterface</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename> e
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/utcdatetimeinterface.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-bson-utcdatetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,11 +9,11 @@
  <partintro>
   <section xml:id="mongodb-bson-utcdatetimeinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por
     <classname>MongoDB\BSON\UTCDateTime</classname> para ser usada como um parâmetro,
     um retorno, ou um tipo de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-utcdatetimeinterface.synopsis">
@@ -32,22 +32,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/vectortype.xml
+++ b/reference/mongodb/bson/vectortype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dac7a370d34ddda0a647ea551c28d6e168261613 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="enum.mongodb-bson-vectortype" role="enum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,11 +9,11 @@
  <partintro>
   <section xml:id="mongodb-bson-vectortype.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A enumeração <enumname>MongoDB\BSON\VectorType</enumname> é usada para especificar o tipo de
     dados de vetor armazenados em um <classname>MongoDB\BSON\Binary</classname> com o
     subtipo <constant>MongoDB\BSON\Binary::TYPE_VECTOR</constant>.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="mongodb-bson-vectortype.synopsis">


### PR DESCRIPTION
30 ``reference/mongodb/bson/*.xml`` BSON class/interface refentries: mechanical refactor only (``<para>`` → ``<simpara>`` on short intros, ``<para>`` wrapper dropped around ``<informaltable>`` in changelog sections). Portuguese prose untouched. EN-Revision hashes bumped to ``9f4cb232...``, ``Maintainer: lacatoire``.

The 7 ``reference/mongodb/*.xml`` chapters listed by revcheck were already at the EN HEAD locally and therefore left out.