### PR TITLE
Sync EN: mongodb driver Server, ServerApi, ServerDescription, TopologyDescription

### DIFF
--- a/reference/mongodb/mongodb/driver/server.xml
+++ b/reference/mongodb/mongodb/driver/server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\Server intro -->
   <section xml:id="mongodb-driver-server.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
 
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -109,73 +109,73 @@
     <varlistentry xml:id="mongodb-driver-server.constants.type-unknown">
      <term><constant>MongoDB\Driver\Server::TYPE_UNKNOWN</constant></term>
      <listitem>
-      <para>Tipo de servidor desconhecido, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor desconhecido, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-standalone">
      <term><constant>MongoDB\Driver\Server::TYPE_STANDALONE</constant></term>
      <listitem>
-      <para>Tipo de servidor autônomo, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor autônomo, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-mongos">
      <term><constant>MongoDB\Driver\Server::TYPE_MONGOS</constant></term>
      <listitem>
-      <para>Tipo de servidor Mongos, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor Mongos, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-possible-primary">
      <term><constant>MongoDB\Driver\Server::TYPE_POSSIBLE_PRIMARY</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas, possivelmente primário, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
-      <para>Um servidor pode ser identificado como um possível primário se ainda não tiver sido verificado, mas outra memória do conjunto de réplicas pensa que é o primário.</para>
+      <simpara>Tipo de servidor conjunto de réplicas, possivelmente primário, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Um servidor pode ser identificado como um possível primário se ainda não tiver sido verificado, mas outra memória do conjunto de réplicas pensa que é o primário.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-primary">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_PRIMARY</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas primário, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor conjunto de réplicas primário, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-secondary">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_SECONDARY</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas secundário, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor conjunto de réplicas secundário, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-arbiter">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_ARBITER</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas árbitro, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor conjunto de réplicas árbitro, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-other">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_OTHER</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas outros, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
-      <para>Esses servidores podem estar ocultos, inicializando ou recuperando. Eles não podem ser consultados, mas suas listas de hosts são úteis para descobrir a configuração atual do conjunto de réplicas.</para>
+      <simpara>Tipo de servidor conjunto de réplicas outros, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Esses servidores podem estar ocultos, inicializando ou recuperando. Eles não podem ser consultados, mas suas listas de hosts são úteis para descobrir a configuração atual do conjunto de réplicas.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-ghost">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_GHOST</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas fantasma, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
-      <para>Os servidores podem ser identificados como tal em pelo menos três situações: brevemente durante a inicialização do servidor; em um conjunto de réplicas não inicializado; ou quando o servidor é evitado (ou seja, removido da configuração do conjunto de réplicas). Eles não podem ser consultados, nem sua lista de hosts pode ser usada para descobrir a configuração atual do conjunto de réplicas; entretanto, o cliente pode monitorar este servidor na esperança de que ele faça a transição para um estado mais útil.</para>
+      <simpara>Tipo de servidor conjunto de réplicas fantasma, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Os servidores podem ser identificados como tal em pelo menos três situações: brevemente durante a inicialização do servidor; em um conjunto de réplicas não inicializado; ou quando o servidor é evitado (ou seja, removido da configuração do conjunto de réplicas). Eles não podem ser consultados, nem sua lista de hosts pode ser usada para descobrir a configuração atual do conjunto de réplicas; entretanto, o cliente pode monitorar este servidor na esperança de que ele faça a transição para um estado mais útil.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-load-balancer">
      <term><constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant></term>
      <listitem>
-      <para>Tipo de servidor balanceador de carga, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Tipo de servidor balanceador de carga, retornada por <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
@@ -185,30 +185,28 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 1.11.0</entry>
-        <entry>
-         <para>
-          A constante
-          <constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant>
-          foi adicionada.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        <simpara>
+         A constante
+         <constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant>
+         foi adicionada.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/server/construct.xml
+++ b/reference/mongodb/mongodb/driver/server/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dcfd0933c0adfb15d1efafa5c553b2e57c03d3a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Server::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Os objetos <classname>MongoDB\Driver\Server</classname> são criados internamente
    pelo <classname>MongoDB\Driver\Manager</classname> quando uma conexão com o banco de dados
    é estabelecida e podem ser retornados por
    <function>MongoDB\Driver\Manager::getServers</function> e
    <function>MongoDB\Driver\Manager::selectServer</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,21 +15,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa uma ou mais operações de gravação neste servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Um <classname>MongoDB\Driver\BulkWrite</classname> pode ser construído com
    uma ou mais operações de gravação de vários tipos (por exemplo, atualizações, exclusões e
    inserções). O driver tentará enviar operações do mesmo tipo ao
    servidor no menor número possível de solicitações para otimizar viagens de ida e volta.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O valor padrão para a opção <literal>"writeConcern"</literal> será
    inferido de uma transação ativa (indicada pela
    opção <literal>"session"</literal>), seguida pelo
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -82,60 +82,58 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O parâmetro <parameter>options</parameter> não aceita mais uma instância de
-        <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passar um objeto <classname>MongoDB\Driver\WriteConcern</classname> como
-        <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançada se a opção <literal>"session"</literal> for usada em combinação
-        com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        O terceiro parâmetro agora é um array <parameter>options</parameter>.
-        Para compatibilidade com versões anteriores, esse parâmetro ainda aceitará
-        um objeto <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        agora é lançada se <parameter>bulk</parameter> não contiver nenhuma operação
-        de gravação. Anteriormente, uma
-        <classname>MongoDB\Driver\Exception\BulkWriteException</classname> era
-        lançada.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O parâmetro <parameter>options</parameter> não aceita mais uma instância de
+       <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passar um objeto <classname>MongoDB\Driver\WriteConcern</classname> como
+       <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançada se a opção <literal>"session"</literal> for usada em combinação
+       com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       O terceiro parâmetro agora é um array <parameter>options</parameter>.
+       Para compatibilidade com versões anteriores, esse parâmetro ainda aceitará
+       um objeto <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       agora é lançada se <parameter>bulk</parameter> não contiver nenhuma operação
+       de gravação. Anteriormente, uma
+       <classname>MongoDB\Driver\Exception\BulkWriteException</classname> era
+       lançada.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,22 +14,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa uma ou mais operações de gravação neste servidor usando o comando
    <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
    introduzido no MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Um <classname>MongoDB\Driver\BulkWriteCommand</classname> pode ser construído
    com uma ou mais operações de gravação de tipos variados (por exemplo, inserções, atualizações
    e exclusões). Cada operação de gravação pode ter como alvo uma coleção diferente.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O valor padrão para a opção <literal>"writeConcern"</literal> será
    inferido a partir de uma transação ativa (indicada pela opção
    <literal>"session"</literal>), seguida pelo
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,23 +15,23 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa o comando neste servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método não aplica nenhuma lógica especial ao comando. Os
    valores padrão para as opções <literal>"readPreference"</literal>,
    <literal>"readConcern"</literal> e <literal>"writeConcern"</literal>
    serão inferidos de uma transação ativa (indicada pela
    opção <literal>"session"</literal>). Se não houver nenhuma transação ativa, uma
    preferência de leitura primária será usada para seleção do servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Os valores padrão <emphasis>não</emphasis> serão inferidos do
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
    Os usuários são, portanto, incentivados a usar métodos de comando específicos
    de leitura e/ou gravação, se possível.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -86,50 +86,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O parâmetro <parameter>options</parameter> não aceita mais uma instância de
-        <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
-        <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançada se a opção <literal>"session"</literal> for usada em
-        combinação com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        O terceiro parâmetro agora é um array <parameter>options</parameter>.
-        Para compatibilidade com versões anteriores, esse parâmetro ainda aceitará
-        um objeto <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O parâmetro <parameter>options</parameter> não aceita mais uma instância de
+       <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
+       <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançada se a opção <literal>"session"</literal> for usada em
+       combinação com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       O terceiro parâmetro agora é um array <parameter>options</parameter>.
+       Para compatibilidade com versões anteriores, esse parâmetro ainda aceitará
+       um objeto <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,15 +15,15 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa a consulta neste servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Os valores padrão para a opção <literal>"readPreference"</literal> e para a
    opção <literal>"readConcern"</literal> da consulta serão inferidos de uma transação
    ativa (indicada pela opção <literal>"session"</literal >), seguida
    pelo <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -73,42 +73,40 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O parâmetro <parameter>options</parameter> não aceita mais uma instância de
-        <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
-        <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        O terceiro parâmetro agora é um array <parameter>options</parameter>.
-        Para compatibilidade com versões anteriores, esse parâmetro ainda aceitará
-        um objeto <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O parâmetro <parameter>options</parameter> não aceita mais uma instância de
+       <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passar um objeto <classname>MongoDB\Driver\ReadPreference</classname> como
+       <parameter>options</parameter> foi descontinuado e será removido na versão 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       O terceiro parâmetro agora é um array <parameter>options</parameter>.
+       Para compatibilidade com versões anteriores, esse parâmetro ainda aceitará
+       um objeto <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,18 +15,18 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa o comando neste servidor, independentemente da
    opção <literal>"readPreference"</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará uma lógica específica para comandos de leitura (por exemplo,
    <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
    Os valores padrão para as opções <literal>"readPreference"</literal> e
    <literal>"readConcern"</literal> serão inferidos de uma transação
    ativa (indicada pela opção <literal>"session"</literal>), seguida
    pelo <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa o comando neste servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará lógica específica para comandos de leitura e gravação
    (por exemplo, <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Os valores padrão para as opções <literal>"readConcern"</literal> e
    <literal>"writeConcern"</literal> serão inferidos de uma transação
    ativa (indicada pela opção <literal>"session"</literal>), seguida
    pelo <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -78,28 +78,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançada se a opção <literal>"session"</literal> for usada em
-        combinação com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançada se a opção <literal>"session"</literal> for usada em
+       combinação com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Executa o comando neste servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará lógica específica para comandos que escrevem (por exemplo,
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    O valor padrão para a opção <literal>"writeConcern"</literal> será
    inferido de uma transação ativa (indicada pela
    opção <literal>"session"</literal>), seguida pelo
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexão</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Este método não se destina a ser usado para executar comandos
@@ -88,28 +88,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        será lançada se a opção <literal>"session"</literal> for usada em
-        combinação com uma preocupação de gravação não reconhecida.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       será lançada se a opção <literal>"session"</literal> for usada em
+       combinação com uma preocupação de gravação não reconhecida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/gethost.xml
+++ b/reference/mongodb/mongodb/driver/server/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Server::getHost</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome do host deste servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do host deste servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/server/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,22 +13,22 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um array de informações que descrevem o servidor. Esse array é derivado
    da resposta do comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link> mais recente
    obtida por meio de
    <link xlink:href="&url.mongodb.sdam;">monitoramento do servidor</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Quando o driver estiver conectado a um balanceador de carga, esse método retornará
     a resposta do comando
     <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
     enviada pelo servidor de apoio no handshake de conexão inicial. Isso contrasta
     com outros métodos (por exemplo, <function>MongoDB\Driver\Server::getType</function>),
     que retornarão informações sobre o próprio balanceador de carga.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -39,9 +39,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array de informações que descrevem este servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -205,28 +205,26 @@ array(23) {
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Quando o driver está conectado a um balanceador de carga, esse método retorna
-        a resposta do comando <literal>hello</literal> enviada pelo servidor de apoio
-        no handshake de conexão inicial.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Quando o driver está conectado a um balanceador de carga, esse método retorna
+       a resposta do comando <literal>hello</literal> enviada pelo servidor de apoio
+       no handshake de conexão inicial.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/getlatency.xml
+++ b/reference/mongodb/mongodb/driver/server/getlatency.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.getlatency" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>integer</type><type>null</type></type><methodname>MongoDB\Driver\Server::getLatency</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna a latência deste servidor em milissegundos. Este é o
    <link xlink:href="&url.mongodb.sdam;#round-trip-time">tempo de ida e volta</link>
    de um comando <literal>hello</literal>
    medido pelo cliente .
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a latência deste servidor em milissegundos ou &null; se nenhuma latência
    tiver sido medida (por exemplo, o cliente está conectado a um balanceador de carga).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -43,28 +43,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Este método retornará &null; se nenhuma latência tiver sido medida. Nas
-        versões anteriores, um número inteiro sempre era retornado e um valor não definido
-        poderia ser relatado como <literal>-1</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Este método retornará &null; se nenhuma latência tiver sido medida. Nas
+       versões anteriores, um número inteiro sempre era retornado e um valor não definido
+       poderia ser relatado como <literal>-1</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/server/getport.xml
+++ b/reference/mongodb/mongodb/driver/server/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Server::getPort</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna a porta na qual este servidor está escutando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a porta na qual este servidor está escutando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/getserverdescription.xml
+++ b/reference/mongodb/mongodb/driver/server/getserverdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.getserverdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ServerDescription</type><methodname>MongoDB\Driver\Server::getServerDescription</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um <classname>MongoDB\Driver\ServerDescription</classname> para este
    servidor. Este é um objeto de valor imutável que descreverá o servidor
    no momento em que este método for chamado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <classname>MongoDB\Driver\ServerDescription</classname> para este
    servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/gettags.xml
+++ b/reference/mongodb/mongodb/driver/server/gettags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.gettags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getTags</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um <type>array</type> de
    <link xlink:href="&url.mongodb.glossary;#term-tag">tags</link> usadas para
    descrever este servidor em um conjunto de réplicas. O array conterá zero ou mais
    pares de chave e valor <type>string</type>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <type>array</type> de tags usadas para descrever este servidor em um
    conjunto de réplicas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/gettype.xml
+++ b/reference/mongodb/mongodb/driver/server/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Server::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um <type>int</type> denotando o tipo deste servidor. O valor
    será correlacionado com uma constante <classname>MongoDB\Driver\Server</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <type>int</type> denotando o tipo deste servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/isarbiter.xml
+++ b/reference/mongodb/mongodb/driver/server/isarbiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.isarbiter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isArbiter</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se este servidor é um
    <link xlink:href="&url.mongodb.glossary;#term-arbiter">membro árbitro</link>
    de um conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se este servidor for um membro árbitro de um conjunto de réplicas ou
    &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/ishidden.xml
+++ b/reference/mongodb/mongodb/driver/server/ishidden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.ishidden" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isHidden</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se este servidor é um
    <link xlink:href="&url.mongodb.glossary;#term-hidden-member">membro oculto</link>
    de um conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se este servidor for um membro oculto de um conjunto de réplicas
    ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/ispassive.xml
+++ b/reference/mongodb/mongodb/driver/server/ispassive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.ispassive" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPassive</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se este servidor é um
    <link xlink:href="&url.mongodb.glossary;#term-passive-member">membro passivo</link>
    de um conjunto de réplicas (ou seja, sua prioridade é <literal>0</literal> ).
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se este servidor for um membro passivo de um conjunto de réplicas
    ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/isprimary.xml
+++ b/reference/mongodb/mongodb/driver/server/isprimary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.isprimary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPrimary</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se este servidor é um
    <link xlink:href="&url.mongodb.glossary;#term-primary">membro primário</link>
    de um conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se este servidor for um membro primário de um conjunto de réplicas
    ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/issecondary.xml
+++ b/reference/mongodb/mongodb/driver/server/issecondary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-server.issecondary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isSecondary</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se este servidor é um
    <link xlink:href="&url.mongodb.glossary;#term-secondary">membro secundário</link>
    de um conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se este servidor for um membro secundário de um conjunto de réplicas
    ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverapi.xml
+++ b/reference/mongodb/mongodb/driver/serverapi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-serverapi" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\ServerApi intro -->
   <section xml:id="mongodb-driver-serverapi.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
 
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -62,7 +62,7 @@
     <varlistentry xml:id="mongodb-driver-serverapi.constants.v1">
      <term><constant>MongoDB\Driver\ServerApi::V1</constant></term>
      <listitem>
-      <para>API do Servidor versão 1.</para>
+      <simpara>API do Servidor versão 1.</simpara>
      </listitem>
     </varlistentry>
 
@@ -114,11 +114,11 @@ echo $buildInfo->version, "\n";
 
    <example>
     <title>Declara uma versão estrita da API em um gerenciador</title>
-    <para>
+    <simpara>
      O exemplo a seguir define o sinalizador <parameter>strict</parameter>, que
      informa ao servidor para rejeitar qualquer comando que não faça parte da versão declarada
      da API. Isso resulta em um erro ao executar o comando buildInfo.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eaee72c33fe65d1d4648cd8a30bbec0aeb76c960 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverapi.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um objeto para serializar o ServerApi como BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7b808a875840b8850631210ef2190d681b6edfa Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverapi.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,11 +16,11 @@
    <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Cria uma nova instância <classname>MongoDB\Driver\ServerApi</classname>
    usada para declarar uma versão da API ao criar um
    <classname>MongoDB\Driver\Manager</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,36 +29,36 @@
    <varlistentry xml:id="mongodb-driver-serverapi.construct-version">
     <term><parameter>version</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma versão da API do servidor.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Versões de API suportadas são fornecidas como constantes em
       <classname>MongoDB\Driver\ServerApi</classname>. A única versão da API
       suportada é <constant>MongoDB\Driver\ServerApi::V1</constant>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="mongodb-driver-manager.construct-strict">
     <term><parameter>strict</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Se o parâmetro <parameter>strict</parameter> estiver definido como &true;, o
       servidor gerará um erro para qualquer comando que não faça parte da
       versão da API especificada. Se nenhum valor for fornecido, o valor padrão do servidor
       (&false;) será usado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="mongodb-driver-manager.construct-deprecationErrors">
     <term><parameter>deprecationErrors</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Se o parâmetro <parameter>deprecationErrors</parameter> estiver definido como &true;,
       o servidor gerará um erro ao usar um comando que está obsoleto na
       versão da API especificada. Se nenhum valor for fornecido, o valor padrão do servidor
       (&false;) será usado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/serverdescription.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-serverdescription" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,13 +11,13 @@
 <!-- {{{ MongoDB\Driver\ServerDescription intro -->
   <section xml:id="mongodb-driver-serverdescription.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\ServerDescription</classname> é um objeto de valor
     que representa um servidor ao qual o driver está conectado. Instâncias
     desta classe são retornadas pelos métodos
     <function>MongoDB\Driver\Server::getServerDescription</function> e
     <classname>MongoDB\Driver\Monitoring\ServerChangedEvent</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -113,73 +113,73 @@
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-unknown">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_UNKNOWN</constant></term>
      <listitem>
-      <para>Tipo de servidor desconhecido, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor desconhecido, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-standalone">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_STANDALONE</constant></term>
      <listitem>
-      <para>Tipo de servidor autônomo, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor autônomo, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-mongos">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_MONGOS</constant></term>
      <listitem>
-      <para>Tipo de servidor Mongos, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor Mongos, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-possible-primary">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_POSSIBLE_PRIMARY</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas, possivelmente primário, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
-      <para>Um servidor pode ser identificado como um possível primário se ainda não tiver sido verificado, mas outra memória do conjunto de réplicas pensa que é o primário.</para>
+      <simpara>Tipo de servidor conjunto de réplicas, possivelmente primário, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
+      <simpara>Um servidor pode ser identificado como um possível primário se ainda não tiver sido verificado, mas outra memória do conjunto de réplicas pensa que é o primário.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-primary">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_PRIMARY</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas primário, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor conjunto de réplicas primário, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-secondary">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_SECONDARY</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas secundário, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor conjunto de réplicas secundário, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-arbiter">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_ARBITER</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas árbitro, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor conjunto de réplicas árbitro, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-other">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_OTHER</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas outros, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
-      <para>Esses servidores podem estar ocultos, inicializando ou recuperando. Eles não podem ser consultados, mas suas listas de hosts são úteis para descobrir a configuração atual do conjunto de réplicas.</para>
+      <simpara>Tipo de servidor conjunto de réplicas outros, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
+      <simpara>Esses servidores podem estar ocultos, inicializando ou recuperando. Eles não podem ser consultados, mas suas listas de hosts são úteis para descobrir a configuração atual do conjunto de réplicas.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-ghost">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_GHOST</constant></term>
      <listitem>
-      <para>Tipo de servidor conjunto de réplicas fantasma, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
-      <para>Os servidores podem ser identificados como tal em pelo menos três situações: brevemente durante a inicialização do servidor; em um conjunto de réplicas não inicializado; ou quando o servidor é evitado (ou seja, removido da configuração do conjunto de réplicas). Eles não podem ser consultados, nem sua lista de hosts pode ser usada para descobrir a configuração atual do conjunto de réplicas; entretanto, o cliente pode monitorar este servidor na esperança de que ele faça a transição para um estado mais útil.</para>
+      <simpara>Tipo de servidor conjunto de réplicas fantasma, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
+      <simpara>Os servidores podem ser identificados como tal em pelo menos três situações: brevemente durante a inicialização do servidor; em um conjunto de réplicas não inicializado; ou quando o servidor é evitado (ou seja, removido da configuração do conjunto de réplicas). Eles não podem ser consultados, nem sua lista de hosts pode ser usada para descobrir a configuração atual do conjunto de réplicas; entretanto, o cliente pode monitorar este servidor na esperança de que ele faça a transição para um estado mais útil.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-load-balancer">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_LOAD_BALANCER</constant></term>
      <listitem>
-      <para>Tipo de servidor balanceador de carga, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Tipo de servidor balanceador de carga, retornada por <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/serverdescription/gethelloresponse.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gethelloresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverdescription.gethelloresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,23 +13,23 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\ServerDescription::getHelloResponse</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um array de informações que descrevem o servidor. Este array é derivado
    da resposta mais recento ao comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link> (no momento em que
    <classname>MongoDB\Driver\ServerDescription</classname> foi construído)
    obtida através do
    <link xlink:href="&url.mongodb.sdam;">monitoramento do servidor</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Quando o driver estiver conectado a um balanceador de carga, esse método retornará um
     array vazio, pois os balanceadores de carga não são monitorados. Isso contrasta com
     <function>MongoDB\Driver\Server::getInfo</function>, que retornaria a resposta do comando
     <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
     do servidor de apoio
     no handshake de conexão inicial.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -40,9 +40,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array de informações que descrevem o servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/gethost.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverdescription.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerDescription::getHost</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome do host deste servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome do host deste servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getlastupdatetime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getlastupdatetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverdescription.getlastupdatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getLastUpdateTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o horário da última atualização do servidor em microssegundos.
-  </para>
+  </simpara>
   <note>
    <simpara>
     O valor retornado é um timestamp monotônico, que começa em um ponto
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o horário da última atualização do servidor em microssegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getport.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverdescription.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getPort</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna a porta na qual este servidor está escutando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a porta na qual este servidor está escutando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverdescription.getroundtriptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\ServerDescription::getRoundTripTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o tempo de ida e volta do servidor em milissegundos. Esta é a medida do
    cliente sobre a duração
    de um comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o tempo de ida e volta do servidor em milissegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-serverdescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerDescription::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna uma <type>string</type> denotando o tipo deste servidor. O valor
    será correlacionado com uma constante
    <classname>MongoDB\Driver\ServerDescription</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma <type>string</type> denotando o tipo deste servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-topologydescription" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,13 +11,13 @@
 <!-- {{{ MongoDB\Driver\TopologyDescription intro -->
   <section xml:id="mongodb-driver-topologydescription.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\TopologyDescription</classname> é um
     objeto de valor que representa uma topologia à qual o driver está conectado.
     As instâncias desta classe são retornadas pelos
     métodos
     <classname>MongoDB\Driver\Monitoring\TopologyChangedEvent</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -89,42 +89,42 @@
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-unknown">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_UNKNOWN</constant></term>
      <listitem>
-      <para>Tipo de topologia desconhecido, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Tipo de topologia desconhecido, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-single">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_SINGLE</constant></term>
      <listitem>
-      <para>Servidor único (ou seja, conexão direta), retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Servidor único (ou seja, conexão direta), retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-sharded">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_SHARDED</constant></term>
      <listitem>
-      <para>Cluster fragmentado, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Cluster fragmentado, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-replica-set-no-primary">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_REPLICA_SET_NO_PRIMARY</constant></term>
      <listitem>
-      <para>Conjunto de réplicas sem servidor primário, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Conjunto de réplicas sem servidor primário, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-replica-set-with-primary">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_REPLICA_SET_WITH_PRIMARY</constant></term>
      <listitem>
-      <para>Conjunto de réplicas com um servidor primário, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Conjunto de réplicas com um servidor primário, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-load-balanced">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_LOAD_BALANCED</constant></term>
      <listitem>
-      <para>Topologia com balanceamento de carga, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Topologia com balanceamento de carga, retornada por <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-topologydescription.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\TopologyDescription::getServers</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna um array de objetos <classname>MongoDB\Driver\ServerDescription</classname>
    correspondentes aos servidores conhecidos na topologia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array de objetos <classname>MongoDB\Driver\ServerDescription</classname>
    correspondentes aos servidores conhecidos na topologia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-topologydescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\TopologyDescription::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna uma <type>string</type> denotando o tipo desta topologia. O valor
    será correlacionado com uma constante
    <classname>MongoDB\Driver\TopologyDescription</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma <type>string</type> denotando o tipo desta topologia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-topologydescription.hasreadableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasReadableServer</methodname>
    <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se a topologia possui um servidor para leitura ou, se
    <parameter>readPreference</parameter> for especificado, um servidor
    que corresponda à preferência de leitura especificada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,11 +27,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna se a topologia possui um servidor para leitura ou, se
    <parameter>readPreference</parameter> for especificado, um servidor
    que corresponda à preferência de leitura especificada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-topologydescription.haswritableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasWritableServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se a topologia possui um servidor para gravação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna se a topologia possui um servidor para gravação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
36 refentries: ``Server`` + ``ServerApi`` + ``ServerDescription`` + ``TopologyDescription`` and their methods. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.