### PR TITLE
Sync EN: mongodb driver Manager

### DIFF
--- a/reference/mongodb/mongodb/driver/manager.xml
+++ b/reference/mongodb/mongodb/driver/manager.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-manager" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,21 +11,21 @@
 <!-- {{{ MongoDB\Driver\Manager intro -->
   <section xml:id="mongodb-driver-manager.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\Manager</classname> é o principal ponto de entrada
     para a extensão. É responsável por manter conexões com o MongoDB
     (seja ele servidor independente, conjunto de réplicas ou cluster fragmentado).
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Nenhuma conexão com o MongoDB é feita ao instanciar a classe.
     Isso significa que o objeto <classname>MongoDB\Driver\Manager</classname> sempre pode ser
     construído, mesmo que um ou mais servidores MongoDB estejam inativos.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Qualquer escrita ou consulta pode lançar exceções de conexão, pois as conexões são criadas lentamente.
     Um servidor MongoDB também pode ficar indisponível durante a vida útil do script.
     Portanto, é importante que todas as ações no objeto Manager sejam agrupadas em instruções try/catch.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -57,13 +57,13 @@
 
    <example>
     <title>Exemplo básico de <function>MongoDB\Driver\Manager::__construct</function></title>
-    <para>
+    <simpara>
      A função <function>var_dump</function> executada em um
      objeto <classname>MongoDB\Driver\Manager</classname> irá mostrar vários
      detalhes sobre o gerenciador do driver que não são normalmente expostas.
      Isso pode ser útil para depurar como o driver visualiza a configuração do MongoDB e
      quais opções são usadas.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.addsubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::addSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Inscreve um assinante de evento de monitoramento neste gerenciador.
    O assinante será notificado de todos os eventos deste gerenciador.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Se o <parameter>subscriber</parameter> já estiver inscrito neste
@@ -33,9 +33,9 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um assinante de evento de monitoramento para increver-se neste gerenciador.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,9 +43,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
+++ b/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.createclientencryption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ClientEncryption</type><methodname>MongoDB\Driver\Manager::createClientEncryption</methodname>
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo objeto <classname>MongoDB\Driver\ClientEncryption</classname> com as opções especificadas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -51,9 +51,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma nova instância de <classname>MongoDB\Driver\ClientEncryption</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -66,72 +66,70 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.16.0</entry>
-       <entry>
-        <para>
-         O provedor AWS KMS para criptografia do lado do cliente agora aceita uma
-         opção <literal>"sessionToken"</literal>, que pode ser usada para
-         autenticação com credenciais temporárias da AWS.
-        </para>
-        <para>
-         Adicionado <literal>"tlsDisableOCSPEndpointCheck"</literal> à opção
-         <literal>"tlsOptions"</literal>.
-        </para>
-        <para>
-         Se um documento vazio for especificado para o provedor KMS <literal>"azure"</literal> ou
-         <literal>"gcp"</literal>, o driver tentará
-         configurar o provedor usando
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        <para>
-         Se um documento vazio for especificado para o provedor KMS <literal>"aws"</literal>,
-         o driver tentará configurar o provedor usando
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.12.0</entry>
-       <entry>
-        <para>
-         O KMIP agora é suportado como um provedor KMS para criptografia do lado do cliente e
-         pode ser configurado na opção <literal>"kmsProviders"</literal>.
-        </para>
-        <para>
-         Adicionada a opção <literal>"tlsOptions"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.10.0</entry>
-       <entry>
-        O Azure e o GCP agora são suportados como provedores KMS para criptografia
-        do lado do cliente e podem ser configurados na
-        opção <literal>"kmsProviders"</literal>. Strings codificadas em Base64 agora são
-        aceitas como uma alternativa ao <classname>MongoDB\BSON\Binary</classname>
-        para opções dentro de <literal>"kmsProviders"</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.16.0</entry>
+      <entry>
+       <simpara>
+        O provedor AWS KMS para criptografia do lado do cliente agora aceita uma
+        opção <literal>"sessionToken"</literal>, que pode ser usada para
+        autenticação com credenciais temporárias da AWS.
+       </simpara>
+       <simpara>
+        Adicionado <literal>"tlsDisableOCSPEndpointCheck"</literal> à opção
+        <literal>"tlsOptions"</literal>.
+       </simpara>
+       <simpara>
+        Se um documento vazio for especificado para o provedor KMS <literal>"azure"</literal> ou
+        <literal>"gcp"</literal>, o driver tentará
+        configurar o provedor usando
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       <simpara>
+        Se um documento vazio for especificado para o provedor KMS <literal>"aws"</literal>,
+        o driver tentará configurar o provedor usando
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.12.0</entry>
+      <entry>
+       <simpara>
+        O KMIP agora é suportado como um provedor KMS para criptografia do lado do cliente e
+        pode ser configurado na opção <literal>"kmsProviders"</literal>.
+       </simpara>
+       <simpara>
+        Adicionada a opção <literal>"tlsOptions"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.10.0</entry>
+      <entry>
+       O Azure e o GCP agora são suportados como provedores KMS para criptografia
+       do lado do cliente e podem ser configurados na
+       opção <literal>"kmsProviders"</literal>. Strings codificadas em Base64 agora são
+       aceitas como uma alternativa ao <classname>MongoDB\BSON\Binary</classname>
+       para opções dentro de <literal>"kmsProviders"</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,21 +15,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa uma ou mais operações de escrita no servidor primário.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Um <classname>MongoDB\Driver\BulkWrite</classname> pode ser construído com
    uma ou mais operações de escrita de vários tipos (por exemplo, atualizações, exclusões e
    inserções). O driver tentará enviar operações do mesmo tipo ao
    servidor no menor número possível de solicitações para otimizar viagens de ida e volta.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O valor padrão para a opção <literal>"writeConcern"</literal> será
    inferido de uma transação ativa (indicada pela
    opção <literal>"session"</literal>), seguida pelo
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -82,60 +82,58 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O parâmetro <parameter>options</parameter> não aceita mais uma instância
-        de <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passar um objeto <classname>MongoDB\Driver\WriteConcern</classname> como
-        <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançado se a opção <literal>"session"</literal> for usada em combinação
-        com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        O terceiro parâmetro agora é um array <parameter>options</parameter>.
-        Para compatibilidade com versões anteriores, este parâmetro ainda aceitará um
-        objeto <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        agora é lançada se <parameter>bulk</parameter> não contiver nenhuma operação
-        de escrita. Anteriormente, uma
-        <classname>MongoDB\Driver\Exception\BulkWriteException</classname> era
-        lançada.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O parâmetro <parameter>options</parameter> não aceita mais uma instância
+       de <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passar um objeto <classname>MongoDB\Driver\WriteConcern</classname> como
+       <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançado se a opção <literal>"session"</literal> for usada em combinação
+       com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       O terceiro parâmetro agora é um array <parameter>options</parameter>.
+       Para compatibilidade com versões anteriores, este parâmetro ainda aceitará um
+       objeto <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       agora é lançada se <parameter>bulk</parameter> não contiver nenhuma operação
+       de escrita. Anteriormente, uma
+       <classname>MongoDB\Driver\Exception\BulkWriteException</classname> era
+       lançada.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,22 +14,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa uma ou mais operações de gravação no servidor primário usando o comando
    <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
    introduzido no MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Um <classname>MongoDB\Driver\BulkWriteCommand</classname> pode ser construído
    com uma ou mais operações de gravação de tipos variados (por exemplo, inserções, atualizações
    e exclusões). Cada operação de gravação pode ter como alvo uma coleção diferente.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O valor padrão para a opção <literal>"writeConcern"</literal> será
    inferido a partir de uma transação ativa (indicada pela opção
    <literal>"session"</literal>), seguida pelo
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -83,12 +83,12 @@
   &reftitle.examples;
   <example>
    <title>Operações de gravação mistas</title>
-   <para>
+   <simpara>
     Operações de gravação mistas (ou seja, inserções, atualizações e exclusões) serão enviadas
     para o servidor usando um único
     comando
     <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,24 +15,24 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Seleciona um servidor de acordo com a opção <literal>"readPreference"</literal>
    e executa o comando nesse servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método não aplica nenhuma lógica especial ao comando. Os
    valores padrão para as opções <literal>"readPreference"</literal>,
    <literal>"readConcern"</literal> e <literal>"writeConcern"</literal>
    serão inferidos de uma transação ativa (indicada pelo opção
    <literal>"session"</literal>). Se não houver nenhuma transação ativa, uma
    preferência de leitura primária será usada para seleção do servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Os valores padrão <emphasis>não</emphasis> serão inferidos do
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
    Os usuários são, portanto, incentivados a usar métodos de comando específicos de leitura
    e/ou gravação, se possível.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -86,50 +86,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O parâmetro <parameter>options</parameter> não aceita mais uma instância
-        de <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
-        <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançado se a opção <literal>"session"</literal> for usada em
-        combinação com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        O terceiro parâmetro agora é um array <parameter>options</parameter>.
-        Para compatibilidade com versões anteriores, este parâmetro ainda aceitará
-        um objeto <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O parâmetro <parameter>options</parameter> não aceita mais uma instância
+       de <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
+       <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançado se a opção <literal>"session"</literal> for usada em
+       combinação com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       O terceiro parâmetro agora é um array <parameter>options</parameter>.
+       Para compatibilidade com versões anteriores, este parâmetro ainda aceitará
+       um objeto <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -223,7 +221,7 @@ object(stdClass)#7 (2) {
 
   <example>
    <title>Limitando o tempo de execução de um comando</title>
-   <para>
+   <simpara>
     O tempo de execução de um comando pode ser limitado especificando um valor para
     <literal>"maxTimeMS"</literal> no
     documento <classname>MongoDB\Driver\Command</classname>. Observe que esse limite
@@ -231,7 +229,7 @@ object(stdClass)#7 (2) {
     rede. Consulte
     <link xlink:href="&url.mongodb.docs.maxtimems;">Encerrar Operações em Execução</link>
     no manual do MongoDB para obter mais informações.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -251,12 +249,12 @@ var_dump($cursor->toArray()[0]);
 ?>
 ]]>
    </programlisting>
-   <para>
+   <simpara>
     Se o comando não for concluído após um segundo de tempo de execução no
     servidor, um
     <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>
     será lançado.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Seleciona um servidor de acordo com a opção <literal>"readPreference"</literal>
    e executa a consulta nesse servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Os valores padrão para a opção <literal>"readPreference"</literal> e para a opção
    <literal>"readConcern"</literal> da consulta serão inferidos de uma transação
    ativa (indicada pela opção <literal>"session"</literal>), seguidos
    pelo <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -73,42 +73,40 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O parâmetro <parameter>options</parameter> não aceita mais uma instância
-        de <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
-        <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        O terceiro parâmetro agora é um array <parameter>options</parameter>.
-        Para compatibilidade com versões anteriores, este parâmetro ainda aceitará um
-        objeto <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O parâmetro <parameter>options</parameter> não aceita mais uma instância
+       de <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
+       <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       O terceiro parâmetro agora é um array <parameter>options</parameter>.
+       Para compatibilidade com versões anteriores, este parâmetro ainda aceitará um
+       objeto <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -160,14 +158,14 @@ object(stdClass)#7 (1) {
 
   <example>
    <title>Limitando o tempo de execução de uma consulta</title>
-   <para>
+   <simpara>
     A opção <literal>"maxTimeMS"</literal>
     da classe<classname>MongoDB\Driver\Query</classname> pode ser usada para limitar o
     tempo de execução de uma consulta. Observe que esse limite de tempo é aplicado no
     lado do servidor e não leva em consideração a latência da rede. Consulte
     <link xlink:href="&url.mongodb.docs.maxtimems;">Encerrar Operações em Execução</link>
     no manual do MongoDB para obter mais informações.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -189,12 +187,12 @@ foreach ($cursor as $document) {
 ?>
 ]]>
    </programlisting>
-   <para>
+   <simpara>
     Se a consulta não for concluída após um segundo de tempo de execução no
     servidor, uma
     <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>
     será lançada.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,18 +15,18 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Seleciona um servidor de acordo com a opção <literal>"readPreference"</literal>
    e executa o comando nesse servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará uma lógica específica para comandos de leitura (por exemplo,
    <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
    Os valores padrão para as opções <literal>"readPreference"</literal> e
    <literal>"readConcern"</literal> serão inferidos de uma transação
    ativa (indicada pela opção <literal>"session"</literal>), seguido
    pelo <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c90167b57a4b5a81acc18f9f952022e062b08104 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa o comando no servidor primário.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará lógica específica para comandos de leitura e gravação
    (por exemplo, <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Os valores padrão para as opções <literal>"readConcern"</literal> e
    <literal>"writeConcern"</literal> serão inferidos de uma transação
    ativa (indicada pela opção <literal>"session"</literal>), seguido
    pelo <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -78,28 +78,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançada se a opção <literal>"session"</literal> for usada em
-        combinação com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançada se a opção <literal>"session"</literal> for usada em
+       combinação com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa o comando no servidor primário.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará lógica específica para comandos que escrevem (por exemplo,
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    O valor padrão para a opção <literal>"writeConcern"</literal> será
    inferido de uma transação ativa (indicada pela
    opção <literal>"session"</literal>), seguido pelo
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Este método não se destina a ser usado para executar
@@ -88,28 +88,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançada se a opção <literal>"session"</literal> for usada em
-        combinação com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançada se a opção <literal>"session"</literal> for usada em
+       combinação com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
+++ b/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6c44e7b831d1ee04c932847b83a19cecfd51c98e Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.getencryptedfieldsmap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Manager::getEncryptedFieldsMap</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna a opção de criptografia automática <literal>encryptedFieldsMap</literal>
    para o gerenciador, se especificado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    A opção de criptografia automática <literal>encryptedFieldsMap</literal> para o
    gerenciador ou &null; se não foi especificado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.getreadconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadConcern</type><methodname>MongoDB\Driver\Manager::getReadConcern</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\ReadConcern</classname> para o
    gerenciador, que é derivado de suas opções de URI. Esta é a preocupação
    de leitura padrão para consultas e comandos executados no gerenciador.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O <classname>MongoDB\Driver\ReadConcern</classname> para o gerenciador.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.getreadpreference" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadPreference</type><methodname>MongoDB\Driver\Manager::getReadPreference</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\ReadPreference</classname> para o
    gerenciador, que é derivado de suas opções de URI. Esta é a preferência de leitura
    padrão para consultas e comandos executados no gerenciador.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O <classname>MongoDB\Driver\ReadPreference</classname> para o gerenciador.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getservers.xml
+++ b/reference/mongodb/mongodb/driver/manager/getservers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2de5fb458e886b011050a210c6f406ca9ed51c75 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Manager::getServers</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um <type>array</type> de instâncias <classname>MongoDB\Driver\Server</classname>
    às quais este gerenciador está conectado.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Como o driver se conecta ao banco de dados lentamente, este método pode retornar um
@@ -33,10 +33,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <type>array</type> de instâncias <classname>MongoDB\Driver\Server</classname>
    às quais este gerenciador está conectado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.getwriteconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteConcern</type><methodname>MongoDB\Driver\Manager::getWriteConcern</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\WriteConcern</classname> para o
    gerenciador, que é derivado de suas opções de URI. Esta é a preocupação de
    gravação padrão para gravações e comandos executados no gerenciador.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O <classname>MongoDB\Driver\WriteConcern</classname> para o gerenciador.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40dbbc56e321e36deee0f82df820c91fa79087cb Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.removesubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::removeSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cancela o registro de um assinante de evento de monitoramento com este gerenciador.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Se o <parameter>subscriber</parameter> ainda não estiver registrado neste
@@ -30,9 +30,9 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um assinante do evento de monitoramento para cancelar o registro neste gerenciador.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -40,9 +40,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/selectserver.xml
+++ b/reference/mongodb/mongodb/driver/manager/selectserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 929fb17986921c8aadadb7c7bd877ee6f7a7126e Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.selectserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Manager::selectServer</methodname>
    <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Seleciona um <classname>MongoDB\Driver\Server</classname> correspondente
    à preferência de leitura informada em <parameter>readPreference</parameter>. Se
    <parameter>readPreference</parameter> for &null; ou omitido, o servidor
    primário será selecionado por padrão. Isto pode ser usado para pré-selecionar um servidor
    para realizar a verificação de versão antes de executar uma operação.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Ao contrário do <function>MongoDB\Driver\Manager::getServers</function>, este método
@@ -37,10 +37,10 @@
    <varlistentry>
     <term><parameter>readPreference</parameter> (<classname>MongoDB\Driver\ReadPreference</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       A preferência de leitura a ser usada para selecionar um servidor.
       Se &null; ou omitido, o servidor primário será selecionado por padrão.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -48,10 +48,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <classname>MongoDB\Driver\Server</classname> que corresponde à
    preferência de leitura.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -64,27 +64,25 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        O <parameter>readPreference</parameter> agora é opcional. Se &null;
-        ou omitido, o servidor primário será selecionado por padrão.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       O <parameter>readPreference</parameter> agora é opcional. Se &null;
+       ou omitido, o servidor primário será selecionado por padrão.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-manager.startsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Session</type><methodname>MongoDB\Driver\Manager::startSession</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cria um objeto <classname>MongoDB\Driver\Session</classname> para as opções
    fornecidas. A sessão pode então ser especificada ao executar comandos, consultas
    e operações de gravação.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Um <classname>MongoDB\Driver\Session</classname> só pode ser usado com o
@@ -49,16 +49,16 @@
           <entry>causalConsistency</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Configura a consistência causal em uma sessão. Se &true;, cada operação
             na sessão será ordenada causalmente após a operação anterior de leitura ou
             gravação. Se definido como &false;, desativa a consistência causal.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Consulte
             <link xlink:href="&url.mongodb.docs;core/read-isolation-consistency-recency/#causal-consistency">Consistência Causal</link>
             no manual do MongoDB para obter mais informações.
-           </para>
+           </simpara>
           </entry>
           <entry>&true;</entry>
          </row>
@@ -66,11 +66,11 @@
           <entry>defaultTransactionOptions</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Opções padrão a serem aplicadas a transações recém-criadas. Estas
             opções são utilizadas a menos que sejam substituídas quando uma transação é
             iniciada com valores diferentes para cada opção.
-           </para>
+           </simpara>
            <para>
             <table>
              <title>Opções</title>
@@ -91,9 +91,9 @@
              </tgroup>
             </table>
            </para>
-           <para>
+           <simpara>
             Esta opção está disponível no MongoDB 4.0+.
-           </para>
+           </simpara>
           </entry>
           <entry><literal>[]</literal></entry>
          </row>
@@ -101,7 +101,7 @@
           <entry>snapshot</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Configure leituras de instantâneos em uma sessão. Se &true;, um timestamp
             será obtido da primeira operação de leitura suportada na sessão
             (ou seja, <literal>find</literal>, <literal>aggregate</literal> ou
@@ -109,18 +109,18 @@
             subsequentes dentro da sessão utilizarão um nível de preocupação de leitura
             <literal>"snapshot"</literal> (instantâneo) para ler os dados confirmados pela maioria daquele
             timestamp. Se definido como &false;, desativa leituras de instantâneos.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             As leituras de instantâneo requerem MongoDB 5.0+ e não podem ser usadas
             com consistência causal, transações ou operações de gravação. Se
             <literal>"snapshot"</literal> for &true;,
             <literal>"causalConsistency"</literal> será padronizado como &false;.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Consulte
             <link xlink:href="&url.mongodb.docs;reference/read-concern-snapshot/#read-concern-and-atclustertime">Preocupação de Leitura "snapshot"</link>
             no manual do MongoDB para obter mais informações.
-           </para>
+           </simpara>
           </entry>
           <entry>&false;</entry>
          </row>
@@ -135,9 +135,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <classname>MongoDB\Driver\Session</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -151,45 +151,43 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        <para>
-         A opção <literal>"snapshot"</literal> foi adicionada.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.6.0</entry>
-       <entry>
-        <para>
-         A opção <literal>"maxCommitTimeMS"</literal> foi adicionada a
-         <literal>"defaultTransactionOptions"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.5.0</entry>
-       <entry>
-        <para>
-         A opção <literal>"defaultTransactionOptions"</literal> foi adicionada.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       <simpara>
+        A opção <literal>"snapshot"</literal> foi adicionada.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.6.0</entry>
+      <entry>
+       <simpara>
+        A opção <literal>"maxCommitTimeMS"</literal> foi adicionada a
+        <literal>"defaultTransactionOptions"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.5.0</entry>
+      <entry>
+       <simpara>
+        A opção <literal>"defaultTransactionOptions"</literal> foi adicionada.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
18 refentries under ``reference/mongodb/mongodb/driver/manager*``: mechanical XML refactor (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.

``manager/construct.xml`` left out: its EN diff adds new URI option rows (``enableOverloadRetargeting``, ``maxAdaptiveRetries``) with substantial prose, requires a real translation pass.