### PR TITLE
Sync EN: mongodb BSON methods (maxkey..utcdatetime)

### DIFF
--- a/reference/mongodb/bson/maxkey/jsonserialize.xml
+++ b/reference/mongodb/bson/maxkey/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-maxkey.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\MaxKey</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/minkey/jsonserialize.xml
+++ b/reference/mongodb/bson/minkey/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-minkey.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\MinKey</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/objectid/construct.xml
+++ b/reference/mongodb/bson/objectid/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-objectid.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,10 +21,10 @@
    <varlistentry>
     <term><parameter>id</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Uma string hexadecimal de 24 caracteres Se não informada, a extensão irá
       gerar um ObjectId.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/bson/objectid/gettimestamp.xml
+++ b/reference/mongodb/bson/objectid/gettimestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-objectid.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\BSON\ObjectId::getTimestamp</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O componente timestamp de um ObjectId são seus 32 bits mais significativos, o que
    denota o número de segundos desde a época Unix. Este valor é lido como um
    número inteiro sem sinal de 32 bits com ordem de bytes big-endian.
-  </para>
+  </simpara>
   &mongodb.note.uint32;
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o componente timestamp deste ObjectId.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/objectid/jsonserialize.xml
+++ b/reference/mongodb/bson/objectid/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-objectid.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\ObjectId</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/objectid/tostring.xml
+++ b/reference/mongodb/bson/objectid/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-objectid.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação hexidecimal deste ObjectId.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/objectidinterface/gettimestamp.xml
+++ b/reference/mongodb/bson/objectidinterface/gettimestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-objectidinterface.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    etorna o componente timestamp deste ObjectIdInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/objectidinterface/tostring.xml
+++ b/reference/mongodb/bson/objectidinterface/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-objectidinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação hexidecimal deste ObjectIdInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/packedarray/construct.xml
+++ b/reference/mongodb/bson/packedarray/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\PackedArray::__construct</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Objetos <classname>MongoDB\BSON\PackedArray</classname> são criados através de
    métodos estáticos de fabricação e não podem ser instanciados diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/bson/packedarray/fromjson.xml
+++ b/reference/mongodb/bson/packedarray/fromjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.fromjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::fromJSON</refname>
@@ -12,11 +12,11 @@
    <modifier>final</modifier> <modifier>static</modifier> <modifier>public</modifier> <type>MongoDB\BSON\PackedArray</type><methodname>MongoDB\BSON\PackedArray::fromJSON</methodname>
    <methodparam><type>string</type><parameter>json</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte uma string em
    <link xlink:href="&url.mongodb.docs.extendedjson;">JSON estendido</link>
    para sua representação BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>json</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor JSON a ser convertido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma nova instância de <classname>MongoDB\BSON\PackedArray</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/packedarray/fromphp.xml
+++ b/reference/mongodb/bson/packedarray/fromphp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,10 +21,10 @@
    <varlistentry>
     <term><parameter>value</parameter> (<type>array</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       O array PHP a ser convertido para um array BSON. O array precisa ser uma lista (isto é,
       ter chaves sequenciais numéricas iniciando com <literal>0</literal>).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retonar uma nova instância de <classname>MongoDB\BSON\PackedArray</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/packedarray/get.xml
+++ b/reference/mongodb/bson/packedarray/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,9 +21,9 @@
    <varlistentry>
     <term><parameter>key</parameter> (<type>int</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       O índice a ser obtido do array.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -31,10 +31,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o valor associado com o índice informado. Se o índice não estiver
    presente no array, uma exceção é lançada.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao encontrar um valor codificado como inteiro de 64 bits no array BSON,

--- a/reference/mongodb/bson/packedarray/getiterator.xml
+++ b/reference/mongodb/bson/packedarray/getiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma instância de <classname>MongoDB\BSON\Iterator</classname> que pode ser
    usada para iterar sobre todos os índices no array.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/packedarray/has.xml
+++ b/reference/mongodb/bson/packedarray/has.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,9 +21,9 @@
    <varlistentry>
     <term><parameter>index</parameter> (<type>int</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       O índice a ser procurado no array.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -31,9 +31,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se o índice estiver presente no array ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/packedarray/offsetexists.xml
+++ b/reference/mongodb/bson/packedarray/offsetexists.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.offsetexists" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::offsetExists</refname>
@@ -20,9 +20,9 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice a ser procurado no array.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -31,9 +31,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se o índice estiver presente no array ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.offsetget" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::offsetGet</refname>
@@ -20,9 +20,9 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice a ser obtido do array. Somente <type>int</type> é suportado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -31,10 +31,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o valor associado com o índice informado. Se o índice não estiver
    presente no array, uma exceção é lançada.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao encontrar um valor codificado como inteiro de 64 bits no array BSON,

--- a/reference/mongodb/bson/packedarray/offsetset.xml
+++ b/reference/mongodb/bson/packedarray/offsetset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.offsetset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::offsetSet</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Define o valor na chave especificada em <parameter>key</parameter> para <parameter>value</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +25,17 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice a ser definido.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O novo valor para <parameter>key</parameter>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/packedarray/offsetunset.xml
+++ b/reference/mongodb/bson/packedarray/offsetunset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.offsetunset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::offsetUnset</refname>
@@ -11,9 +11,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetUnset</methodname>
    <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Remove a definição do valor no índice especificado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice que será removido.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/packedarray/tocanonicalextendedjson.xml
+++ b/reference/mongodb/bson/packedarray/tocanonicalextendedjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.tocanonicalextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::toCanonicalExtendedJSON</refname>
@@ -12,14 +12,14 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\PackedArray::toCanonicalExtendedJSON</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte o array BSON em sua representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">JSON Estendida Canônica</link>.
    O formato canônico prefere a fidelidade de tipo em detrimento da
    saída concisa e é mais adequado para produzir saída que pode ser convertida
    de volta para BSON sem qualquer perda de informação de tipo (por exemplo, os tipos numéricos
    permanecerão diferenciados).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,11 +29,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma string contendo a representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">JSON Estendida Canônica</link>
    do array BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/packedarray/tophp.xml
+++ b/reference/mongodb/bson/packedarray/tophp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor PHP decodificado.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao encontrar um valor codificado como inteiro de 64 bits no array BSON,

--- a/reference/mongodb/bson/packedarray/torelaxedextendedjson.xml
+++ b/reference/mongodb/bson/packedarray/torelaxedextendedjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c84b0297195da8c0c2dad2d33f2c143dd3421b0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-bson-packedarray.torelaxedextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\PackedArray::toRelaxedExtendedJSON</refname>
@@ -12,13 +12,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\PackedArray::toRelaxedExtendedJSON</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte o array BSON em sua representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">JSON estendida relaxada</link>.
    O formato relaxado prefere o uso de primitivos do tipo JSON em
    detrimento da fidelidade do tipo e é mais adequado para produzir resultados que podem ser
    facilmente consumidos por APIs da web e humanos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,11 +28,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma string contendo a representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">JSON estendida relaxada</link>
    do array BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/packedarray/tostring.xml
+++ b/reference/mongodb/bson/packedarray/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-packedarray.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste array BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/persistable/bsonserialize.xml
+++ b/reference/mongodb/bson/persistable/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e3c3525f7f288bc3a455a9619215fa759c2a9f5f Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-persistable.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,25 +13,25 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>stdClass</type><type>MongoDB\BSON\Document</type></type><methodname>MongoDB\BSON\Persistable::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Chamado durante a serialização do objeto para BSON. O método precisa retornar um
    <type>array</type>, uma <classname>stdClass</classname> ou
    um <classname>MongoDB\BSON\Document</classname>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O valor de retorno sempre será serializado como um documento BSON. O documento
    serializado irá incluir um campo contendo o nome da classe do objeto. Por
    esta razão, não é possível retornar uma instância de
    <classname>MongoDB\BSON\PackedArray</classname> neste método.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Usuários são encorajados a incluir uma propriedade <property>_id</property> (ex.: um
    <classname>MongoDB\BSON\ObjectId</classname> inicializado no construtor)
    ao retornar dados para um documento nativo BSON. Na ausência se uma
    propriedade <property>_id</property>, a extensão ou servidor irá gerar um
    <classname>MongoDB\BSON\ObjectId</classname> para operações de inserção ou
    atualização, respectivamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,38 +41,36 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Um <type>array</type>, uma <classname>stdClass</classname> ou um <classname>MongoDB\BSON\Document</classname>
    a ser serializado como um documento BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.tentative-return-types-enforced;
-      <row>
-       <entry>PECL mongodb 1.17.0</entry>
-       <entry>
-        <para>
-         Este método agora também pode retornar instâncias de <classname>MongoDB\BSON\Document</classname>
-         além de um <type>array</type> e uma <classname>stdClass</classname>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.tentative-return-types-enforced;
+     <row>
+      <entry>PECL mongodb 1.17.0</entry>
+      <entry>
+       <simpara>
+        Este método agora também pode retornar instâncias de <classname>MongoDB\BSON\Document</classname>
+        além de um <type>array</type> e uma <classname>stdClass</classname>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/regex/construct.xml
+++ b/reference/mongodb/bson/regex/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af5f2f87b3b0bb9ee0f83ccb787a4e7db1eb6bd4 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-regex.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
    <varlistentry>
     <term><parameter>pattern</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       A expressão regular.
-     </para>
+     </simpara>
      <note>
       <simpara>
        A expressão não deve ser envolvida por caracteres delimitadores.
@@ -35,11 +35,11 @@
    <varlistentry>
     <term><parameter>flags</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       As <link xlink:href="&url.mongodb.docs.regex;#op._S_options">opções
       de expressões regulares</link>. Caracteres neste argumento serão ordenados
       alfabeticamente.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -55,40 +55,38 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         O argumento <parameter>flags</parameter> é opcional e seu padrão
-         é uma string vazia.
-        </para>
-        <para>
-         Caracteres no argumento <parameter>flags</parameter> serão ordenados
-         alfabeticamente quando um Regex for construído. Anteriormente, os caracteres
-         seriam armazenados na ordem em que fossem informados.
-        </para>
-        <para>
-         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-         é lançada se <parameter>pattern</parameter> ou
-         <parameter>flags</parameter> contiverem bytes nulos. Anteriormente, valores
-         seriam truncados no primeiro byte nulo.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        O argumento <parameter>flags</parameter> é opcional e seu padrão
+        é uma string vazia.
+       </simpara>
+       <simpara>
+        Caracteres no argumento <parameter>flags</parameter> serão ordenados
+        alfabeticamente quando um Regex for construído. Anteriormente, os caracteres
+        seriam armazenados na ordem em que fossem informados.
+       </simpara>
+       <simpara>
+        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        é lançada se <parameter>pattern</parameter> ou
+        <parameter>flags</parameter> contiverem bytes nulos. Anteriormente, valores
+        seriam truncados no primeiro byte nulo.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/regex/getflags.xml
+++ b/reference/mongodb/bson/regex/getflags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c8537156314afaa1191aa8afe529b3e9b42c538 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-regex.getflags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna as opções de Regex.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/regex/getpattern.xml
+++ b/reference/mongodb/bson/regex/getpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c8537156314afaa1191aa8afe529b3e9b42c538 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-regex.getpattern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a expressão regular de Regex.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/regex/jsonserialize.xml
+++ b/reference/mongodb/bson/regex/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-regex.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\Regex</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/regex/tostring.xml
+++ b/reference/mongodb/bson/regex/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-regex.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste Regex.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/timestampinterface/tostring.xml
+++ b/reference/mongodb/bson/timestampinterface/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-timestampinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste TimestampInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/undefined/construct.xml
+++ b/reference/mongodb/bson/undefined/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aaaeefbb399293b9b61bc84b8b5593d3132850ca Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-undefined.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\Undefined::__construct</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Objetos <classname>MongoDB\BSON\Undefined</classname> são criados através de
    conversão de um tipo descontinuado do BSON e não podem ser construídos diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/bson/undefined/jsonserialize.xml
+++ b/reference/mongodb/bson/undefined/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-undefined.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\Undefined</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/undefined/tostring.xml
+++ b/reference/mongodb/bson/undefined/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-undefined.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma string vazia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/unserializable/bsonunserialize.xml
+++ b/reference/mongodb/bson/unserializable/bsonunserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e3c3525f7f288bc3a455a9619215fa759c2a9f5f Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-unserializable.bsonunserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,14 +13,14 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Unserializable::bsonUnserialize</methodname>
    <methodparam><type>array</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Chamado durante a desserialização do objeto a partir do BSON. As propriedades do
    array ou documento BSON serão passadas ao método como um <type>array</type>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Lembre-se de considerar uma propriedade <property>_id</property> ao manipular dados
    a aprtir de um documento BSON.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Este método atua como o
@@ -37,9 +37,9 @@
    <varlistentry>
     <term><parameter>data</parameter> (<type>array</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Propriedades dentro do array ou documento BSON.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -47,28 +47,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor de retorno deste método é ignorado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.tentative-return-types-enforced;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.tentative-return-types-enforced;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/utcdatetime/construct.xml
+++ b/reference/mongodb/bson/utcdatetime/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetime.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,19 +21,19 @@
    <varlistentry>
     <term><parameter>milliseconds</parameter> (<type class="union"><type>int</type><type>MongoDB\BSON\Int64</type><type>DateTimeInterface</type><type>null</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Número de milissegundos desde a época Unix (1º de janeiro de 1970). Valores negativos
       representam datas anteriores a 1970. Este valor pode ser fornecido como um
       <type>int</type> de 64 bits. Para compatibilidade com sistemas de 32 bits, este parâmetro
       também pode ser fornecido como um <classname>MongoDB\BSON\Int64</classname>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Se o argumento for um <classname>DateTimeInterface</classname>, o número de
       milissegundos desde a época Unix será derivado desse valor.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Se este argumento for &null;, o horário atual será usado por padrão.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -48,53 +48,51 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        <para>
-         O parâmetro <parameter>milliseconds</parameter> não aceita mais um argumento
-         <type>string</type> ou <type>float</type>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        <para>
-         O parâmetro <parameter>milliseconds</parameter> agora aceita um objeto
-         <classname>MongoDB\BSON\Int64</classname> (para compatibilidade com
-         plataformas de 32 bits). Especificar um <type>string</type> ou
-         um <type>float</type> foi descontinuado.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         O argumento <parameter>milliseconds</parameter> é opcional e
-         o padrão é &null; (ou seja, horário atual). O argumento também aceita um
-         <classname>DateTimeInterface</classname>, que pode ser usado para derivar
-         o número de milissegundos desde a época Unix. Anteriormente, apenas
-         os tipos <type>int</type>, <type>float</type> e <type>string</type>
-         eram aceitos.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       <simpara>
+        O parâmetro <parameter>milliseconds</parameter> não aceita mais um argumento
+        <type>string</type> ou <type>float</type>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       <simpara>
+        O parâmetro <parameter>milliseconds</parameter> agora aceita um objeto
+        <classname>MongoDB\BSON\Int64</classname> (para compatibilidade com
+        plataformas de 32 bits). Especificar um <type>string</type> ou
+        um <type>float</type> foi descontinuado.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        O argumento <parameter>milliseconds</parameter> é opcional e
+        o padrão é &null; (ou seja, horário atual). O argumento também aceita um
+        <classname>DateTimeInterface</classname>, que pode ser usado para derivar
+        o número de milissegundos desde a época Unix. Anteriormente, apenas
+        os tipos <type>int</type>, <type>float</type> e <type>string</type>
+        eram aceitos.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/utcdatetime/jsonserialize.xml
+++ b/reference/mongodb/bson/utcdatetime/jsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66d301903b063375c1618d754f1570a9d38746e3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetime.jsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna dados que podem ser serializados por <function>json_encode</function> para
    produzir uma representação JSON estendida de
    <classname>MongoDB\BSON\UTCDateTime</classname>.
-  </para>
+  </simpara>
   &mongodb.note.extended-json;
  </refsect1>
 

--- a/reference/mongodb/bson/utcdatetime/todatetime.xml
+++ b/reference/mongodb/bson/utcdatetime/todatetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c9ff64ac878c34562858be79626e533a1ccaf072 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetime.todatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em <classname>DateTime</classname> deste
    UTCDateTime. O <classname>DateTime</classname> retornado usará o fuso horário
    UTC.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/utcdatetime/todatetimeimmutable.xml
+++ b/reference/mongodb/bson/utcdatetime/todatetimeimmutable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c9ff64ac878c34562858be79626e533a1ccaf072 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetime.todatetimeimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em <classname>DateTimeImmutable</classname> deste
    UTCDateTime. O <classname>DateTimeImmutable</classname> retornado usará o fuso
    horário UTC.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/bson/utcdatetime/tostring.xml
+++ b/reference/mongodb/bson/utcdatetime/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetime.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste UTCDateTime.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/bson/utcdatetimeinterface/todatetime.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface/todatetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetimeinterface.todatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em <classname>DateTime</classname> deste
    UTCDateTimeInterface. O <classname>DateTime</classname> retornado deve usar
    o fuso horário UTC.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/utcdatetimeinterface/todatetimeimmutable.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface/todatetimeimmutable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetimeinterface.todatetimeimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação <classname>DateTimeImmutable</classname> desta
    UTCDateTimeInterface. O <classname>DateTimeImmutable</classname> retornado usará o
    fuso horário UTC.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/bson/utcdatetimeinterface/tostring.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-bson-utcdatetimeinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em string deste UTCDateTimeInterface.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
41 BSON method refentries (maxkey, minkey, objectid, packedarray, persistable, regex, undefined, unserializable, utcdatetime and their interfaces): mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose untouched. Hashes bumped, ``Maintainer: lacatoire``.