### PR TITLE
Sync EN: mongodb monitoring subscribers

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-monitoring-commandsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
 <!-- {{{ MongoDB\Driver\Monitoring\CommandSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-commandsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Classes podem implementar este interface para registrar um assinante de evento que será
     notificado em cada evento de comando iniciado, bem-sucedido ou falhado.
     <xref linkend="mongodb.tutorial.apm" /> para informações adicionais.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -47,22 +47,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandfailed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandfailed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandfailed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandFailed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\CommandFailedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, esse método será chamado quando um comando falhar.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandFailedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre o comando com falha.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandstarted.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandstarted.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandstarted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\CommandStartedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, este método será chamado quando um comando for enviado
    ao servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandStartedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre o comando iniciado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandsucceeded.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandsucceeded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandsucceeded" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandSucceeded</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\CommandSucceededEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, esse método será chamado quando um comando
    for bem-sucedido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandSucceededEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre o comando bem-sucedido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-monitoring-logsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,18 +11,18 @@
 <!-- {{{ MongoDB\Driver\Monitoring\LogSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-logsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     As classes que implementam esta interface podem ser registradas como assinantes e
     receber mensagens de registro da extensão. Isso é semelhante ao registro de depuração
     baseado em fluxo (ou seja, <link linkend="ini.mongodb.debug">mongodb.debug</link>),
     exceto que as mensagens de registro em nível de rastreio <emphasis>não</emphasis> são recebidas.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Assim como acontece com o registro baseado em fluxo, só é possível inscrever um criador de regsitros
     globalmente usando <function>MongoDB\Driver\Monitoring\addSubscriber</function>.
     A extensão não é capaz de distinguir mensagens de regsitros para objetos
     <classname>MongoDB\Driver\Manager</classname> individuais.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -97,60 +97,60 @@
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-error">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de registro de erros. Uma condição de erro que a extensão não consegue relatar
        por meio de sua API. Este é o nível de registro mais severo na extensão.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-critical">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de registro crítico. Uma condição de erro com gravidade um pouco menor. Esta
        constante existe para consistência com libmongoc; no entanto, é improvável que
        a extensão o utilize na prática.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-warning">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de registro de alerta. Indica uma situação em que pode ocorrer comportamento
        indesejável da aplicação.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-message">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de registro de mensagens ou avisos. Indica um evento incomum, mas não
        problemático.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-info">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de registro de informações. Informações de alto nível sobre o comportamento normal do driver.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-debug">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de registro de depuração. Informações detalhadas que podem ser úteis ao depurar
        uma aplicação.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-logsubscriber.log" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam><type>string</type><parameter>domain</parameter></methodparam>
    <methodparam><type>string</type><parameter>message</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, esse método será chamado para cada mensagem
    registrada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,26 +27,26 @@
    <varlistentry>
     <term><parameter>level</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O nível de severidade. Este será uma das
       <link linkend="mongodb-driver-monitoring-logsubscriber.constants">constantes de interface</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>domain</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O nome do componente do driver que emitiu a mensagem de registro.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>message</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A mensagem de registro.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-monitoring-sdamsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,13 +11,13 @@
 <!-- {{{ MongoDB\Driver\Monitoring\SDAMSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-sdamsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     As classes podem implementar esta interface para registrar um assinante de evento que é
     notificado sobre vários eventos SDAM. Consulte as
     especificações de <link xlink:href="&url.mongodb.sdam;">Descoberta e Monitoramento de Servidores</link>
     e <link xlink:href="&url.mongodb.sdam-monitoring;">Monitoramento de SDAM</link>
     para obter informações adicionais.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -49,22 +49,20 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.tentative-return-types-enforced;
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.tentative-return-types-enforced;
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverchanged.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverchanged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverchanged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverChanged</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerChangedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, esse método será chamado quando a descrição do
    servidor for alterada. Por exemplo, a mudança do tipo de servidor de secundário para
    primário faria com que a descrição do servidor mudasse.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerChangedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a descrição alterada
       do servidor.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverclosed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverclosed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverclosed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverClosed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerClosedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, esse método será chamado quando um
    servidor existente for removido da topologia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerClosedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre o servidor fechado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatfailed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatfailed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverheartbeatfailed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverHeartbeatFailed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, este método será chamado quando uma pulsação
    de servidor (ou seja,
    o comando <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    emitido através do
    <link xlink:href ="&url.mongodb.sdam;">monitoramento do servidor</link>) falha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a pulsação do servidor
       com falha.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -39,9 +39,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatstarted.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatstarted.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverheartbeatstarted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,14 +13,14 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverHeartbeatStarted</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, este método será chamado quando uma pulsação
    de servidor (ou seja,
    o comando <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    emitido através do
    <link xlink:href="&url.mongodb.sdam;">monitoramento do servidor</link>) é enviada
    ao servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,10 +29,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a pulsação do
       servidor iniciada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -40,9 +40,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatsucceeded.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatsucceeded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverheartbeatsucceeded" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverHeartbeatSucceeded</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, este método será chamado quando uma pulsação
    de servidor (ou seja,
    o comando <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    emitido através do
    <link xlink:href="&url.mongodb.sdam;">monitoramento do servidor</link>) for bem sucedida.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a pulsação do servidor
       bem-sucedida.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -39,9 +39,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serveropening.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serveropening.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serveropening" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverOpening</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerOpeningEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver registrado, este método será chamado quando um novo servidor
    for adicionado à topologia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerOpeningEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre o servidor aberto.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologychanged.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologychanged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologychanged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyChanged</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyChangedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver cadastrado, este método será chamado quando a descrição
    da topologia for alterada. Por exemplo, uma topologia que descobrisse um novo conjunto
    de réplicas primário causaria uma alteração na descrição da topologia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyChangedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a descrição da topologia
       alterada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyclosed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyclosed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologyclosed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyClosed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyClosedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver cadastrado, este método será chamado quando a topologia for
    fechada.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Devido ao comportamento de
@@ -35,9 +35,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyClosedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a topologia fechada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyopening.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyopening.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologyopening" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyOpening</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyOpeningEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o assinante estiver cadastrado, este método será chamado quando a topologia for
    aberta.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Devido ao comportamento de
@@ -34,9 +34,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyOpeningEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um objeto de evento que encapsula informações sobre a topologia aberta.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-monitoring-subscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\Driver\Monitoring\Subscriber intro -->
   <section xml:id="mongodb-driver-monitoring-subscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Interface base para assinantes de eventos. É usada como um tipo de parâmetro nas funções
     <function>MongoDB\Driver\Monitoring\addSubscriber</function> e
     <function>MongoDB\Driver\Monitoring\removeSubscriber</function> e não deve
     ser implementada diretamente.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -38,10 +38,10 @@
    </classsynopsis>
 <!-- }}} -->
 
-   <para>
+   <simpara>
     Esta interface não possui métodos. Seu único propósito é ser a interface base
     para todos os assinantes de evento.
-   </para>
+   </simpara>
 
   </section>
 


### PR DESCRIPTION
17 refentries under ``reference/mongodb/mongodb/driver/monitoring/{commandsubscriber,logsubscriber,sdamsubscriber,subscriber}/``: mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>`` on the two class files). Portuguese prose untouched.