### PR TITLE
Sync EN: mongodb driver Session

### DIFF
--- a/reference/mongodb/mongodb/driver/session.xml
+++ b/reference/mongodb/mongodb/driver/session.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\Driver\Session intro -->
   <section xml:id="mongodb-driver-session.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\Session</classname> representa uma
     sessão do cliente e é retornada por
     <methodname>MongoDB\Driver\Manager::startSession</methodname>. Comandos,
     consultas e operações de gravação podem então ser associados à sessão.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -83,45 +83,45 @@
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-none">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_NONE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Não há nenhuma transação em andamento.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-starting">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_STARTING</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Uma transação foi iniciada, mas nenhuma operação foi enviada ao servidor.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-in-progress">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_IN_PROGRESS</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Uma transação está em andamento.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-committed">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_COMMITTED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        A transação foi confirmada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-aborted">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_ABORTED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        A transação foi abortada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/session/aborttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/aborttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f1e951b988e8aafe49b33bdf2f7812740c66c2d2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.aborttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::abortTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Encerra a transação de vários documentos e reverte quaisquer alterações de dados
    feitas pelas operações da transação. Ou seja, a transação termina
    sem salvar nenhuma das alterações feitas pelas operações da transação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.advanceclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +13,17 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>clusterTime</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Avança o tempo do cluster para esta sessão. Se o tempo do cluster for menor
    ou igual ao tempo atual do cluster da sessão, esta função não terá ação.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Ao usar este método em conjunto com
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> para copiar
    o cluster e os tempos de operação de outra sessão, é garantido que
    as operações nesta sessão serão causalmente consistentes com a última operação na
    outra sessão.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,12 +32,12 @@
    <varlistentry>
     <term><parameter>clusterTime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O horário do cluster é um documento que contém um timestamp lógico e uma
       assinatura do servidor. Normalmente, esse valor será obtido chamando
       <methodname>MongoDB\Driver\Session::getClusterTime</methodname> em outro
       objeto de sessão.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.advanceoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,18 +13,18 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceOperationTime</methodname>
    <methodparam><type>MongoDB\BSON\TimestampInterface</type><parameter>operationTime</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Avança o tempo de operação desta sessão. Se o tempo de operação for menor
    ou igual ao tempo de operação atual da sessão, esta função
    não terá ação.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Ao usar este método em conjunto com
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> para copiar
    os tempos de operação e cluster de outra sessão, é garantido que
    as operações nesta sessão sejam causalmente consistentes com a última operação
    na outra sessão.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -33,12 +33,12 @@
    <varlistentry>
     <term><parameter>operationTime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O tempo de operação é um timestamp lógico. Normalmente, esse valor será
       obtido chamando
       <methodname>MongoDB\Driver\Session::getOperationTime</methodname> em
       outro objeto de sessão.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,9 +46,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63fc2906221a3cdb9bc086aba6f05ee407d2c13b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.committransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::commitTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Salva as alterações feitas pelas operações na transação multidocumento
    e finaliza a transação. Até a confirmação, nenhuma das alterações de dados feitas
    dentro da transação será visível fora da transação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/construct.xml
+++ b/reference/mongodb/mongodb/driver/session/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Session::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Os objetos <classname>MongoDB\Driver\Session</classname> são retornados por
    <methodname>MongoDB\Driver\Manager::startSession</methodname> e não podem ser
    construídos diretamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/session/endsession.xml
+++ b/reference/mongodb/mongodb/driver/session/endsession.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 69b7314dc644c27289de76afc93684a98428ad05 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.endsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::endSession</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Este método fecha uma sessão existente. Se uma transação foi associada
    a esta sessão, a transação será abortada. Após chamar esse
    método, as aplicações não deverão invocar outros métodos na sessão.
-  </para>
+  </simpara>
   <note>
    <simpara>
     As sessões também são encerradas durante a coleta de lixo. Não deveria ser
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/getclustertime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.getclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Session::getClusterTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o tempo do cluster para esta sessão. Se a sessão não tiver sido usada
    para nenhuma operação e
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> não tiver
    sido chamado, o tempo do cluster será &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o tempo do cluster para esta sessão, ou &null; se a sessão não
    tiver tempo de cluster.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
+++ b/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.getlogicalsessionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Session::getLogicalSessionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o ID da sessão lógica desta sessão, que pode ser usado para
    identificar as operações desta sessão no servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o ID da sessão lógica desta sessão.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/getoperationtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.getoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Timestamp</type><type>null</type></type><methodname>MongoDB\Driver\Session::getOperationTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o tempo de operação desta sessão. Se a sessão não tiver sido usada
    para nenhuma operação e
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> não tiver
    sido chamado, o tempo de operação será &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o tempo de operação desta sessão, ou &null; se a sessão não
    tiver tempo de operação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getserver.xml
+++ b/reference/mongodb/mongodb/driver/session/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +13,17 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\Server</type><type>null</type></type><methodname>MongoDB\Driver\Session::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> ao qual esta
    sessão está fixada. Se a sessão não estiver fixada a um servidor, &null; será
    retornado.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    A fixação de sessão é usada principalmente para transações fragmentadas, pois todos os comandos
    dentro de uma transação fragmentada devem ser enviados para a mesma instância do mongos. Este
    método destina-se a ser usado por bibliotecas construídas sobre a extensão para permitir
    o uso de um servidor fixado em vez de invocar a seleção do servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -33,10 +33,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> ao qual esta sessão
    está fixada ou &null; se a sessão não estiver fixada em nenhum servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.gettransactionoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna opções para a transação atualmente em execução.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <type>array</type> contendo opções de transação atuais, ou
    &null; se nenhuma transação estiver em execução.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8482dea2af701e5aef299fda555ddc9e1587184 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.gettransactionstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Session::getTransactionState</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o estado da transação para esta sessão.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o estado atual da transação para esta sessão.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/isdirty.xml
+++ b/reference/mongodb/mongodb/driver/session/isdirty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d5127e772887addc6553066a33b31af086cd93b1 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.isdirty" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isDirty</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se a sessão foi marcada como suja (ou seja, foi usada
    com um comando que encontrou um erro de rede).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna se a sessão foi marcada como suja.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/isintransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/isintransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.isintransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isInTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se uma transação de vários documentos está em andamento para
    esta sessão. Uma transação é considerada “em andamento” se tiver sido
    iniciada, mas não tiver sido confirmada ou abortada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se uma transação estiver em andamento para esta sessão
    ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-session.starttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,15 +13,15 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::startTransaction</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Inicia uma transação de vários documentos associada à sessão. A qualquer momento,
    pode-se ter no máximo uma transação aberta por sessão. Após iniciar
    uma transação, o objeto de sessão deve ser passado para cada operação através
    da opção <literal>"session"</literal> (por exemplo,
    <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) para
    associar aquela operação com a transação.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    As transações podem ser confirmadas por meio de
    <methodname>MongoDB\Driver\Session::commitTransaction</methodname> e
    abortadas com
@@ -29,7 +29,7 @@
    As transações também são abortadas automaticamente quando a sessão é fechada
    pela coleta de lixo ou chamando explicitamente
    <methodname>MongoDB\Driver\Session::endSession</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,13 +38,13 @@
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       As opções podem ser passadas como argumento para este método. Cada elemento neste
       array de opções substitui a opção correspondente da
       opção <literal>"defaultTransactionOptions"</literal>, se definida ao
       iniciar a sessão com
       <methodname>MongoDB\Driver\Manager::startSession</methodname>.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>Opções</title>
@@ -72,9 +72,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -88,28 +88,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.6.0</entry>
-       <entry>
-        <para>
-         A opção <literal>"maxCommitTimeMS"</literal> foi adicionada.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.6.0</entry>
+      <entry>
+       <simpara>
+        A opção <literal>"maxCommitTimeMS"</literal> foi adicionada.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
16 refentries: ``Session`` and its methods. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``, trailing whitespace cleanup). Portuguese prose preserved.