### PR TITLE
Sync EN: mongodb driver ClientEncryption

### DIFF
--- a/reference/mongodb/mongodb/driver/clientencryption.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-clientencryption" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,11 +11,11 @@
   <!-- {{{ MongoDB\Driver\ClientEncryption intro -->
   <section xml:id="mongodb-driver-clientencryption.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\ClientEncryption</classname> lida com
     a criação de chaves de dados para criptografia no lado do cliente e também com
     criptografia e descriptografia manuais de valores.
-   </para>
+   </simpara>
   </section>
   <!-- }}} -->
 
@@ -95,49 +95,49 @@
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.deterministic">
      <term><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC</constant></term>
      <listitem>
-      <para>Especifica um algoritmo para <link xlink:href="&url.mongodb.docs;core/csfle/fundamentals/encryption-algorithms/#deterministic-encryption">criptografia determinística</link>, que é adequado para consultas.</para>
+      <simpara>Especifica um algoritmo para <link xlink:href="&url.mongodb.docs;core/csfle/fundamentals/encryption-algorithms/#deterministic-encryption">criptografia determinística</link>, que é adequado para consultas.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.random">
      <term><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM</constant></term>
      <listitem>
-      <para>Especifica um algoritmo para <link xlink:href="&url.mongodb.docs;core/csfle/fundamentals/encryption-algorithms/#randomized-encryption">criptografia aleatorizada</link></para>
+      <simpara>Especifica um algoritmo para <link xlink:href="&url.mongodb.docs;core/csfle/fundamentals/encryption-algorithms/#randomized-encryption">criptografia aleatorizada</link></simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.algorithm-indexed">
      <term><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant></term>
      <listitem>
-      <para>Especifica um algoritmo para uma carga criptografada e indexada, que pode ser usada com criptografia consultável.</para>
-      <para>Para inserir ou consultado com uma carga criptografada e indexada, a classe <classname>MongoDB\Driver\Manager</classname> precisa ser configurada com a opção <literal>"autoEncryption"</literal> do driver. A opção de autocriptografia <literal>"bypassQueryAnalysis"</literal> pode ser &true;. A opção de autocriptografia <literal>"bypassAutoEncryption"</literal> precisa ser &false;.</para>
+      <simpara>Especifica um algoritmo para uma carga criptografada e indexada, que pode ser usada com criptografia consultável.</simpara>
+      <simpara>Para inserir ou consultado com uma carga criptografada e indexada, a classe <classname>MongoDB\Driver\Manager</classname> precisa ser configurada com a opção <literal>"autoEncryption"</literal> do driver. A opção de autocriptografia <literal>"bypassQueryAnalysis"</literal> pode ser &true;. A opção de autocriptografia <literal>"bypassAutoEncryption"</literal> precisa ser &false;.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.algorithm-unindexed">
      <term><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant></term>
      <listitem>
-      <para>Especifica um algoritmo para uma carga criptografada e não indexada.</para>
+      <simpara>Especifica um algoritmo para uma carga criptografada e não indexada.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.algorithm-range">
      <term><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Especifica um algoritmo para uma carga criptografada por intervalo, que pode ser usada
        com criptgrafia consultável.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Para consultar com uma carga criptografada por intervalo, a classe
        <classname>MongoDB\Driver\Manager</classname> precisa ser configurada com a opção de driver
        <literal>"autoEncryption"</literal>. A
        opção de criptografia automática <literal>"bypassQueryAnalysis"</literal> pode ser
        &true;. A opção de criptografia automática <literal>"bypassAutoEncryption"</literal>
        deve ser &false;.
-      </para>
+      </simpara>
       <note>
-       <para>A extensão ainda não oferece suporte a consultas de intervalo para tipos de campo Decimal128 BSON.</para>
+       <simpara>A extensão ainda não oferece suporte a consultas de intervalo para tipos de campo Decimal128 BSON.</simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -145,20 +145,20 @@
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.query-type-equality">
      <term><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Especifica um tipo de consulta de igualdade, que é usada em conjunto com
        <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-clientencryption.constants.query-type-range">
      <term><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Especifica um tipo de consulta de intervalo, que é usada em conjunto com
        <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
@@ -168,57 +168,55 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.0.0</entry>
-        <entry>
-         <para>
-          Removidas as constantes <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
-          e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.20.0</entry>
-        <entry>
-         <para>
-          Adicionadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>
-          e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant>.
-         </para>
-         <para>
-          Descontinuadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
-          e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.16.0</entry>
-        <entry>
-         Adicionadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.0.0</entry>
+       <entry>
+        <simpara>
+         Removidas as constantes <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
          e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.14.0</entry>
-        <entry>
-         Adicionadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>,
-         <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant>,
-         e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        <simpara>
+         Adicionadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>
+         e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant>.
+        </simpara>
+        <simpara>
+         Descontinuadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
+         e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.16.0</entry>
+       <entry>
+        Adicionadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
+        e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.14.0</entry>
+       <entry>
+        Adicionadas <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>,
+        <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant>,
+        e <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
   <section xml:id="mongodb-driver-clientencryption.seealso">

--- a/reference/mongodb/mongodb/driver/clientencryption/addkeyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/addkeyaltname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.addkeyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,10 +14,10 @@
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
    <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona <parameter>keyAltName</parameter> ao conjunto de nomes alternativos para o
    documento da chave com o UUID <parameter>keyId</parameter> fornecido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
    <varlistentry>
     <term><parameter>keyId</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma instância <classname>MongoDB\BSON\Binary</classname> com subtipo 4
       (UUID) identificando o documento da chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 
    <varlistentry>
     <term><parameter>keyAltName</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Nome alternativo a ser adicionado ao documento da chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,10 +46,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a versão anterior do documento da chave ou &null; se nenhum documento
    corresponder.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/construct.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ClientEncryption::__construct</methodname>
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo objeto <classname>MongoDB\Driver\ClientEncryption</classname> com as opções especificadas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -63,50 +63,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.16.0</entry>
-       <entry>
-        <para>
-         O provedor AWS KMS para criptografia do lado do cliente agora aceita uma
-         opção <literal>"sessionToken"</literal>, que pode ser usada para
-         autenticação com credenciais temporárias da AWS.
-        </para>
-        <para>
-         Adicionado <literal>"tlsDisableOCSPEndpointCheck"</literal> à
-         opção <literal>"tlsOptions"</literal>.
-        </para>
-        <para>
-         Se um documento vazio for especificado para o provedor KMS <literal>"azure"</literal> ou
-         <literal>"gcp"</literal>, o driver tentará
-         configurar o provedor usando
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        <para>
-         Se um documento vazio for especificado para o provedor KMS <literal>"aws"</literal>,
-         o driver tentará configurar o provedor usando
-         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.16.0</entry>
+      <entry>
+       <simpara>
+        O provedor AWS KMS para criptografia do lado do cliente agora aceita uma
+        opção <literal>"sessionToken"</literal>, que pode ser usada para
+        autenticação com credenciais temporárias da AWS.
+       </simpara>
+       <simpara>
+        Adicionado <literal>"tlsDisableOCSPEndpointCheck"</literal> à
+        opção <literal>"tlsOptions"</literal>.
+       </simpara>
+       <simpara>
+        Se um documento vazio for especificado para o provedor KMS <literal>"azure"</literal> ou
+        <literal>"gcp"</literal>, o driver tentará
+        configurar o provedor usando
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       <simpara>
+        Se um documento vazio for especificado para o provedor KMS <literal>"aws"</literal>,
+        o driver tentará configurar o provedor usando
+        <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Credenciais Automáticas</link>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 592e10fe7c16ddd3dc1c99f16f7bb1823e9f5b68 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.createdatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>string</type><parameter>kmsProvider</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cria um novo documento de chave e insere-o na coleção do cofre de chaves.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
    <varlistentry>
     <term><parameter>kmsProvider</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O provedor KMS (por exemplo, <literal>"local"</literal>,
       <literal>"aws"</literal>) que será usado para criptografar a nova chave de dados.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 
@@ -51,11 +51,11 @@
           <entry>masterKey</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             O documento masterKey identifica uma chave específica do KMS usada para criptografar
             a nova chave de dados. Esta opção é obrigatória, a menos que
             <parameter>kmsProvider</parameter> seja <literal>"local"</literal>.
-           </para>
+           </simpara>
            &mongodb.option.encryption.masterKey-options-by-provider;
           </entry>
          </row>
@@ -63,25 +63,25 @@
           <entry>keyAltNames</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Uma lista opcional de nomes alternativos de string usados ​​para fazer referência a uma chave.
             Se uma chave for criada com nomes alternativos, a criptografia poderá referir-se
             à chave pelo nome alternativo exclusivo em vez de por
             <literal>_id</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>keyMaterial</entry>
           <entry><classname>MongoDB\BSON\Binary</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Um valor opcional de 96 bytes para usar como material de chave personalizado para a chave
             de dados que está sendo criada. Se keyMaterial for fornecido, o material de chave personalizado
             será usado para criptografar e descriptografar dados. Caso contrário, o material
             de chave para a nova chave de dados é gerado a partir de um dispositivo
             aleatório criptograficamente seguro.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -95,10 +95,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o identificador da nova chave como
    um objeto <classname>MongoDB\BSON\Binary</classname> com subtipo 4 (UUID).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -111,39 +111,37 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Adicionada a opção <literal>"delegated"</literal> à opções masterKey do provedor KMIP.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.15.0</entry>
-       <entry>
-        Adicionada a opção <literal>"keyMaterial"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.10.0</entry>
-       <entry>
-        O Azure e o GCP agora têm suporte como provedores KMS para criptografia do
-        lado do cliente.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Adicionada a opção <literal>"delegated"</literal> à opções masterKey do provedor KMIP.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.15.0</entry>
+      <entry>
+       Adicionada a opção <literal>"keyMaterial"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.10.0</entry>
+      <entry>
+       O Azure e o GCP agora têm suporte como provedores KMS para criptografia do
+       lado do cliente.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/mongodb/mongodb/driver/clientencryption/decrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/decrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b63591939951b1551d47b40650fbfb4693490d16 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\Driver\ClientEncryption::decrypt</methodname>
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Descriptografa o valor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma instância <classname>MongoDB\BSON\Binary</classname> com subtipo 6
       contendo o valor criptografado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,10 +35,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o valor descriptografado conforme foi passado para
    <function>MongoDB\Driver\ClientEncryption::encrypt</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.deletekey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::deleteKey</methodname>
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Remove o documento de chave com o UUID <parameter>keyId</parameter> fornecido
    da coleção de cofres de chaves.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
    <varlistentry>
     <term><parameter>keyId</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma instância <classname>MongoDB\BSON\Binary</classname> com subtipo 4
       (UUID) identificando o documento chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,10 +36,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o resultado da operação interna <literal>deleteOne</literal> na
    coleção de cofres de chaves.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27aaf9a626b5711866a2e6957f568e3c31143760 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Criptografa o valor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O valor a ser criptografado. Qualquer valor que possa ser inserido no MongoDB pode
       ser criptografado usando este método.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    &mongodb.parameter.encryptOpts;
@@ -37,10 +37,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o valor criptografado como
    objeto <classname>MongoDB\BSON\Binary</classname> com subtipo 6.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -53,40 +53,38 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Adicionada a opção de intervalo <literal>"trimFactor"</literal>. A opção
-        de intervalo <literal>"sparsity"</literal> agora é opcional.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.16.0</entry>
-       <entry>
-        Adicionada a opção <literal>"rangeOpts"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.14.0</entry>
-       <entry>
-        Adicionadas as opções <literal>"contentionFactor"</literal> e
-        <literal>"queryType"</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Adicionada a opção de intervalo <literal>"trimFactor"</literal>. A opção
+       de intervalo <literal>"sparsity"</literal> agora é opcional.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.16.0</entry>
+      <entry>
+       Adicionada a opção <literal>"rangeOpts"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.14.0</entry>
+      <entry>
+       Adicionadas as opções <literal>"contentionFactor"</literal> e
+       <literal>"queryType"</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27aaf9a626b5711866a2e6957f568e3c31143760 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.encryptexpression" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>expr</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Criptografa uma expressão de correspondência ou de agregação para consultar um índice de intervalo.
-  </para>
-  <para>Para consultar com uma carga criptografada por intervalo, o <classname>MongoDB\Driver\Manager</classname> deve ser configurado com a opção de driver <literal>"autoEncryption"</literal>. A opção de criptografia automática <literal>"bypassQueryAnalysis"</literal> pode ser &true;. A opção de criptografia automática <literal>"bypassAutoEncryption"</literal> deve ser &false;.</para>
+  </simpara>
+  <simpara>Para consultar com uma carga criptografada por intervalo, o <classname>MongoDB\Driver\Manager</classname> deve ser configurado com a opção de driver <literal>"autoEncryption"</literal>. A opção de criptografia automática <literal>"bypassQueryAnalysis"</literal> pode ser &true;. A opção de criptografia automática <literal>"bypassAutoEncryption"</literal> deve ser &false;.</simpara>
   <note>
-   <para>A extensão ainda não oferece suporte a consultas de intervalo para tipos de campo Decimal128 BSON.</para>
+   <simpara>A extensão ainda não oferece suporte a consultas de intervalo para tipos de campo Decimal128 BSON.</simpara>
   </note>
  </refsect1>
 
@@ -29,17 +29,17 @@
    <varlistentry>
     <term><parameter>expr</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A expressão de correspondência ou agregação a ser criptografada. As expressões devem usar pelo
       menos um dos operadores <literal>$gt</literal>, <literal>$gte</literal>,
       <literal>$lt</literal> ou <literal>$lte</literal>. Um operador
       <literal>$and</literal> de nível superior é necessário, mesmo que apenas um único
       operador de comparação seja usado.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Um exemplo de expressão de correspondência suportada (aplica-se a consultas e ao
       estágio de agregação <literal>$match</literal>) é o seguinte:
-     </para>
+     </simpara>
      <programlisting role="text">
 <![CDATA[
 [
@@ -50,9 +50,9 @@
 ]
 ]]>
      </programlisting>
-     <para>
+     <simpara>
       Um exemplo de expressão de agregação suportada é o seguinte:
-     </para>
+     </simpara>
      <programlisting role="text">
 <![CDATA[
 [
@@ -71,9 +71,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a expressão criptografada como um objeto.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -86,27 +86,25 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Adiciona a opção de intervalo <literal>"trimFactor"</literal> A
-        opção de intervalo <literal>"sparsity"</literal> agora é opcional.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Adiciona a opção de intervalo <literal>"trimFactor"</literal> A
+       opção de intervalo <literal>"sparsity"</literal> agora é opcional.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/clientencryption/getkey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.getkey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::getKey</methodname>
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Encontra um único documento de chave na coleção do cofre de chaves com o UUID
    <parameter>keyId</parameter> fornecido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
    <varlistentry>
     <term><parameter>keyId</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma instância <classname>MongoDB\BSON\Binary</classname> com subtipo 4
       (UUID) identificando o documento de chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de chave ou &null; se nenhum documento corresponder.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.getkeybyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::getKeyByAltName</methodname>
    <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Encontra um único documento de chave na coleção do cofre de chaves com o
    nome alternativo fornecido em <parameter>keyAltName</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>keyAltName</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Nome alternativo para o documento de chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de chave ou &null; se nenhum documento corresponder.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeys.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeys.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.getkeys" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\ClientEncryption::getKeys</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Encontra todos os documentos de chave na coleção do cofre de chaves.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/clientencryption/removekeyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/removekeyaltname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.removekeyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,10 +14,10 @@
    <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
    <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Remove <parameter>keyAltName</parameter> do conjunto de nomes alternativos para
    o documento de chave com o UUID <parameter>keyId</parameter> fornecido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
    <varlistentry>
     <term><parameter>keyId</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma instância <classname>MongoDB\BSON\Binary</classname> com subtipo 4
       (UUID) identificando o documento de chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 
    <varlistentry>
     <term><parameter>keyAltName</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Nome alternativo a ser removido do documento de chave.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,10 +46,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a versão anterior do documento de chave ou &null; se nenhum documento
    corresponder.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 592e10fe7c16ddd3dc1c99f16f7bb1823e9f5b68 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-clientencryption.rewrapmanydatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,16 +14,16 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reencapsula (ou seja, descriptografa e criptografa novamente) zero ou mais chaves de dados na coleção
    de cofres de chaves que correspondem ao filtro fornecido no parâmetro <parameter>filter</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Se a opção <literal>"provider"</literal> não for especificada, as chaves de dados
    correspondentes serão reencapsuladas com seu provedor KMS atual. Caso contrário, as chaves de dados
    correspondentes serão criptografadas novamente de acordo com as opções
    <literal>"provider"</literal> e <literal>"masterKey"</literal> especificadas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,28 +49,28 @@
           <entry>provider</entry>
           <entry><type>string</type></entry>
           <entry>
-           <para>
+           <simpara>
             O provedor KMS (por exemplo, <literal>"local"</literal>,
             <literal>"aws"</literal>) que será usado para criptografar novamente as
             chaves de dados correspondentes.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se um provedor KMS não for especificado, as chaves de dados correspondentes serão
             criptografadas novamente com seu provedor KMS atual.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>masterKey</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             A masterKey identifica uma chave específica do KMS usada para criptografar a nova
             chave de dados. Esta opção não deve ser especificada sem a opção
             <literal>"provider"</literal>. Esta opção é necessária se
             <literal>"provider"</literal> for especificada e não
             <literal>"local"</literal>.
-           </para>
+           </simpara>
            &mongodb.option.encryption.masterKey-options-by-provider;
           </entry>
          </row>
@@ -85,13 +85,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um objeto, que terá uma propriedade opcional
    <literal>bulkWriteResult</literal> contendo o resultado da operação
    interna <literal>bulkWrite</literal> como um objeto. Se nenhuma chave de dados
    corresponder ao filtro ou a gravação não for reconhecida, a
    propriedade <literal>bulkWriteResult</literal> será &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -105,26 +105,24 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Adicionada a opção <literal>"delegated"</literal> às opções masterKey do provedor KMIP.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Adicionada a opção <literal>"delegated"</literal> às opções masterKey do provedor KMIP.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 </refentry>
 


### PR DESCRIPTION
13 refentries: ``ClientEncryption`` and its methods. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.