### PR TITLE
Sync EN: mongodb BSON methods (binary..document)

### DIFF
--- a/reference/mongodb/bson/binary/construct.xml
+++ b/reference/mongodb/bson/binary/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c7fbc342dffb14f19f84b5ba8883624b69df5262 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,17 +22,17 @@
    <varlistentry>
     <term><parameter>data</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Dados binários.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>type</parameter> (<type>int</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Inteiro de 8 bits sem sinal denotando o tipo de dados. O padrão é <constant>MongoDB\BSON\Binary::TYPE_GENERIC</constant> se não especificado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -49,51 +49,49 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        <para>
-         O padrão para o parâmetro <parameter>type</parameter> é
-         <constant>MongoDB\BSON\Binary::TYPE_GENERIC</constant> se não for especificado.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-         é lançada se <parameter>type</parameter> for
-         <constant>MongoDB\BSON\Binary::TYPE_UUID</constant> ou
-         <constant>MongoDB\BSON\Binary::TYPE_OLD_UUID</constant> e
-         <parameter>data</parameter> não tiver exatamente 16 bytes.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.1.3</entry>
-       <entry>
-        <para>
-         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-         é lançada se <parameter>type</parameter> não for um inteiro de 8 bits
-         sem sinal.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       <simpara>
+        O padrão para o parâmetro <parameter>type</parameter> é
+        <constant>MongoDB\BSON\Binary::TYPE_GENERIC</constant> se não for especificado.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        é lançada se <parameter>type</parameter> for
+        <constant>MongoDB\BSON\Binary::TYPE_UUID</constant> ou
+        <constant>MongoDB\BSON\Binary::TYPE_OLD_UUID</constant> e
+        <parameter>data</parameter> não tiver exatamente 16 bytes.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.1.3</entry>
+      <entry>
+       <simpara>
+        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        é lançada se <parameter>type</parameter> não for um inteiro de 8 bits
+        sem sinal.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/binary/fromvector.xml
+++ b/reference/mongodb/bson/binary/fromvector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dac7a370d34ddda0a647ea551c28d6e168261613 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.fromvector" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -35,9 +35,9 @@
    <varlistentry>
     <term><parameter>vectorType</parameter> (<type>MongoDB\BSON\VectorType</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       O tipo de dados do vetor.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um novo binário com subtipo <constant>MongoDB\BSON\Binary::SUBTYPE_VECTOR</constant>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/binary/getdata.xml
+++ b/reference/mongodb/bson/binary/getdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.getdata" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna os dados de Binary.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/binary/gettype.xml
+++ b/reference/mongodb/bson/binary/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o tipo de Binary.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/binary/getvectortype.xml
+++ b/reference/mongodb/bson/binary/getvectortype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dac7a370d34ddda0a647ea551c28d6e168261613 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.getvectortype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o tipo de dados do vetor binário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/binary/jsonserialize.xml
+++ b/reference/mongodb/bson/binary/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\Binary</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/binary/toarray.xml
+++ b/reference/mongodb/bson/binary/toarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dac7a370d34ddda0a647ea551c28d6e168261613 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.toarray" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array contendo os dados do vetor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/binary/tostring.xml
+++ b/reference/mongodb/bson/binary/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binary.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Binary::__toString</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    &info.method.alias; <methodname>MongoDB\BSON\Binary::getData</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna string representando os dados de Binary.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/binaryinterface/getdata.xml
+++ b/reference/mongodb/bson/binaryinterface/getdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binaryinterface.getdata" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna os dados da BinaryInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/binaryinterface/gettype.xml
+++ b/reference/mongodb/bson/binaryinterface/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binaryinterface.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o tipo da BinaryInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/binaryinterface/tostring.xml
+++ b/reference/mongodb/bson/binaryinterface/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-binaryinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\BinaryInterface::__toString</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    &info.method.alias; <methodname>MongoDB\BSON\BinaryInterface::getData</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna os dados da BinaryInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/dbpointer/construct.xml
+++ b/reference/mongodb/bson/dbpointer/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aaaeefbb399293b9b61bc84b8b5593d3132850ca Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-dbpointer.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\DBPointer::__construct</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Objetos <classname>MongoDB\BSON\DBPointer</classname> são criados através da
    conversão de um tipo BSON preterido e não podem ser construídos diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/bson/dbpointer/jsonserialize.xml
+++ b/reference/mongodb/bson/dbpointer/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-dbpointer.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\DBPointer</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/dbpointer/tostring.xml
+++ b/reference/mongodb/bson/dbpointer/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-dbpointer.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma string vazia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/decimal128/construct.xml
+++ b/reference/mongodb/bson/decimal128/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-decimal128.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
    <varlistentry>
     <term><parameter>value</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Uma string decimal.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/bson/decimal128/jsonserialize.xml
+++ b/reference/mongodb/bson/decimal128/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-decimal128.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\Decimal128</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/decimal128/tostring.xml
+++ b/reference/mongodb/bson/decimal128/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-decimal128.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste Decimal128.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/decimal128interface/tostring.xml
+++ b/reference/mongodb/bson/decimal128interface/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-decimal128interface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste Decimal128Interface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/document/construct.xml
+++ b/reference/mongodb/bson/document/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\Document::__construct</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Objetos <classname>MongoDB\BSON\Document</classname> são criados através de
    métodos estáticos de fabricação e não podem ser instanciados diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/bson/document/frombson.xml
+++ b/reference/mongodb/bson/document/frombson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.frombson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,9 +21,9 @@
    <varlistentry>
     <term><parameter>bson</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Uma string contendo um documento no formato BSON.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -31,9 +31,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma nova instância de <classname>MongoDB\BSON\Document</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/fromjson.xml
+++ b/reference/mongodb/bson/document/fromjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.fromjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>static</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Document</type><methodname>MongoDB\BSON\Document::fromJSON</methodname>
    <methodparam><type>string</type><parameter>json</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte uma string
    <link xlink:href="&url.mongodb.docs.extendedjson;">JSON estendida</link>
    na sua representação BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
    <varlistentry>
     <term><parameter>json</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor JSON a ser convertido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma nova instância de <classname>MongoDB\BSON\Document</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/fromphp.xml
+++ b/reference/mongodb/bson/document/fromphp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,11 +21,11 @@
    <varlistentry>
     <term><parameter>value</parameter> (<type class="union"><type>object</type><type>array</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto ou array do PHP contendo o documento. Ao passar um array com
       chaves numéricas, os valores numéricos são convertidos para strings e usados como
       chaves do documento.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma nova instância de <classname>MongoDB\BSON\Document</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/get.xml
+++ b/reference/mongodb/bson/document/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,9 +21,9 @@
    <varlistentry>
     <term><parameter>key</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       A chave a ser recuperada do documento.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -31,10 +31,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o valor associado com a chave informada. Se a chave não estiver presente no
    documento, uma exceção é lançada.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao encontrar um valor codificado como inteiro de 64 bits no documento BSON,

--- a/reference/mongodb/bson/document/getiterator.xml
+++ b/reference/mongodb/bson/document/getiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma instância de <classname>MongoDB\BSON\Iterator</classname> que pode ser
    usada para iterar sobre todas as chaves do documento.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/has.xml
+++ b/reference/mongodb/bson/document/has.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,9 +21,9 @@
    <varlistentry>
     <term><parameter>key</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       A chave a ser procurada no documento.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -31,9 +31,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se a chave estiver presente no documento ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/offsetexists.xml
+++ b/reference/mongodb/bson/document/offsetexists.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-document.offsetexists" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\Document::offsetExists</refname>
@@ -20,9 +20,9 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A chave a ser procurada no documento.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -31,9 +31,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se a chave estiver presente no documento ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/document/offsetget.xml
+++ b/reference/mongodb/bson/document/offsetget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-document.offsetget" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\Document::offsetGet</refname>
@@ -20,9 +20,9 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A chave a ser recuperada do documento.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -31,10 +31,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o valor associado com a chave informada. Se a chave não estiver presente no
    documento, uma exceção é lançada.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao encontrar um valor codificado como inteiro de 64 bits no documento BSON,

--- a/reference/mongodb/bson/document/offsetset.xml
+++ b/reference/mongodb/bson/document/offsetset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-document.offsetset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\Document::offsetSet</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Define o valor na chave especificada <parameter>key</parameter> para <parameter>value</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +25,17 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice da chave sendo definida.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O novo valor para a chave <parameter>key</parameter>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/offsetunset.xml
+++ b/reference/mongodb/bson/document/offsetunset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-document.offsetunset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\Document::offsetUnset</refname>
@@ -11,9 +11,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetUnset</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Remove a definição do valor no índice especificado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice que será removido.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/document/tocanonicalextendedjson.xml
+++ b/reference/mongodb/bson/document/tocanonicalextendedjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.tocanonicalextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,14 +13,14 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte o documento BSON para sua representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">JSON Estendida Canônica</link>
    O formato canônico prefere a fidelidade de tipo em detrimento da
    saída concisa e é mais adequado para produzir saída que pode ser convertida
    de volta para BSON sem qualquer perda de informação de tipo (por exemplo, os tipos numéricos
    permanecerão diferenciados).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,11 +30,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma string contendo a representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">JSON Canônica Estendida</link>
    do documento BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/document/tophp.xml
+++ b/reference/mongodb/bson/document/tophp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\BSON\Document::toPHP</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>typeMap</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Desserializa o documento BSON para sua representação em PHP. O
    parâmetro <parameter>typeMap</parameter> pode ser usado para controlar os tipos PHP
    usados para converter arrays e documentos BSON (tanto nativos quanto integrados).
-  </para>
+  </simpara>
   &mongodb.warning.duplicate-keys;
  </refsect1>
 
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor decodificado em PHP.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao encontrar um valor codificado como inteiro de 64 bits no documento BSON,

--- a/reference/mongodb/bson/document/torelaxedextendedjson.xml
+++ b/reference/mongodb/bson/document/torelaxedextendedjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.torelaxedextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte o documento BSON para sua representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">JSON Estentida Relaxada</link>
    O formato relaxado prefere o uso de primitivos do tipo JSON em
    detrimento da fidelidade de tipo e é mais adequado para produzir resultados que podem ser
    facilmente consumidos por APIs da web e humanos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,11 +29,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma string contendo a representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">JSON Estendida Relaxada</link>
    do documento BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/document/tostring.xml
+++ b/reference/mongodb/bson/document/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-document.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste documento como BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
33 BSON method refentries (binary, binaryinterface, dbpointer, decimal128, decimal128interface, document): mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose untouched. Hashes bumped, ``Maintainer: lacatoire``.