### PR TITLE
Sync EN: mongodb monitoring command events methods

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getcommandname.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getcommandname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getcommandname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getCommandName</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome do comando (ex: <literal>"find"</literal>,
    <literal>"aggregate"</literal>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdatabasename.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdatabasename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca33dfb525027bb876fd0239060f5441e377ed0b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getdatabasename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o banco de dados no qual o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    A duração do comando é um valor calculado que inclui o tempo para enviar a
    mensagem e receber a resposta do servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a duração do comando em microssegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.geterror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a <classname>Exception</classname> associada ao comando com falha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do servidor no qual o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getoperationid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getoperationid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getoperationid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getOperationId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O ID da operação é gerado pela extensão e pode ser usado para vincular eventos,
    como operações de gravação em massa, que podem ter sido divididas em
    vários comandos no nível do protocolo.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Como vários comandos podem compartilhar o mesmo ID de operação, não é confiável
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da operação do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a porta do servidor em que o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getreply.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O documento de resposta será convertido de BSON para PHP usando as regras padrão
    de <link linkend="mongodb.persistence.deserialization">desserialização</link>
    (por exemplo, documentos BSON serão convertidos para <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de resposta do comando como um objeto
    <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getrequestid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getrequestid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getrequestid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getRequestId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O ID da solicitação é gerado pela extensão e pode ser usado para associar
    este <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname> a um
    <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
    anterior.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da solicitação do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserver.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,14 +9,14 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Este método foi <emphasis>DESCONTINUADO</emphasis> a partir da versão de
     extensão 1.20.0 e foi removido na versão 2.0. As aplicações devem usar
     <methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getHost</methodname>
     e
     <methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getPort</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -26,10 +26,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> no qual o comando
    foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,10 +39,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> no qual o comando
    foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -54,21 +54,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.method-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.method-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserverconnectionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6b1dd7035f8a4428081faa43e6e244e4b89f495 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getserverconnectionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getServerConnectionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o ID de conexão do servidor para o comando. O ID de conexão do servidor é
    distinto do servidor (ou seja,
    <function>MongoDB\Driver\Monitoring\CommandFailedEvent::getServer</function>)
    e é retornado no campo "connectionId" de uma resposta de comando <literal>hello</literal>
    do MongoDB 4.2+.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID de conexão do servidor ou &null; se não estiver disponível.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserviceid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserviceid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1632139847f823b9a715fba7648945faf60f5f4 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getserviceid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getServiceId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Quando o driver está conectado a um cluster MongoDB por meio de um balanceador de carga,
    o ID do serviço corresponde ao campo <literal>serviceId</literal> na
    resposta do comando <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID do serviço do balanceador de carga ou &null; se o driver não estiver
    conectado a um balanceador de carga.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommand.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getCommand</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O documento de resposta será convertido de BSON para PHP usando as regras padrão de
    <link linkend="mongodb.persistence.deserialization">desserialização</link>
    (por exemplo, documentos BSON serão convertidos para <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de comando como um objeto <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommandname.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommandname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getcommandname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getCommandName</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome do comando (ex.: <literal>"find"</literal>,
    <literal>"aggregate"</literal>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getdatabasename.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getdatabasename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getdatabasename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o banco de dados no qual o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do servidor no qual o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getoperationid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getoperationid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getoperationid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getOperationId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O ID da operação é gerado pela extensão e pode ser usado para vincular eventos,
    como operações de gravação em massa, que podem ter sido divididas em
    vários comandos no nível do protocolo.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Como vários comandos podem compartilhar o mesmo ID de operação, não é confiável
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da operação do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a porta do servidor em que o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getrequestid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getrequestid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getrequestid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getRequestId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O ID da solicitação é gerado pela extensão e pode ser usado para associar
    este <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
    a um
    <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname> ou
    <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname> posterior.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da solicitação do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserver.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,14 +9,14 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Este método foi <emphasis>DESCONTINUADO</emphasis> a partir da versão de
     extensão 1.20.0 e foi removido na versão 2.0. As aplicações devem usar
     <methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getHost</methodname>
     e
     <methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getPort</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -26,10 +26,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> no qual o comando
    foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,10 +39,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> no qual o comando
    foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -54,21 +54,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.method-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.method-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserverconnectionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6b1dd7035f8a4428081faa43e6e244e4b89f495 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getserverconnectionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getServerConnectionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o ID de conexão do servidor para o comando. O ID de conexão do servidor é
    distinto do servidor (ou seja,
    <function>MongoDB\Driver\Monitoring\CommandStartedEvent::getServer</function>)
    e é retornado no campo "connectionId" de uma resposta de comando <literal>hello</literal>
    do MongoDB 4.2+.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID de conexão do servidor ou &null; se não estiver disponível.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserviceid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserviceid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1632139847f823b9a715fba7648945faf60f5f4 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getserviceid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getServiceId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Quando o driver está conectado a um cluster MongoDB por meio de um balanceador de carga,
    o ID do serviço corresponde ao campo <literal>serviceId</literal> na
    resposta do comando <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID do serviço do balanceador de carga ou &null; se o driver não estiver
    conectado a um balanceador de carga.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getcommandname.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getcommandname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getcommandname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getCommandName</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome do comando (ex.: <literal>"find"</literal>,
    <literal>"aggregate"</literal>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdatabasename.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdatabasename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca33dfb525027bb876fd0239060f5441e377ed0b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getdatabasename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o banco de dados no qual o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    A duração do comando é um valor calculado que inclui o tempo para enviar a
    mensagem e receber a resposta do servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a duração do comando em microssegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do servidor no qual o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getoperationid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getoperationid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getoperationid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getOperationId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O ID da operação é gerado pela extensão e pode ser usado para vincular eventos,
    como operações de gravação em massa, que podem ter sido divididas em
    vários comandos no nível do protocolo.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Como vários comandos podem compartilhar o mesmo ID de operação, não é confiável
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da operação do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a porta do servidor em que o comando foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getreply.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O documento de resposta será convertido de BSON para PHP usando as regras padrão
    de <link linkend="mongodb.persistence.deserialization">desserialização</link>
    (por exemplo, documentos BSON serão convertidos para <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de resposta do comando como um objeto
    <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getrequestid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getrequestid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getrequestid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getRequestId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    O ID da solicitação é gerado pela extensão e pode ser usado para associar
    este <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
    a um
    <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname> anterior.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da solicitação do comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserver.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,14 +9,14 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Este método foi <emphasis>DESCONTINUADO</emphasis> a partir da versão de
     extensão 1.20.0 e foi removido na versão 2.0. As aplicações devem usar
     <methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getHost</methodname>
     e
     <methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getPort</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -26,10 +26,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> no qual o comando
    foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,10 +39,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> no qual o comando
    foi executado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -54,21 +54,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.method-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.method-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserverconnectionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6b1dd7035f8a4428081faa43e6e244e4b89f495 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getserverconnectionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServerConnectionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o ID de conexão do servidor para o comando. O ID de conexão do servidor é
    distinto do servidor (ou seja,
    <function>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServer</function>)
    e é retornado no campo "connectionId" de uma resposta de comando <literal>hello</literal>
    do MongoDB 4.2+.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID de conexão do servidor ou &null; se não estiver disponível.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserviceid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserviceid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1632139847f823b9a715fba7648945faf60f5f4 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getserviceid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServiceId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Quando o driver está conectado a um cluster MongoDB por meio de um balanceador de carga,
    o ID do serviço corresponde ao campo <literal>serviceId</literal> na
    resposta do comando <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID do serviço do balanceador de carga ou &null; se o driver não estiver
    conectado a um balanceador de carga.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
33 method refentries under ``reference/mongodb/mongodb/driver/monitoring/command{Failed,Started,Succeeded}Event/``: mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose untouched.

The 3 class-level files (``commandFailedEvent.xml``, ``commandStartedEvent.xml``, ``commandSucceededEvent.xml``) are deliberately left out: their EN diff adds a new ``Properties`` section and a non-trivial changelog row, which require a real translation pass.