### PR TITLE
Sync EN: mongodb driver BulkWrite, BulkWriteCommand, BulkWriteCommandResult

### DIFF
--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-bulkwrite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,21 +11,21 @@
 <!-- {{{ MongoDB\Driver\BulkWrite intro -->
   <section xml:id="mongodb-driver-bulkwrite.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\BulkWrite</classname> coleta uma ou mais
     operações de gravação que devem ser enviadas ao servidor. Depois de adicionar qualquer
     número de operações de inserção, atualização e exclusão, a coleção pode ser
     executada via
     <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     As operações de gravação podem ser ordenadas (padrão) ou não ordenadas. As operações
     de gravação ordenadas são enviadas ao servidor, na ordem fornecida, para execução
     serial. Se uma gravação falhar, todas as operações restantes serão abortadas.
     As operações não ordenadas são enviadas ao servidor em uma ordem arbitrária,
     onde podem ser executadas em paralelo. Quaisquer erros que ocorram são relatados
     após todas as operações terem sido tentadas.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -61,10 +61,10 @@
 
    <example>
     <title>As operações de gravação mistas são agrupadas por tipo</title>
-    <para>
+    <simpara>
      Operações de gravação mistas (ou seja, inserções, atualizações e exclusões) serão
      agrupados em comandos de gravação para serem enviados sequencialmente ao servidor.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -79,11 +79,11 @@ $bulk->delete(['x' => 1]);
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Resultará na execução de quatro comandos de gravação (ou seja, ida e volta). Como
      as operações são ordenadas, a terceira inserção não pode ser enviada até que a
      atualização anterior seja executada.
-    </para>
+    </simpara>
    </example>
    <example>
     <title>Operações de gravação ordenadas causando um erro</title>
@@ -148,10 +148,10 @@ Inseridos 4 documentos
 Atualizados 2 documentos
 ]]>
    </screen>
-   <para>
+   <simpara>
     Se a preocupação de gravação não pudesse ser atendida, o exemplo acima geraria
     algo como:
-   </para>
+   </simpara>
    <screen>
 <![CDATA[
 waiting for replication timed out (64): array (
@@ -162,9 +162,9 @@ Inseridos 4 documentos
 Atualizados 2 documentos
 ]]>
    </screen>
-   <para>
+   <simpara>
     Se for executado o exemplo acima, mas permitindo gravações não ordenadas:
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>public</modifier> <methodname>MongoDB\Driver\BulkWrite::__construct</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo <classname>MongoDB\Driver\BulkWrite</classname>, que é um
    objeto mutável para o qual uma ou mais operações de escrita podem ser adicionadas. As
    escritas podem então ser executadas com
    <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -44,14 +44,14 @@
           <entry>bypassDocumentValidation</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Se for igual a &true;, permite operações de inserção e atualização para contornar
             validação no nível de documento.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 3.2+ e é ignorada em versões
             mais antigas do servidor, que não suportam validação no nível de documento.
-           </para>
+           </simpara>
           </entry>
           <entry>&false;</entry>
          </row>
@@ -59,15 +59,15 @@
           <entry>comment</entry>
           <entry><type>mixed</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um comentário arbitrário para ajudar a rastrear a operação por meio da
             perfilagem do banco de dados, da saída da operação atual e de registros.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 4.4+ e resultará em uma
             exceção em tempo de execução se especificada para uma versão mais
             antiga do servidor.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.let;
@@ -99,33 +99,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.14.0</entry>
-       <entry>
-        Opções <literal>"comment"</literal> e <literal>"let"</literal>
-        adicionadas.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.1.0</entry>
-       <entry>
-        Opção <literal>"bypassDocumentValidation"</literal> adicionada.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.14.0</entry>
+      <entry>
+       Opções <literal>"comment"</literal> e <literal>"let"</literal>
+       adicionadas.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.1.0</entry>
+      <entry>
+       Opção <literal>"bypassDocumentValidation"</literal> adicionada.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/bulkwrite/count.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af5f2f87b3b0bb9ee0f83ccb787a4e7db1eb6bd4 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWrite::count</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o número de operações de escrita adicionadas
    ao objeto <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de operações de escrita adicionadas
    ao objeto <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,29 +42,27 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        Retorna o número de operações de escrita adicionadas
-        ao objeto <classname>MongoDB\Driver\BulkWrite</classname>. Versões anteriores
-        retornavam o número esperado de viagens de ida e volta de cliente para servidor necessárias para
-        executar todas as operações de escrita.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       Retorna o número de operações de escrita adicionadas
+       ao objeto <classname>MongoDB\Driver\BulkWrite</classname>. Versões anteriores
+       retornavam o número esperado de viagens de ida e volta de cliente para servidor necessárias para
+       executar todas as operações de escrita.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,10 +14,10 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>deleteOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação de remoção
    ao <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -46,16 +46,16 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação do índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará
             apenas os planos usando o índice sugerido.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 4.4+ e resultará em uma
             exceção em tempo de execução se especificada para uma versão
             mais antiga do servidor.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -75,9 +75,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -89,32 +89,30 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.8.0</entry>
-       <entry>
-        Opção <literal>"hint"</literal> adicionada.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        Opção <literal>"collation"</literal> adicionada.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.8.0</entry>
+      <entry>
+       Opção <literal>"hint"</literal> adicionada.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       Opção <literal>"collation"</literal> adicionada.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2a9a8244a05d5d870de10b7000394f4e6bd4ebbb Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.insert" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\Driver\BulkWrite::insert</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação de inserção ao
    <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
    <varlistentry>
     <term><parameter>document</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um documento a ser inserido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,12 +36,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <literal>_id</literal> do documento inserido. Se o documento informado em
    <parameter>document</parameter> não tinha um <literal>_id</literal>, o objeto
    <classname>MongoDB\BSON\ObjectId</classname> gerado para a inserção será
    retornado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -53,28 +53,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        O <literal>_id</literal> do documento inserido é sempre retornado.
-        Anteriormente, o método somente retornava um valor se um objeto
-        <classname>MongoDB\BSON\ObjectId</classname> fosse gerado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       O <literal>_id</literal> do documento inserido é sempre retornado.
+       Anteriormente, o método somente retornava um valor se um objeto
+       <classname>MongoDB\BSON\ObjectId</classname> fosse gerado.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d7be221e79375970f0973a1ad7f483b0af52846f Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.update" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>newObj</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>updateOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação de atualização ao
    <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -29,12 +29,12 @@
    <varlistentry>
     <term><parameter>newObj</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um documento contendo operadores de atualização (ex.:
       <literal>$set</literal>), um documento para substituição (ou seja,
       <emphasis>somente</emphasis> expressões <literal>campo:valor</literal>), ou
       um <link xlink:href="&url.mongodb.docs.command;update/#update-with-an-aggregation-pipeline">pipeline de agregação</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -57,17 +57,17 @@
           <entry>arrayFilters</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um array de documentos de filtro que determina quais elementos do array serão
             modificados para uma operação de atualização em um campo do array. Consulte
             <link xlink:href="&url.mongodb.docs.command;update/#update-command-arrayfilters">Especificar arrayFilters para operações de atualização de array</link>
             no manual do MongoDB para obter mais informações.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 3.6+ e resultará em uma
             exceção em tempo de execução se especificada para uma versão mais
             antiga do servidor.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -75,16 +75,16 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação do índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará
             apenas os planos usando o índice sugerido.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 4.2+ e resultará em uma
             exceção em tempo de execução se especificada para uma versão mais
             antiga do servidor.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -101,19 +101,19 @@
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especifica que documento a operação atualiza se a consulta corresponder
             a múltiplos documentos. O primeiro documento correspondente à ordenação
             será atualizado.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção não pode ser usada se <literal>"multi"</literal> for &true;.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 8.0+ e resultará em uma
             exceção no momento da execução se especificada para uma versão
             antiga do servidor.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -140,9 +140,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -154,60 +154,58 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Adicionada a opção <literal>"sort"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.7.0</entry>
-       <entry>
-        Opção <literal>"hint"</literal> adicionada.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.6.0</entry>
-       <entry>
-        O parâmetro <parameter>newObj</parameter> agora aceita um pipeline de
-        agregação. Este recurso requer MongoDB 4.2+ e resultará em uma
-        exceção em tempo de execução se especificado para uma versão de servidor mais antiga.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.5.0</entry>
-       <entry>
-        Usar a opção <literal>"arrayFilters"</literal> resultará em uma
-        exceção em tempo de execução se não for suportada pelo servidor. Anteriormente,
-        nenhuma exceção seria lançada e a opção poderia ser ignorada.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        Opção <literal>"arrayFilters"</literal> adicionada.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        Opção <literal>"collation"</literal> adicionada.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Adicionada a opção <literal>"sort"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.7.0</entry>
+      <entry>
+       Opção <literal>"hint"</literal> adicionada.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.6.0</entry>
+      <entry>
+       O parâmetro <parameter>newObj</parameter> agora aceita um pipeline de
+       agregação. Este recurso requer MongoDB 4.2+ e resultará em uma
+       exceção em tempo de execução se especificado para uma versão de servidor mais antiga.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.5.0</entry>
+      <entry>
+       Usar a opção <literal>"arrayFilters"</literal> resultará em uma
+       exceção em tempo de execução se não for suportada pelo servidor. Anteriormente,
+       nenhuma exceção seria lançada e a opção poderia ser ignorada.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       Opção <literal>"arrayFilters"</literal> adicionada.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       Opção <literal>"collation"</literal> adicionada.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-bulkwritecommand" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,28 +11,28 @@
 <!-- {{{ MongoDB\Driver\BulkWriteCommand intro -->
   <section xml:id="mongodb-driver-bulkwritecommand.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>MongoDB\Driver\BulkWriteCommand</classname> coleta uma ou mais
     operações de gravação que devem ser enviadas ao servidor usando o comando
     <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
     introduzido no MongoDB 8.0. Após adicionar qualquer número de operações de inserção,
     atualização e exclusão, o comando pode ser executado via
     <methodname>MongoDB\Driver\Manager::executeBulkWriteCommand</methodname>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Ao contrário de <classname>MongoDB\Driver\BulkWrite</classname>, onde todas as operações de gravação
     devem ter como alvo a mesma coleção, cada operação de gravação dentro de
     <classname>MongoDB\Driver\BulkWriteCommand</classname> pode ter como alvo uma
     coleção diferente.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     As operações de gravação podem ser ordenadas (padrão) ou não ordenadas. As operações de gravação ordenadas
     são enviadas ao servidor, na ordem fornecida, para execução
     em série. Se uma gravação falhar, as operações restantes serão abortadas.
     As operações não ordenadas são enviadas ao servidor em uma ordem arbitrária
     onde podem ser executadas em paralelo. Quaisquer erros que ocorram são reportados
     após todas as operações terem sido tentadas.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -68,12 +68,12 @@
 
    <example>
     <title>Operações de gravação mistas</title>
-    <para>
+    <simpara>
      Operações de gravação mistas (ou seja, inserções, atualizações e exclusões) serão enviadas
      para o servidor usando um único
      comando
      <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>public</modifier> <methodname>MongoDB\Driver\BulkWriteCommand::__construct</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cria um novo <classname>MongoDB\Driver\BulkWriteCommand</classname>,
    que pode ser usado para executar diversas operações de inserção, atualização e exclusão em
    várias coleções em uma única solicitação usando o comando
@@ -21,11 +21,11 @@
    introduzido no MongoDB 8.0. Isso difere de
    <classname>MongoDB\Driver\BulkWrite</classname>, que é suportado por todas
    as versões do servidor, mas limitado a uma única coleção.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Após todas as operações de gravação terem sido adicionadas, este objeto pode ser executado com
    <methodname>MongoDB\Driver\Manager::executeBulkWriteCommand</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -51,10 +51,10 @@
           <entry>bypassDocumentValidation</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Se &true;, permite que operações de inserção e atualização contornem
             a validação em nível de documento.
-           </para>
+           </simpara>
           </entry>
           <entry>&false;</entry>
          </row>
@@ -62,10 +62,10 @@
           <entry>comment</entry>
           <entry><type>mixed</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um comentário arbitrário para ajudar a rastrear a operação por meio do
             profiler do banco de dados, da saída currentOp e dos registros.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.let;
@@ -73,12 +73,12 @@
           <entry>ordered</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Se as operações nesta gravação em massa devem ser executadas
             na ordem em que foram especificadas. Se &false;, as gravações
             continuarão a ser executadas se uma gravação individual falhar. Se &true;,
             as gravações deixarão de ser executadas se uma gravação individual falhar.
-           </para>
+           </simpara>
           </entry>
           <entry>&true;</entry>
          </row>
@@ -86,11 +86,11 @@
           <entry>verboseResults</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Se os resultados detalhados de cada operação bem-sucedida devem ser
             incluídos no
             <classname>MongoDB\Driver\BulkWriteCommandResult</classname> retornado.
-           </para>
+           </simpara>
           </entry>
           <entry>&false;</entry>
          </row>

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/count.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWriteCommand::count</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o número de operações de gravação adicionadas ao objeto
    <classname>MongoDB\Driver\BulkWriteCommand</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de operações de gravação adicionadas ao objeto
    <classname>MongoDB\Driver\BulkWriteCommand</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/deletemany.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/deletemany.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.deletemany" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,12 +15,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adicione uma operação deleteMany ao
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. Todos os documentos
    que correspondem a <parameter>filter</parameter> na coleção identificada por
    <parameter>namespace</parameter> serão excluídos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,11 +49,11 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação de índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará apenas
             planos que utilizem o índice sugerido.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -67,9 +67,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/deleteone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/deleteone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.deleteone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,12 +15,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação deleteOne ao
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. O primeiro documento
    correspondente a <parameter>filter</parameter> na coleção identificada por
    <parameter>namespace</parameter> será excluído.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,11 +49,11 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação de índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará apenas
             planos que utilizem o índice sugerido.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -67,9 +67,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/insertone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/insertone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.insertone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,12 @@
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação insertOne ao
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. O documento será
    inserido na coleção identificada por
    <parameter>namespace</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
    <varlistentry>
     <term><parameter>document</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um documento para inserir.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -39,12 +39,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <literal>_id</literal> do documento inserido. Se o
 <parameter>document</parameter> não tiver um <literal>_id</literal>, o
 <classname>MongoDB\BSON\ObjectId</classname> gerado para a inserção será
 retornado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/replaceone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/replaceone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.replaceone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,12 +16,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>replacement</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação replaceOne ao
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. O primeiro documento
    correspondente a <parameter>filter</parameter> na coleção identificada por
    <parameter>namespace</parameter> será substituído.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,9 +33,9 @@
    <varlistentry>
     <term><parameter>replacement</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um documento de substituição.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -59,22 +59,22 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação de índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará apenas
             planos que utilizem o índice sugerido.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especifica qual documento a operação substitui se a consulta corresponder a
             vários documentos. O primeiro documento correspondido pela ordem de classificação
             será substituído.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -98,9 +98,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/updatemany.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/updatemany.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.updatemany" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,12 +16,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>update</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação updateMany ao
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. Todos os documentos
    que correspondem a <parameter>filter</parameter> na coleção identificada por
    <parameter>namespace</parameter> serão atualizados.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,11 +33,11 @@
    <varlistentry>
     <term><parameter>update</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um documento contendo operadores de atualização (por exemplo,
       <literal>$set</literal>) ou um
       <link xlink:href="&url.mongodb.docs.command;update/#update-with-an-aggregation-pipeline">pipeline de agregação</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -60,12 +60,12 @@
           <entry>arrayFilters</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um conjunto de documentos de filtro que determina quais elementos do conjunto devem
             ser modificados para uma operação de atualização em um campo do conjunto. Consulte
             <link xlink:href="&url.mongodb.docs.command;update/#update-command-arrayfilters">Especificar Filtros de Conjunto para Operações de Atualização de Conjunto</link>
             no manual do MongoDB para obter mais informações.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -73,11 +73,11 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação de índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará apenas
             planos que utilizem o índice sugerido.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -102,9 +102,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/updateone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/updateone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.updateone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,12 +16,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>update</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona uma operação updateOne ao
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. O primeiro documento
    correspondente a <parameter>filter</parameter> na coleção identificada por
    <parameter>namespace</parameter> será atualizado.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,11 +33,11 @@
    <varlistentry>
     <term><parameter>update</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um documento contendo operadores de atualização (por exemplo,
       <literal>$set</literal>) ou um
       <link xlink:href="&url.mongodb.docs.command;update/#update-with-an-aggregation-pipeline">pipeline de agregação</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -60,12 +60,12 @@
           <entry>arrayFilters</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um conjunto de documentos de filtro que determina quais elementos do conjunto devem
             ser modificados para uma operação de atualização em um campo do conjunto. Consulte
             <link xlink:href="&url.mongodb.docs.command;update/#update-command-arrayfilters">Especificar Filtros de Conjunto para Operações de Atualização de Conjunto</link>
             no manual do MongoDB para obter mais informações.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -73,22 +73,22 @@
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação de índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta considerará apenas
             planos que utilizem o índice sugerido.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especifica qual documento a operação atualiza se a consulta corresponder
             a vários documentos. O primeiro documento correspondido pela ordem de classificação
             será atualizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -113,9 +113,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-bulkwritecommandresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,12 +11,12 @@
 <!-- {{{ MongoDB\Driver\BulkWriteCommandResult intro -->
   <section xml:id="mongodb-driver-bulkwritecommandresult.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\BulkWriteCommandResult</classname>
     encapsula informações sobre um
     <classname>MongoDB\Driver\BulkWriteCommand</classname> executado e é retornada por
     <methodname>MongoDB\Driver\Manager::executeBulkWriteCommand</methodname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getdeletedcount.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getdeletedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getdeletedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWriteCommandResult::getDeletedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número total de documentos excluídos por todas as operações.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getdeleteresults.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getdeleteresults.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getdeleteresults" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Document</type><type>null</type></type><methodname>MongoDB\Driver\BulkWriteCommandResult::getDeleteResults</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,12 +24,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um documento contendo o resultado de cada operação de exclusão
    bem-sucedida, ou &null; se resultados detalhados não foram solicitados. As chaves do documento
    corresponderão ao índice da operação de gravação de
    <classname>MongoDB\Driver\BulkWriteCommand</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getinsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getinsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getinsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWriteCommandResult::getInsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número total de documentos inseridos (excluindo upserts) por todas as
    operações.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getinsertresults.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getinsertresults.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getinsertresults" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Document</type><type>null</type></type><methodname>MongoDB\Driver\BulkWriteCommandResult::getInsertResults</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Como os campos <literal>_id</literal> para documentos inseridos são gerados
    pela extensão, o valor de <literal>insertedId</literal> em cada resultado
    corresponderá ao valor de retorno de
    <methodname>MongoDB\Driver\BulkWriteCommand::insertOne</methodname> para
    a operação de inserção correspondente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,12 +29,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um documento contendo o resultado de cada operação de inserção bem-sucedida
    ou &null; se resultados detalhados não foram solicitados. As chaves do documento
    corresponderão ao índice da operação de gravação de
    <classname>MongoDB\Driver\BulkWriteCommand</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getmatchedcount.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getmatchedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getmatchedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWriteCommandResult::getMatchedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Se a operação de atualização não resultar em nenhuma alteração no documento (por exemplo, definindo
    o valor de um campo para seu valor atual), a contagem correspondente poderá ser maior
    que o valor retornado por
    <methodname>MongoDB\Driver\BulkWriteCommandResult::getModifiedCount</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número total de documentos selecionados para atualização por todas as operações.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getmodifiedcount.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getmodifiedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getmodifiedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWriteCommandResult::getModifiedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Se a operação de atualização não resultar em nenhuma alteração no documento (por exemplo, definindo
    o valor de um campo para seu valor atual), a contagem modificada poderá ser menor
    que o valor retornado por
    <methodname>MongoDB\Driver\BulkWriteCommandResult::getMatchedCount</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número total de documentos existentes atualizados por todas as operações.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getupdateresults.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getupdateresults.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getupdateresults" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Document</type><type>null</type></type><methodname>MongoDB\Driver\BulkWriteCommandResult::getUpdateResults</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,12 +24,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um documento contendo o resultado de cada operação de atualização bem-sucedida
    ou &null; se resultados detalhados não foram solicitados. As chaves do documento
    corresponderão ao índice da operação de gravação de
    <classname>MongoDB\Driver\BulkWriteCommand</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/getupsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/getupsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.getupsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,8 +13,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWriteCommandResult::getUpsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número total de documentos inseridos ou atualizados por todas as operações.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/isacknowledged.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/isacknowledged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandresult.isacknowledged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\BulkWriteCommandResult::isAcknowledged</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Se a gravação for confirmada, outros campos estarão disponíveis no objeto
    <classname>MongoDB\Driver\BulkWriteCommandResult</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se a gravação foi confirmada e &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
25 refentries: ``BulkWrite`` + ``BulkWriteCommand`` + ``BulkWriteCommandResult`` and their methods. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.