### PR TITLE
Sync EN: mongodb driver Write{Concern,ConcernError,Error,Result} methods

### DIFF
--- a/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5eca06ae7725b4c35eefecbb0d722a3e198ff21 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcern.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um objeto para serializar WriteConcern como BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcern.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>wtimeout</parameter><initializer>&null;</initializer></methodparam>
   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>journal</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo <classname>MongoDB\Driver\WriteConcern</classname>, que
    é um objeto de valor imutável.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -65,15 +65,15 @@
          <row>
           <entry><constant>MongoDB\Driver\WriteConcern::MAJORITY</constant></entry>
           <entry>
-           <para>
+           <simpara>
             Solicita o reconhecimento de que as operações de gravação foram propagadas para
             a maioria dos nós de votação, incluindo o primário, e foram
             gravadas no diário em disco para esses nós.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Antes do MongoDB 3.0, isso se referia à maioria dos membros do conjunto de
             réplicas (não apenas aos nós de votação).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -93,21 +93,21 @@
    <varlistentry>
     <term><parameter>wtimeout</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Quanto tempo esperar (em milissegundos) pelos secundários antes de falhar.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       <literal>wtimeout</literal> faz com que as operações de gravação retornem com um
       erro (<classname>WriteConcernError</classname>) após o limite especificado,
       mesmo que a preocupação de gravação necessária acabe sendo bem-sucedida. Quando
       essas operações de gravação retornam, o MongoDB não desfaz as modificações de dados
       bem-sucedidas realizadas antes que a preocupação de gravação excedesse o
       limite de tempo <literal>wtimeout</literal>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Se especificado, <literal>wtimeout</literal> deve ser um número inteiro de 64 bits, com sinal,
       maior ou igual a zero.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>Tempo limite de preocupação de gravação</title>
@@ -138,9 +138,9 @@
    <varlistentry>
     <term><parameter>journal</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Espera até que o mongod aplique a gravação no diário.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -156,26 +156,24 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.7.0</entry>
-       <entry>
-        O parâmetro <parameter>wTimeout</parameter> agora aceita valores de 64 bits.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.7.0</entry>
+      <entry>
+       O parâmetro <parameter>wTimeout</parameter> agora aceita valores de 64 bits.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcern.getjournal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "journal" do WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/getw.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcern.getw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "w" do WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcern.getwtimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "wtimeout" do WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -36,28 +36,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.7.0</entry>
-       <entry>
-        Em sistemas de 32 bits, este método sempre truncará o valor <literal>wTimeout</literal>
-        se exceder o intervalo de 32 bits. Nesse caso, um alerta
-        será emitido.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.7.0</entry>
+      <entry>
+       Em sistemas de 32 bits, este método sempre truncará o valor <literal>wTimeout</literal>
+       se exceder o intervalo de 32 bits. Nesse caso, um alerta
+       será emitido.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/writeconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\WriteConcern::isDefault</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se esta é a preocupação de gravação padrão (ou seja, nenhuma opção
    é especificada). Este método destina-se principalmente a ser usado em conjunto com
    <methodname>MongoDB\Driver\Manager::getWriteConcern</methodname> para determinar
    se o gerenciador foi construído sem nenhuma opção de preocupação de gravação.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O driver não incluirá uma preocupação de gravação padrão em suas operações de gravação
    (por exemplo, <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>)
    para permitir que o servidor aplique seu próprio padrão, que pode ter sido
@@ -27,7 +27,7 @@
    Bibliotecas que acessam a preocupação de gravação do gerenciador para incluí-la em seus próprios
    comandos de gravação devem usar esse método para garantir que as preocupações de gravação
    padrão não sejam definidas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se esta for a preocupação de gravação padrão ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteConcernError::getCode</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o código de erro do WriteConcernError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcernError::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de metadados para WriteConcernError ou &null; se
    nenhum metadado estiver disponível.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\WriteConcernError::getMessage</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a mensagem de erro do WriteConcernError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeerror.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteError::getCode</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o código de erro do WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getindex.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeerror.getindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteError::getIndex</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,11 +26,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o índice da operação de gravação (de
    <classname>MongoDB\Driver\BulkWrite</classname>)
    correspondente a este WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeerror.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteError::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o documento de metadados para WriteError ou &null; se nenhum metadado
    estiver disponível.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getmessage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 697b3c9468124f58cc13901057bec0b813f6197f Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeerror.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\WriteError::getMessage</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a mensagem de erro do WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getdeletedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getDeletedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de documentos excluídos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -41,21 +41,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getinsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getInsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de documentos inseridos (excluindo inserções de atualização).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -41,21 +41,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getmatchedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Se a operação de atualização não resultar em nenhuma alteração no documento (por exemplo,
    definir o valor de um campo para seu valor atual), a contagem correspondida poderá ser maior
    que o valor retornado por
    <methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de documentos selecionados para atualização.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -43,21 +43,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getmodifiedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Se a operação de atualização não resultar em nenhuma alteração no documento (por exemplo,
    definir o valor de um campo para seu valor atual), a contagem modificada poderá ser menor
    que o valor retornado por
    <methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname >.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de documentos existentes atualizados.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -43,21 +43,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getserver.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\WriteResult::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> associado a este
    resultado de gravação. Este é o servidor que executou o
    <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o <classname>MongoDB\Driver\Server</classname> associado a este
    resultado de gravação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getupsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getUpsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de documentos inseridos por uma inserção de atualização.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -41,21 +41,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2c423ff085531b5a614c7b10c2d8cf957cdda808 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getupsertedids" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\WriteResult::getUpsertedIds</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,12 +26,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array de identificadores (ou seja, valores de campo <literal>"_id"</literal>)
    para documentos inseridos por atualização. As chaves do array corresponderão ao índice da
    operação de gravação (de <classname>MongoDB\Driver\BulkWrite</classname>)
    responsável pela inserção de atualização.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getwriteconcernerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,11 +26,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um <classname>MongoDB\Driver\WriteConcernError</classname> se um erro de preocupação
    de gravação foi encontrado durante a operação de gravação ou &null;
    caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 61f9e84aa71378ccf3958a6c20d3a8017392562c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-writeresult.getwriteerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\WriteResult::getWriteErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,11 +26,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array de objetos <classname>MongoDB\Driver\WriteError</classname>
    para quaisquer erros de gravação encontrados durante a operação de gravação. O array
    estará vazio se não tiverem ocorrido erros de gravação.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
23 method refentries under ``WriteConcern``, ``WriteConcernError``, ``WriteError``, ``WriteResult``: mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.

Class-level files (``writeresult.xml``, ``writeconcern.xml``, ``writeconcernerror.xml``, ``writeerror.xml``) left out: their EN diff adds a new Properties section + changelog row, requires a real translation pass.