### PR TITLE
Sync EN: mongodb driver exceptions

### DIFF
--- a/reference/mongodb/mongodb/driver/exception/authenticationexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/authenticationexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-authenticationexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Exception\AuthenticationException intro -->
   <section xml:id="mongodb-driver-exception-authenticationexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando o driver não consegue se autenticar no servidor.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e5f8a81798fe721d2ab335b654da3d98850e5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-bulkwritecommandexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\Driver\Exception\BulkWriteCommandException intro -->
   <section xml:id="mongodb-driver-exception-bulkwritecommandexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Exceção gerada devido à falha na execução de um
     <classname>MongoDB\Driver\BulkWriteCommand</classname>. Os métodos desta
     classe fornecem mais detalhes do erro ocorrido, incluindo a resposta do erro
     e resultados parciais da gravação em massa.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -91,46 +91,46 @@
     <varlistentry xml:id="mongodb-driver-exception-bulkwritecommandexception.props.errorreply">
      <term><varname>errorReply</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Qualquer erro de nível superior que ocorreu ao tentar se comunicar com
        o servidor ou executar a gravação em massa. Este valor pode ser &null; se a
        exceção foi gerada devido a erros ocorridos em gravações individuais.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mongodb-driver-exception-bulkwritecommandexception.props.partialresult">
      <term><varname>partialResult</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Um <classname>MongoDB\Driver\BulkWriteCommandResult</classname> relatando
        o resultado de quaisquer operações bem-sucedidas que foram executadas antes do
        erro ser encontrado. Este valor pode ser &null; se não for possível
        determinar que pelo menos uma gravação foi realizada com sucesso (e
        reconhecida).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mongodb-driver-exception-bulkwritecommandexception.props.writeconcernerrors">
      <term><varname>writeConcernErrors</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Um array de quaisquer <classname>MongoDB\Driver\WriteConcernError</classname>
        que ocorreram durante a execução da gravação em massa. Esta lista pode ter
        vários itens se mais de um comando de servidor foi necessário para executar
        a gravação em massa.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mongodb-driver-exception-bulkwritecommandexception.props.writeerrors">
      <term><varname>writeErrors</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Um array de quaisquer <classname>MongoDB\Driver\WriteError</classname>s
        que ocorreram durante a execução de operações de gravação individuais. As chaves do array
        corresponderão ao índice da operação de gravação de
        <classname>MongoDB\Driver\BulkWriteCommand</classname>. Este mapa
        conterá no máximo uma entrada se a gravação em massa tiver sido ordenada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/geterrorreply.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/geterrorreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.geterrorreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Document</type><type>null</type></type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getErrorReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,11 +24,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna qualquer erro de nível superior que ocorreu ao tentar se comunicar
    com o servidor ou executar a gravação em massa. Este valor pode ser &null; se a
    exceção foi gerada devido a erros ocorridos em gravações individuais.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getpartialresult.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getpartialresult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getpartialresult" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\BulkWriteCommandResult</type><type>null</type></type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getPartialResult</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,13 +24,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <classname>MongoDB\Driver\BulkWriteCommandResult</classname>
    relatando o resultado de quaisquer operações bem-sucedidas que foram executadas antes
    do erro ser encontrado. O valor de retorno será &null; se não for possível
    determinar que pelo menos uma gravação foi realizada com sucesso (e
    reconhecida).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getwriteconcernerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getWriteConcernErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,12 +24,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Um array de quaisquer <classname>MongoDB\Driver\WriteConcernError</classname>
    que ocorreram durante a execução da gravação em massa. Esta lista pode ter vários
    itens se mais de um comando de servidor foi necessário para executar a gravação
    em massa.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteerrors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getwriteerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getWriteErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,13 +24,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Um array de quaisquer <classname>MongoDB\Driver\WriteError</classname>s que
    ocorreram durante a execução de operações de gravação individuais. As chaves do array
    corresponderão ao índice da operação de gravação de
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. Este mapa
    conterá no máximo uma entrada se a gravação em massa tiver sido ordenada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e3c3525f7f288bc3a455a9619215fa759c2a9f5f Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-bulkwriteexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Exception\BulkWriteException intro -->
   <section xml:id="mongodb-driver-exception-bulkwriteexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando uma operação de gravação em massa falha.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -42,7 +42,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>MongoDB\Driver\WriteResult</type>
      <varname linkend="mongodb-driver-exception-bulkwriteexception.props.writeresult">writeResult</varname>
     </fieldsynopsis>
@@ -74,10 +75,10 @@
     <varlistentry xml:id="mongodb-driver-exception-bulkwriteexception.props.writeresult">
      <term><varname>writeResult</varname></term>
      <listitem>
-      <para>
+      <simpara>
        O objeto <classname>MongoDB\Driver\WriteResult</classname> associado com
        a operação de escrita falhada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -86,31 +87,36 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.0.0</entry>
-        <entry>
-         <para>
-          Esta classe agora estente
-          <classname>MongoDB\Driver\Exception\ServerException</classname>
-          em vez de
-          <classname>MongoDB\Driver\Exception\WriteException</classname>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        A propriedade <varname>writeResult</varname> agora é
+        <modifier>public</modifier> <modifier>readonly</modifier>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 2.0.0</entry>
+       <entry>
+        <simpara>
+         Esta classe agora estende
+         <classname>MongoDB\Driver\Exception\ServerException</classname>
+         em vez de
+         <classname>MongoDB\Driver\Exception\WriteException</classname>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception/getwriteresult.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception/getwriteresult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwriteexception.getwriteresult" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Exception\BulkWriteException::getWriteResult</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\WriteResult</classname> para a operação de escrita com falha.
    Os métodos
    <function>MongoDB\Driver\WriteResult::getWriteErrors</function> e
    <function>MongoDB\Driver\WriteResult::getWriteConcernError</function>
    podem ser usados ​​para obter mais detalhes sobre a falha.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,10 +30,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O <classname>MongoDB\Driver\WriteResult</classname> para a operação de escrita
    com falha.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/exception/commandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-commandexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Exception\CommandException intro -->
   <section xml:id="mongodb-driver-exception-commandexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando um comando falha.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -42,7 +42,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>object</type>
      <varname linkend="mongodb-driver-exception-commandexception.props.resultdocument">resultDocument</varname>
     </fieldsynopsis>
@@ -75,14 +76,37 @@
     <varlistentry xml:id="mongodb-driver-exception-commandexception.props.resultdocument">
      <term><varname>resultDocument</varname></term>
      <listitem>
-      <para>
+      <simpara>
        O documento de resultado associado ao comando com falha.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        A propriedade <varname>resultDocument</varname> agora é
+        <modifier>public</modifier> <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/exception/commandexception/getresultdocument.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception/getresultdocument.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e60f8596d36312e7339dc95e690194172337a91 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-commandexception.getresultdocument" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Exception\CommandException::getResultDocument</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o documento de resultado do comando com falha.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O documento de resultado do comando com falha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/exception/connectionexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/connectionexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-connectionexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\Driver\Exception\ConnectionException intro -->
   <section xml:id="mongodb-driver-exception-connectionexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Classe base para exceções lançadas quando o driver não consegue estabelecer uma
     conexão com o banco de dados.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/connectiontimeoutexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/connectiontimeoutexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-connectiontimeoutexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,13 +11,13 @@
 <!-- {{{ MongoDB\Driver\Exception\ConnectionTimeoutException intro -->
   <section xml:id="mongodb-driver-exception-connectiontimeoutexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando o driver não consegue estabelecer uma conexão com o banco de dados dentro de um
     limite de tempo especificado
     (<link linkend="mongodb-driver-manager.construct-urioptions">connectTimeoutMS</link>)
     ou a seleção do servidor falha
     (<link linkend="mongodb-driver-manager.construct-urioptions">serverSelectionTimeoutMS</link>).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/encryptionexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/encryptionexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-encryptionexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Exception\EncryptionException intro -->
   <section xml:id="mongodb-driver-exception-encryptionexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Classe base para exceções lançadas durante a criptografia do lado do cliente.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/exception.xml
+++ b/reference/mongodb/mongodb/driver/exception/exception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
 <!-- {{{ MongoDB\Driver\Exception\Exception intro -->
   <section xml:id="mongodb-driver-exception-exception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Interface comum para todas as exceções de extensão. Esta interface também é usada
     pela biblioteca e pode ser usada para identificar quaisquer exceções originadas do
     driver MongoDB PHP (ou seja, extensão e biblioteca).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/executiontimeoutexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/executiontimeoutexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-executiontimeoutexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
 <!-- {{{ MongoDB\Driver\Exception\ExecutionTimeoutException intro -->
   <section xml:id="mongodb-driver-exception-executiontimeoutexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando uma consulta ou comando não é concluído dentro de um limite de tempo
     especificado (por exemplo,
     <link xlink:href="&url.mongodb.docs.maxtimems;">maxTimeMS</link>).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -62,31 +62,29 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 1.5.0</entry>
-        <entry>
-         <para>
-          Esta classe agora estende a classe
-          <classname>MongoDB\Driver\Exception\ServerException</classname>
-          ao invés da classe
-          <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.5.0</entry>
+       <entry>
+        <simpara>
+         Esta classe agora estende a classe
+         <classname>MongoDB\Driver\Exception\ServerException</classname>
+         ao invés da classe
+         <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/exception/invalidargumentexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/invalidargumentexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-invalidargumentexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\Driver\Exception\InvalidArgumentException intro -->
   <section xml:id="mongodb-driver-exception-invalidargumentexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando um método de driver recebe argumentos inválidos (por exemplo, tipos de opções
     inválidos).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/logicexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/logicexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-logicexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Exception\LogicException intro -->
   <section xml:id="mongodb-driver-exception-logicexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando o driver é usado incorretamente (por exemplo, retrocedendo um cursor).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/runtimeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/runtimeexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-runtimeexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\Driver\Exception\RuntimeException intro -->
   <section xml:id="mongodb-driver-exception-runtimeexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando o driver encontra um erro no momento da execução (por exemplo, erro interno de
     <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -71,7 +71,7 @@
     <varlistentry xml:id="mongodb-driver-exception-runtimeexception.props.errorlabels">
      <term><varname>errorLabels</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Contém um array de rótulos de erro que acompanham uma exceção. Por exemplo,
        rótulos de erro podem ser usados ​​para detectar se uma transação pode ser repetida
        com segurança se o rótulo <literal>TransientTransactionError</literal> estiver
@@ -80,7 +80,7 @@
        <methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname>,
        em vez de interpretar a propriedade <literal>errorLabels</literal>
        manualmente.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -89,32 +89,30 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 1.6.0</entry>
-        <entry>
-         <para>
-          O método
-          <methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname>
-          e a propriedade
-          <link linkend="mongodb-driver-exception-runtimeexception.props.errorlabels">MongoDB\Driver\Exception\RuntimeException::errorLabels</link>
-          foram adicionados.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.6.0</entry>
+       <entry>
+        <simpara>
+         O método
+         <methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname>
+         e a propriedade
+         <link linkend="mongodb-driver-exception-runtimeexception.props.errorlabels">MongoDB\Driver\Exception\RuntimeException::errorLabels</link>
+         foram adicionados.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/exception/runtimeexception/haserrorlabel.xml
+++ b/reference/mongodb/mongodb/driver/exception/runtimeexception/haserrorlabel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-runtimeexception.haserrorlabel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname>
    <methodparam><type>string</type><parameter>errorLabel</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se <parameter>errorLabel</parameter> foi definido para esta
    exceção. Os rótulos de erro são definidos pelo servidor ou pela extensão para
    indicar situações específicas que podem ser tratadas por uma aplicação. Uma situação
@@ -21,7 +21,7 @@
    falhou devido a um erro transitório (por exemplo, erro de rede, conflito de transação).
    Exemplos de rótulos de erro são <literal>TransientTransactionError</literal>
    e <literal>UnknownTransactionCommitResult</literal>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -31,7 +31,7 @@
    <varlistentry>
     <term><parameter>errorLabel</parameter></term>
     <listitem>
-     <para>O nome do <literal>errorLabel</literal> a ser testado.</para>
+     <simpara>O nome do <literal>errorLabel</literal> a ser testado.</simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -39,10 +39,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Se o <literal>errorLabel</literal> fornecido está associado a esta
    exceção.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/exception/serverexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/serverexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-serverexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Exception\ServerException intro -->
   <section xml:id="mongodb-driver-exception-serverexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Classe base para exceções lançadas pelo servidor. O código desta exceção e suas subclasses corresponderão ao código de erro original do servidor.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/sslconnectionexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/sslconnectionexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-sslconnectionexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -20,9 +20,9 @@
 <!-- {{{ MongoDB\Driver\Exception\SSLConnectionException intro -->
   <section xml:id="mongodb-driver-exception-sslconnectionexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando o driver não consegue estabelecer uma conexão SSL com o servidor.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/unexpectedvalueexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/unexpectedvalueexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-unexpectedvalueexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\Driver\Exception\UnexpectedValueException intro -->
   <section xml:id="mongodb-driver-exception-unexpectedvalueexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lançada quando o driver encontra um valor inesperado (por exemplo, durante a
     serialização ou desserialização do BSON).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/writeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-exception-writeexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -20,10 +20,10 @@
 <!-- {{{ MongoDB\Driver\Exception\WriteException intro -->
   <section xml:id="mongodb-driver-exception-writeexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Classe base para exceções lançadas por uma operação de gravação com falha. A exceção
     encapsula um objeto <classname>MongoDB\Driver\WriteResult</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -86,10 +86,10 @@
     <varlistentry xml:id="mongodb-driver-exception-writeexception.props.writeresult">
      <term><varname>writeResult</varname></term>
      <listitem>
-      <para>
+      <simpara>
        O <classname>MongoDB\Driver\WriteResult</classname> associado à
        operação de gravação com falha.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -98,38 +98,36 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.class-removed;
-       <row>
-        <entry>PECL mongodb 1.20.0</entry>
-        <entry>
-         Esta classe foi descontinuada e será removida na versão 2.0.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.5.0</entry>
-        <entry>
-         <para>
-          Esta classe agora estende a classe
-          <classname>MongoDB\Driver\Exception\ServerException</classname>
-          ao invés da
-          <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.class-removed;
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Esta classe foi descontinuada e será removida na versão 2.0.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.5.0</entry>
+       <entry>
+        <simpara>
+         Esta classe agora estende a classe
+         <classname>MongoDB\Driver\Exception\ServerException</classname>
+         ao invés da
+         <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/exception/writeexception/getwriteresult.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception/getwriteresult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeexception.getwriteresult" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Exception\WriteException::getWriteResult</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\WriteResult</classname> para a operação
    de gravação com falha. Os métodos
    <function>MongoDB\Driver\WriteResult::getWriteErrors</function> e
    <function>MongoDB\Driver\WriteResult::getWriteConcernError</function>
    podem ser usados ​​para obter mais detalhes sobre a falha.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,10 +30,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O <classname>MongoDB\Driver\WriteResult</classname> para a operação de gravação
    com falha.
-  </para>
+  </simpara>
  </refsect1>
 
 


### PR DESCRIPTION
24 refentries under ``reference/mongodb/mongodb/driver/exception/``: mechanical XML refactor (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``, ``protected`` → ``public readonly`` modifiers, templated PECL 2.3.0 changelog row). Portuguese prose preserved.