### PR TITLE
Sync EN: mongodb driver Cursor, CursorId, CursorInterface

### DIFF
--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-cursor" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\Driver\Cursor intro -->
   <section xml:id="mongodb-driver-cursor.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\Cursor</classname> encapsula
     os resultados de um comando ou consulta MongoDB e podem ser retornados por
     <methodname>MongoDB\Driver\Manager::executeCommand</methodname> ou
     <methodname>MongoDB\Driver\Manager::executeQuery</methodname>, respectivamente.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -49,33 +49,31 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 1.9.0</entry>
-        <entry>
-         Implementa <interfacename>Iterator</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.6.0</entry>
-        <entry>
-         Implementa <interfacename>MongoDB\Driver\CursorInterface</interfacename>,
-         que estende <interfacename>Traversable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.9.0</entry>
+       <entry>
+        Implementa <interfacename>Iterator</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.6.0</entry>
+       <entry>
+        Implementa <interfacename>MongoDB\Driver\CursorInterface</interfacename>,
+        que estende <interfacename>Traversable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
   <section xml:id="mongodb-driver-cursor.examples">
@@ -83,19 +81,19 @@
 
    <example xml:id="mongodb-driver-cursor.examples.foreach">
     <title>Lendo um conjunto de resultados</title>
-    <para>
+    <simpara>
      <methodname>MongoDB\Driver\Manager::executeCommand</methodname> e
      <methodname>MongoDB\Driver\Manager::executeQuery</methodname> ambos retornam
      seus resultados como um objeto <classname>MongoDB\Driver\Cursor</classname>.
      Este objeto pode ser usado para iterar sobre conjunto de resultados do comando
      ou consulta.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Como <classname>MongoDB\Driver\Cursor</classname> implementa a
      interface <interfacename>Traversable</interfacename>, pode-se simplesmente
      iterar pelo conjunto de resultados com
      <link linkend="control-structures.foreach"><literal>foreach</literal></link>.
-    </para>
+    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -154,15 +152,15 @@ stdClass Object
 
    <example xml:id="mongodb-driver-cursor.examples.tailable">
     <title>Lendo um conjunto de resultados com um cursor adaptável</title>
-    <para>
+    <simpara>
      <link xlink:href="&url.mongodb.docs;core/tailable-cursors">Cursores adaptáveis</link>
      são um tipo especial de cursor no MongoDB que permite ao cliente ler alguns
      resultados e então esperar até que mais documentos fiquem disponíveis. Esses cursores
      são usado principalmente com
      <link xlink:href="&url.mongodb.docs;core/capped-collections">Coleções Limitadas</link>
      e <link xlink:href="&url.mongodb.docs;changeStreams">Fluxos de Alterações</link>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Enquanto os cursores normais podem ser iterados com <literal>foreach</literal>,
      esse método não irá funcionar com cursores adaptáveis. Quando
      <literal>foreach</literal> é usado com um cursor adaptável, a repetição irá
@@ -172,21 +170,21 @@ stdClass Object
      retroceder o cursor. De forma similar aos objetos de resultados em outros drivers de bancos de dados,
      os cursores no MongoDB suportam apenas iteração para a frente, ou seja, eles não podem
      ser retrocedidos.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Para ler continuamente a partir de um cursor adaptável, o objeto Cursor
      deve ser encapsulado com um <classname>IteratorIterator</classname>. Isso
      permite que a aplicação controle diretamente a iteração do cursor, evite
      retroceder inadvertidamente o cursor e decida quando esperar por novos resultados
      ou interromper totalmente a iteração.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Para demonstrar um cursor adaptável em ação, serão utilizados dois
      scripts: um "produtor" e um "consumidor". O script produtor criará uma nova
      coleção limitada usando o
      comando <link xlink:href="&url.mongodb.docs.command;create">create</link>
      e procederá à inserção de um novo documento nessa coleção a cada segundo.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -210,12 +208,12 @@ while (true) {
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Com o script produtor ainda em execução, um segundo script consumidor pode ser
      executado para ler os documentos inseridos usando um cursor adaptável, indicado
      pelas opções <literal>tailable</literal> e <literal>awaitData</literal>
      para o método <function>MongoDB\Driver\Query::__construct</function>.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -245,7 +243,7 @@ while (true) {
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      O script consumidor começará mostrando rapidamente todos os documentos disponíveis
      na coleção limitada (como se <literal>foreach</literal> tivesse sido usado);
      entretanto, ele não terminará ao atingir o final do conjunto de resultados inicial.
@@ -253,7 +251,7 @@ while (true) {
      <function>IteratorIterator::next</function> bloqueará e aguardará
      resultados adicionais. <function>IteratorIterator::valid</function> também é
      usado para verificar se realmente há dados disponíveis para leitura em cada etapa.
-    </para>
+    </simpara>
     <note>
      <simpara>
       Este exemplo usa a opção de consulta <literal>awaitData</literal> para

--- a/reference/mongodb/mongodb/driver/cursor/construct.xml
+++ b/reference/mongodb/mongodb/driver/cursor/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d88708b86fa2e642dc3b5c1d9903a149aa0c185 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursor.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Cursor::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Objetos <classname>MongoDB\Driver\Cursor</classname> são retornados como o o
    resultado de consultas ou comandos executados e não podem ser construídos diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/cursor/current.xml
+++ b/reference/mongodb/mongodb/driver/cursor/current.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-driver-cursor.current" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Cursor::current</refname>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de resultado atual como um array ou objeto, dependendo do
    mapa de tipo do cursor. Se a iteração não tiver iniciado ou se a posição atual
    não for válida, retorna &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/cursor/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursor/getid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursor.getid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Int64</type><methodname>MongoDB\Driver\Cursor::getId</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o ID para este cursor, que identifica de forma única o cursor no
    servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID para este cursor. O ID será retornado como um
    objeto <classname>MongoDB\BSON\Int64</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -41,36 +41,34 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        O tipo de retorno foi alterado para <classname>MongoDB\BSON\Int64</classname>.
-        O parâmetro <parameter>asInt64</parameter> foi removido.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        O retorno de um <classname>MongoDB\Driver\CursorId</classname> foi descontinuado.
-        Adicionado o parâmetro <parameter>asInt64</parameter> para facilitar a migração para
-        versões futuras. Se <parameter>asInt64</parameter> for &true;, o ID
-        será retornado como um <classname>MongoDB\BSON\Int64</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       O tipo de retorno foi alterado para <classname>MongoDB\BSON\Int64</classname>.
+       O parâmetro <parameter>asInt64</parameter> foi removido.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       O retorno de um <classname>MongoDB\Driver\CursorId</classname> foi descontinuado.
+       Adicionado o parâmetro <parameter>asInt64</parameter> para facilitar a migração para
+       versões futuras. Se <parameter>asInt64</parameter> for &true;, o ID
+       será retornado como um <classname>MongoDB\BSON\Int64</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/cursor/getserver.xml
+++ b/reference/mongodb/mongodb/driver/cursor/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2de5fb458e886b011050a210c6f406ca9ed51c75 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursor.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Cursor::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> associado a este
    cursor. Este é o servidor que executou a
    <classname>MongoDB\Driver\Query</classname> ou o
    <classname>MongoDB\Driver\Command</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> associado a este
    cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursor/isdead.xml
+++ b/reference/mongodb/mongodb/driver/cursor/isdead.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1e327d12051bfc071aea2910c285dd9385565609 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursor.isdead" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Cursor::isDead</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Verifica se definitivamente não há resultados adicionais disponíveis no
    cursor. Este método é semelhante ao método
    <link xlink:href="&url.mongodb.docs;reference/method/cursor.isExhausted/">cursor.isExhausted()</link>
    no shell do MongoDB e é útil principalmente ao iterar
    <link xlink:href="&url.mongodb.docs;core/tailable-cursors/">cursores adaptáveis</link>.
-  </para>
+  </simpara>
   <para>
    Um cursor não tem resultados adicionais e é considerado "morto" quando uma das seguintes
    opções for verdadeira:
@@ -62,10 +62,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se definitivamente não houver resultados adicionais disponíveis no
    cursor e &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursor/key.xml
+++ b/reference/mongodb/mongodb/driver/cursor/key.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- EN-Revision: 57a945c977e3e6d274895f44645c703ebcacfa3c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-driver-cursor.key" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Cursor::key</refname>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O índice numérico do resultado atual dentro do cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/cursor/next.xml
+++ b/reference/mongodb/mongodb/driver/cursor/next.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- EN-Revision: 57a945c977e3e6d274895f44645c703ebcacfa3c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-driver-cursor.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Cursor::next</refname>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Move a posição atual para o próximo elemento no cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursor/rewind.xml
+++ b/reference/mongodb/mongodb/driver/cursor/rewind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- EN-Revision: 57a945c977e3e6d274895f44645c703ebcacfa3c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-driver-cursor.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Cursor::rewind</refname>
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Cursor::rewind</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Se o cursor tiver avançado além da sua primeira posição, não poderá mais ser
    retrocedido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursor/settypemap.xml
+++ b/reference/mongodb/mongodb/driver/cursor/settypemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8b0b6b72fac737d9ec0cb50ce33640eac2558ae4 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursor.settypemap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Cursor::setTypeMap</methodname>
    <methodparam><type>array</type><parameter>typemap</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define a <link linkend="mongodb.persistence.typemaps">configuração do mapa
    de tipos</link> a ser usada ao desserializar os resultados do BSON em
    valores PHP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursor/toarray.xml
+++ b/reference/mongodb/mongodb/driver/cursor/toarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2c423ff085531b5a614c7b10c2d8cf957cdda808 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursor.toarray" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Cursor::toArray</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Itera o cursor e retorna seus resultados em um aray.
    A função <function>MongoDB\Driver\Cursor::setTypeMap</function> pode ser usada para controlar
    como os documentos são desserializados em valores PHP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <type>array</type> contendo todos os resultados deste cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursor/valid.xml
+++ b/reference/mongodb/mongodb/driver/cursor/valid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- EN-Revision: 57a945c977e3e6d274895f44645c703ebcacfa3c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 <refentry xml:id="mongodb-driver-cursor.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Cursor::valid</refname>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; se a posição atual do cursor for válida, &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/cursorid.xml
+++ b/reference/mongodb/mongodb/driver/cursorid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-cursorid" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,18 +11,18 @@
 <!-- {{{ MongoDB\Driver\CursorId intro -->
   <section xml:id="mongodb-driver-cursorid.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\CursorID</classname> é um objeto de valor
     que representa um ID de cursor. Instâncias desta classe são retornadas por
     <function>MongoDB\Driver\Cursor::getId</function>.
-   </para>
+   </simpara>
    <warning>
-    <para>
+    <simpara>
      Esta classe foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
      de extensão 1.20.0 e foi removida na versão 2.0. As aplicações devem atualizar
      seu uso de <methodname>MongoDB\Driver\Cursor::getId</methodname> para retornar
      um <classname>MongoDB\BSON\Int64</classname> no lugar.
-    </para>
+    </simpara>
    </warning>
   </section>
 <!-- }}} -->
@@ -60,39 +60,37 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       &mongodb.changelog.class-removed;
-       <row>
-        <entry>PECL mongodb 1.20.0</entry>
-        <entry>
-         Esta classe foi descontinuada e será removida na versão 2.0.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.12.0</entry>
-        <entry>
-         Implementa <interfacename>Stringable</interfacename> para o PHP 8.0+.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.7.0</entry>
-        <entry>
-         Implementa <interfacename>Serializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &mongodb.changelog.class-removed;
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        Esta classe foi descontinuada e será removida na versão 2.0.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        Implementa <interfacename>Stringable</interfacename> para o PHP 8.0+.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        Implementa <interfacename>Serializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/cursorid/construct.xml
+++ b/reference/mongodb/mongodb/driver/cursorid/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8dcacceecc82fd06ff2f7576a5ef64e2acc62736 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorid.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\CursorId::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Objetos <classname>MongoDB\Driver\CursorId</classname> são retornados pela função
    <function>MongoDB\Driver\Cursor::getId</function> e não podem ser construídos
    diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/cursorid/tostring.xml
+++ b/reference/mongodb/mongodb/driver/cursorid/tostring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ff13d6d3795fd73f8dd57ee92743b967c5fd0d0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorid.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\CursorId::__toString</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna a representação em <type>string</type> do ID de cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a representação em <type>string</type> do ID de cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/cursorinterface.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-cursorinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
   <!-- {{{ MongoDB\Driver\CursorInterface intro -->
   <section xml:id="mongodb-driver-cursorinterface.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Esta interface é implementada por
     <classname>MongoDB\Driver\Cursor</classname> para ser usada como
     um tipo de parâmetro, de retorno ou de propriedade em classes do usuário.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -47,32 +47,30 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.0.0</entry>
-        <entry>
-         <para>
-          Esta interface agora estende <interfacename>Iterator</interfacename>.
-         </para>
-         <para>
-          Tipos de retorno anteriormente declarados como temporários agora devem ser cumpridos.
-         </para>
-        </entry>
-       </row>
-       &mongodb.changelog.tentative-return-types;
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.0.0</entry>
+       <entry>
+        <simpara>
+         Esta interface agora estende <interfacename>Iterator</interfacename>.
+        </simpara>
+        <simpara>
+         Tipos de retorno anteriormente declarados como temporários agora devem ser cumpridos.
+        </simpara>
+       </entry>
+      </row>
+      &mongodb.changelog.tentative-return-types;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/cursorinterface/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/getid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorinterface.getid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Int64</type><methodname>MongoDB\Driver\CursorInterface::getId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o ID deste cursor, que identifica o cursor de forma única no
    servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID deste cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -40,28 +40,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Adicionado <classname>MongoDB\BSON\Int64</classname> ao tipo de retorno
-        provisório para este método. <classname>MongoDB\Driver\CursorId</classname>
-        será removido do tipo de retorno na versão 2.0.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Adicionado <classname>MongoDB\BSON\Int64</classname> ao tipo de retorno
+       provisório para este método. <classname>MongoDB\Driver\CursorId</classname>
+       será removido do tipo de retorno na versão 2.0.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/cursorinterface/getserver.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 04ca316e18ff2e9fec8d15d02b98bd5625fac067 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorinterface.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\CursorInterface::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> associado a este
    cursor. Este é o servidor que executou a
    <classname>MongoDB\Driver\Query</classname> ou o
    <classname>MongoDB\Driver\Command</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> associado a este
    cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursorinterface/isdead.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/isdead.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 04ca316e18ff2e9fec8d15d02b98bd5625fac067 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorinterface.isdead" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,10 +34,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se não houver resultados adicionais disponíveis ou &false;
    caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursorinterface/settypemap.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/settypemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 04ca316e18ff2e9fec8d15d02b98bd5625fac067 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorinterface.settypemap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\CursorInterface::setTypeMap</methodname>
    <methodparam><type>array</type><parameter>typemap</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define a <link linkend="mongodb.persistence.typemaps">configuração do mapa
    de tipos</link> a ser usada ao desserializar os resultados do
    BSON em valores PHP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/cursorinterface/toarray.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface/toarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 04ca316e18ff2e9fec8d15d02b98bd5625fac067 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-cursorinterface.toarray" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\CursorInterface::toArray</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Itera o cursor e retorna seus resultados em um array.
    A função <function>MongoDB\Driver\CursorInterface::setTypeMap</function> pode ser usada
    para controlar como os documentos serão desserializados em valores PHP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <type>array</type> contendo todos os resultados deste cursor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
21 refentries: ``Cursor`` + ``CursorId`` + ``CursorInterface`` and their methods. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.