### PR TITLE
Sync EN: mongodb driver Read{Concern,Preference}, Query, Command methods

### DIFF
--- a/reference/mongodb/mongodb/driver/command.xml
+++ b/reference/mongodb/mongodb/driver/command.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-command" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,13 +11,13 @@
 <!-- {{{ MongoDB\Driver\Command intro -->
   <section xml:id="mongodb-driver-command.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\Command</classname> é um objeto de valor
     que representa um comando de banco de dados.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Para fornecer <quote>Auxílios de Comando</quote>, o objeto <classname>MongoDB\Driver\Command</classname> deve ser composto.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-command.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,19 +14,19 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>commandOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo <classname>MongoDB\Driver\Command</classname>, que é um
    objeto de valor imutável que representa um comando do banco de dados. O comando pode
    então ser executado com
    <methodname>MongoDB\Driver\Manager::executeCommand</methodname>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O documento completo do comando, que inclui o nome do comando e suas
    opções, deve ser expressado no parâmetro <parameter>document</parameter>.
    O parâmetro <parameter>commandOptions</parameter> só é usado
    para especificar opções relacionadas à execução do comando e ao
    <classname>MongoDB\Driver\Cursor</classname> resultante.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,9 +35,9 @@
    <varlistentry>
     <term><parameter>document</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O documento completo do comando, que será enviado ao servidor.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 
@@ -67,14 +67,14 @@
           <entry>maxAwaitTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um inteiro positivo definindo o tempo limite em milissegundos para o
             servidor bloquear uma operação "getMore" se nenhum dado estiver disponível. Esta
             opção deve ser usada somente em conjunto com comandos que retornam
             um cursor adaptável (ex.: <link
             xlink:href="&url.mongodb.docs;changeStreams/">Fluxos de
             Alteração</link>).
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -95,29 +95,27 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        <para>
-         Adicionado um segundo argumento <parameter>commandOptions</parameter>, que suporta
-         a opção <literal>"maxAwaitTimeMS"</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       <simpara>
+        Adicionado um segundo argumento <parameter>commandOptions</parameter>, que suporta
+        a opção <literal>"maxAwaitTimeMS"</literal>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -191,12 +189,12 @@ array(13) {
 
   <example>
    <title>Exemplo de <function>MongoDB\Driver\Command::__construct</function></title>
-   <para>
+   <simpara>
     Comandos também podem aceitar opções, como parte da estrutura normal que
     é criada para enviar ao servidor. Por exemplo, a
     opção <literal>maxTimeMS</literal> pode ser passada com a maioria dos comandos para
     restringir a quantidade de tempo em que um comando pode ficar em execução no servidor.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/query.xml
+++ b/reference/mongodb/mongodb/driver/query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <reference xml:id="class.mongodb-driver-query" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,10 +11,10 @@
 <!-- {{{ MongoDB\Driver\Query intro -->
   <section xml:id="mongodb-driver-query.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A classe <classname>MongoDB\Driver\Query</classname> é um objeto de valor que
     representa uma consulta ao banco de dados.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-query.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>queryOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo <classname>MongoDB\Driver\Query</classname>, que é um
    objeto de valor imutável que representa uma consulta ao banco de dados. A consulta pode então
    ser executada com
    <methodname>MongoDB\Driver\Manager::executeQuery</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -45,26 +45,26 @@
           <entry>allowDiskUse</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Permite que o MongoDB use arquivos de disco temporários para armazenar dados que excedem
             o limite de memória do sistema de 100 megabytes durante o processamento de uma operação bloqueante
             de classificação.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>allowPartialResults</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Para consultas em uma coleção de fragmentos, retorna resultados parciais
             do "mongos" se alguns fragmentos não estiverem disponíveis, em vez de
             lançar um erro.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, a opção obsoleta <literal>"partial"</literal>
             será usada.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -81,16 +81,16 @@
           <entry>batchSize</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             O número de documentos a serem devolvidos no primeiro lote. O padrão é
             101. Um tamanho de lote 0 significa que o cursor será estabelecido,
             mas nenhum documento será retornado no primeiro lote.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Nas versões do MongoDB anteriores à 3.2, onde as consultas usam o protocolo de ligação
             legado OP_QUERY, um tamanho de lote de 1 fechará o cursor,
             independentemente do número de documentos correspondidos.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -98,73 +98,73 @@
           <entry>comment</entry>
           <entry><type>mixed</type></entry>
           <entry>
-           <para>
+           <simpara>
             Um comentário arbitrário para ajudar a rastrear a operação por meio do
             perfilador do banco de dados, da saída currentOp e dos logs.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             O comentário pode ser qualquer tipo BSON válido para MongoDB 4.4+.
             Versões anteriores do servidor suportam apenas valores de string.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$comment"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>exhaust</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Transmite os dados a todo vapor em vários pacotes "more", supondo
             que o cliente lerá completamente todos os dados consultados. Mais rápido
             quando se está extraindo muitos dados e sabe-se que a intenção é extrair
             tudo. Nota: o cliente não tem permissão para não ler todos os dados,
             a menos que feche a conexão.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção não é suportada pelo comando "find" no MongoDB 3.2+ e
             forçará o driver a usar a versão herdada do protocolo de ligação (ou seja,
             OP_QUERY).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>explain</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Se &true;, o <classname>MongoDB\Driver\Cursor</classname> retornado
             conterá um único documento que descreve o processo e os
             índices usados ​​para retornar a consulta.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$explain"</literal>
             será utilizado.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção não é suportada pelo comando "find" no MongoDB 3.2+ e
             só será respeitada ao usar a versão herdada do protocolo wire
             (ou seja, OP_QUERY). O comando
             <link xlink:href="&url.mongodb.docs;reference/command/explain/">explain</link>
             deve ser usado no MongoDB 3.0+.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificação do índice. Especifique o nome do índice como uma string ou
             o padrão de chave do índice. Se especificado, o sistema de consulta
             considerará apenas os planos usando o índice sugerido.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, a opção obsoleta <literal>"hint"</literal>
             será utilizada.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.let;
@@ -172,65 +172,65 @@
           <entry>limit</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             O número máximo de documentos a serem devolvidos. Se não for especificado, o
             padrão será sem limite. Um limite de 0 é equivalente a não definir
             limite.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>max</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             O limite superior <emphasis>exclusivo</emphasis> para um índice específico.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$max"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxAwaitTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Inteiro positivo que indica o limite de tempo em milissegundos para o
             servidor bloquear uma operação "getMore" se nenhum dado estiver disponível. Esta
             opção só deve ser usada em conjunto com as opções
             <literal>"tailable"</literal> e
             <literal>"awaitData"</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             O limite de tempo cumulativo em milissegundos para operações de processamento
             no cursor. O MongoDB aborta a operação o mais cedo possível
             após o ponto de interrupção.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$maxTimeMS"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>min</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             O limite inferior (<emphasis>inclusive</emphasis>) para um índice específico.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$min"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -245,11 +245,11 @@
           <entry>projection</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             A <link xlink:href="&url.mongodb.docs;tutorial/project-fields-from-query-results/">especificação de projeção</link>
             para determinar quais campos devem ser incluídos nos documentos retornados.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se a <link
             linkend="mongodb.persistence.deserialization">funcionalidade
             ODM</link> estiver sendo usada para desserializar documentos como sua classe
@@ -258,54 +258,54 @@
             necessário para que a desserialização funcione e, sem ela, a
             extensão retornará (por padrão) um objeto <classname>stdClass</classname>
             no lugar.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>readConcern</entry>
           <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Uma preocupação de leitura a ser aplicada à operação. Por padrão, a
             preocupação de leitura do
             <link linkend="mongodb-driver-manager.construct-uri">URI de
             conexão do MongoDB</link> será usada.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção está disponível no MongoDB 3.2+ e resultará em uma
             exceção no momento da execução se especificada para uma versão mais
             antiga do servidor.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>returnKey</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Se &true;, retornará apenas as chaves de índice nos documentos resultantes.
             O valor padrão é &false;. Se &true; e o comando "find" não
             usar um índice, os documentos retornados estarão vazios.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$returnKey"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>showRecordId</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Determina se o identificador de registro para cada documento deve ser
             retornado. Se &true;, adiciona um campo <literal>"$recordId"</literal>
             de nível superior aos documentos retornados.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$showDiskLoc"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -325,11 +325,11 @@
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>A especificação de classificação para a ordenação dos resultados.</para>
-           <para>
+           <simpara>A especificação de classificação para a ordenação dos resultados.</simpara>
+           <simpara>
             Se não especificada, o modificador obsoleto <literal>"$orderby"</literal>
             será utilizado.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -355,120 +355,118 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        <para>
-         A opção <literal>"partial"</literal> foi removida. Em vez disso, use a opção
-         <literal>"allowPartialResults"</literal>.
-        </para>
-        <para>
-         A opção <literal>"maxScan"</literal> foi removida. O suporte para esta
-         opção foi removido no MongoDB 4.2.
-        </para>
-        <para>
-         A opção <literal>"modifiers"</literal> foi removida. Esta opção era
-         usada para modificadores de consulta legados, que estão todos descontinuados.
-        </para>
-        <para>
-         A opção <literal>"oplogReplay"</literal> foi removida. Ela é ignorada
-         no MongoDB 4.4 e versões mais recentes.
-        </para>
-        <para>
-         A opção <literal>"snapshot"</literal> foi removida. O suporte para esta
-         opção foi removido no MongoDB 4.0.
-        </para>
-        <para>
-         Um valor negativo para a opção <literal>"limit"</literal> não implica mais
-         em &true; para a opção <literal>"singleBatch"</literal>. Para
-         receber apenas um único lote de resultados, combine um valor positivo
-         <literal>"limit"</literal> com a opção
-         <literal>"singleBatch"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.14.0</entry>
-       <entry>
-        <para>
-         Adicionada a opção <literal>"let"</literal> A opção
-         <literal>"comment"</literal> agora aceita qualquer tipo.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.8.0</entry>
-       <entry>
-        <para>
-         Adicionada a opção <literal>"allowDiskUse"</literal>.
-        </para>
-        <para>
-         A opção <literal>"oplogReplay"</literal> tornou-se obsoleta.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.5.0</entry>
-       <entry>
-        <para>
-         As opções <literal>"maxScan"</literal> e <literal>"snapshot"</literal>
-         tornaram-se obsoletas.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         Adicionada a opção <literal>"maxAwaitTimeMS"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         Adicionadas as opções <literal>"allowPartialResults"</literal>,
-         <literal>"collation"</literal>, <literal>"comment"</literal>,
-         <literal>"hint"</literal>, <literal>"max"</literal>,
-         <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
-         <literal>"min"</literal>, <literal>"returnKey"</literal>,
-         <literal>"showRecordId"</literal> e
-         <literal>"snapshot"</literal>.
-        </para>
-        <para>
-         A opção <literal>"partial"</literal> foi renomeada para
-         <literal>"allowPartialResults"</literal>. Para compatibilidade com versões anteriores,
-         <literal>"partial"</literal> ainda será lida se
-         <literal>"allowPartialResults"</literal> não for especificada.
-        </para>
-        <para>
-         Removida a opção legada <literal>"secondaryOk"</literal>, que está
-         obsoleta. Para consultas usando o protocolo de conexão legado OP_QUERY, o
-         driver definirá o bit <literal>secondaryOk</literal> conforme necessário, de
-         acordo com a
-         <link xlink:href="&url.mongodb.serverselection;">Especificação de Seleção de Servidor</link >.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.1.0</entry>
-       <entry>Adicionada a opção <literal>"readConcern"</literal>.</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       <simpara>
+        A opção <literal>"partial"</literal> foi removida. Em vez disso, use a opção
+        <literal>"allowPartialResults"</literal>.
+       </simpara>
+       <simpara>
+        A opção <literal>"maxScan"</literal> foi removida. O suporte para esta
+        opção foi removido no MongoDB 4.2.
+       </simpara>
+       <simpara>
+        A opção <literal>"modifiers"</literal> foi removida. Esta opção era
+        usada para modificadores de consulta legados, que estão todos descontinuados.
+       </simpara>
+       <simpara>
+        A opção <literal>"oplogReplay"</literal> foi removida. Ela é ignorada
+        no MongoDB 4.4 e versões mais recentes.
+       </simpara>
+       <simpara>
+        A opção <literal>"snapshot"</literal> foi removida. O suporte para esta
+        opção foi removido no MongoDB 4.0.
+       </simpara>
+       <simpara>
+        Um valor negativo para a opção <literal>"limit"</literal> não implica mais
+        em &true; para a opção <literal>"singleBatch"</literal>. Para
+        receber apenas um único lote de resultados, combine um valor positivo
+        <literal>"limit"</literal> com a opção
+        <literal>"singleBatch"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.14.0</entry>
+      <entry>
+       <simpara>
+        Adicionada a opção <literal>"let"</literal> A opção
+        <literal>"comment"</literal> agora aceita qualquer tipo.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.8.0</entry>
+      <entry>
+       <simpara>
+        Adicionada a opção <literal>"allowDiskUse"</literal>.
+       </simpara>
+       <simpara>
+        A opção <literal>"oplogReplay"</literal> tornou-se obsoleta.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.5.0</entry>
+      <entry>
+       <simpara>
+        As opções <literal>"maxScan"</literal> e <literal>"snapshot"</literal>
+        tornaram-se obsoletas.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        Adicionada a opção <literal>"maxAwaitTimeMS"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        Adicionadas as opções <literal>"allowPartialResults"</literal>,
+        <literal>"collation"</literal>, <literal>"comment"</literal>,
+        <literal>"hint"</literal>, <literal>"max"</literal>,
+        <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
+        <literal>"min"</literal>, <literal>"returnKey"</literal>,
+        <literal>"showRecordId"</literal> e
+        <literal>"snapshot"</literal>.
+       </simpara>
+       <simpara>
+        A opção <literal>"partial"</literal> foi renomeada para
+        <literal>"allowPartialResults"</literal>. Para compatibilidade com versões anteriores,
+        <literal>"partial"</literal> ainda será lida se
+        <literal>"allowPartialResults"</literal> não for especificada.
+       </simpara>
+       <simpara>
+        Removida a opção legada <literal>"secondaryOk"</literal>, que está
+        obsoleta. Para consultas usando o protocolo de conexão legado OP_QUERY, o
+        driver definirá o bit <literal>secondaryOk</literal> conforme necessário, de
+        acordo com a
+        <link xlink:href="&url.mongodb.serverselection;">Especificação de Seleção de Servidor</link >.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.1.0</entry>
+      <entry>Adicionada a opção <literal>"readConcern"</literal>.</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5eca06ae7725b4c35eefecbb0d722a3e198ff21 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readconcern.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um objeto para serializar o ReadConcern como BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readconcern.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ReadConcern::__construct</methodname>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>level</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo <classname>MongoDB\Driver\ReadConcern</classname>, que é
    um objeto de valor imutável.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,11 +25,11 @@
    <varlistentry>
     <term><parameter>level</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O <link xlink:href="&url.mongodb.docs.readconcern;#read-concern-levels">nível de preocupação de leitura</link>.
       As <link linkend="mongodb-driver-readconcern.constants">constantes de classe</link> podem ser usadas,
       mas o valor não está limitado a elas.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readconcern.getlevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "level" do ReadConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,19 +13,19 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\ReadConcern::isDefault</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna se esta é a preocupação de leitura padrão (ou seja, nenhuma opção é
    especificada). Este método destina-se principalmente a ser usado em conjunto com
    <methodname>MongoDB\Driver\Manager::getReadConcern</methodname> para determinar
    se o gerenciador foi construído sem nenhuma opção de preocupação de leitura.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    O driver não incluirá uma preocupação de leitura padrão em suas operações de leitura
    (por exemplo, <methodname>MongoDB\Driver\Manager::executeQuery</methodname>) para
    permitir que o servidor aplique seu próprio padrão. Bibliotecas que acessam a
    preocupação de leitura do gerenciador para incluí-la em seus próprios comandos de leitura devem usar
    esse método para garantir que as preocupações de leitura padrão não sejam definidas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna &true; se esta for a preocupação de leitura padrão ou &false; caso contrário.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um objeto para serializar ReadPreference como BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Constrói um novo <classname>MongoDB\Driver\ReadPreference</classname>, que
    é um objeto de valor imutável.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -41,45 +41,45 @@
          <row>
           <entry><literal>"primary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Todas as operações são lidas do conjunto de réplicas primário atual. Esta é
             a preferência de leitura padrão do MongoDB.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"primaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Na maioria das situações, as operações são lidas a partir dos membros primários, mas se não
             estiver disponível, as operações são lidas a partir dos membros secundários.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Todas as operações são lidas nos membros secundários do conjunto de réplicas.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Na maioria das situações, as operações são lidas a partir de membros secundários, mas se nenhum
             membro secundário estiver disponível, as operações são lidas a partir do primário.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"nearest"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Operações lidas do membro do conjunto de réplicas com a menor
             latência de rede, independentemente do tipo do membro.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -91,7 +91,7 @@
    <varlistentry>
     <term><parameter>tagSets</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Os conjuntos de tags permitem direcionar operações de leitura para membros específicos de um
       conjunto de réplicas. Este parâmetro deve ser um array de arrays associativos, cada
       um contendo zero ou mais pares chave/valor. Ao selecionar um servidor para
@@ -100,14 +100,14 @@
       o driver tentará conjuntos subsequentes. Um conjunto de tags vazio
       (<literal>array()</literal>) corresponderá a qualquer nó e pode ser usado como
       substituto.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Tags não são compatíveis com o modo <literal>"primary"</literal> e,
       em geral, só se aplicam ao selecionar um membro secundário de um conjunto para uma
       operação de leitura. No entanto, o modo <literal>"nearest"</literal>, quando
       combinado com um conjunto de tags, seleciona o membro correspondente com a menor
       latência de rede. Este membro pode ser um primário ou um secundário.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -129,8 +129,8 @@
           <entry>hedge</entry>
           <entry><type class="union"><type>object</type><type>array</type></type></entry>
           <entry>
-           <para>Especifica se devem ser usadas <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">leituras protegidas</link>, que são suportadas pelo MongoDB 4.4+ para consultas fragmentadas.</para>
-           <para>
+           <simpara>Especifica se devem ser usadas <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">leituras protegidas</link>, que são suportadas pelo MongoDB 4.4+ para consultas fragmentadas.</simpara>
+           <simpara>
             As leituras protegidas do servidor estão disponíveis para todas as preferências de leitura não primárias
             e são habilitadas por padrão ao usar o modo <literal>"nearest"</literal>.
             Esta opção permite ativar explicitamente leituras protegidas pelo servidor para
@@ -138,36 +138,36 @@
             <literal>['enabled' => true]</literal> ou desabilitando explicitamente
             leituras protegidas pelo servidor para a preferência de leitura <literal>"nearest"</literal>
             especificando <literal>['enabled' => false]</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxStalenessSeconds</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Especifica um atraso máximo de replicação, ou "inatividade", para leituras de
             secundários. Quando a inatividade estimada de um secundário excede
             esse valor, o driver deixa de usá-lo para operações de leitura.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Se especificada, a inatividade máxima deve ser um número inteiro de 32 bits com sinal,
             maior ou igual a
             <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             O padrão é
             <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>,
             o que significa que o driver não considerará o atraso de um secundário
             ao escolher para onde direcionar uma operação de leitura.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opção não é compatível com o modo <literal>"primary"</literal>.
             A especificação de uma inatividade máxima também exige que todas as instâncias
             do MongoDB na implantação usem o MongoDB 3.4+. Uma exceção será
             lançada no momento da execução se alguma instância do MongoDB na implantação
             for de uma versão de servidor mais antiga.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -191,59 +191,57 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        PAssar um <type>int</type> para o argumento <parameter>mode</parameter>
-        não é mais suportado.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Passar um <type>int</type> no parâmetro <parameter>mode</parameter>
-        foi <emphasis>DESCONTINUADO</emphasis>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.8.0</entry>
-       <entry>
-        Adcionada a opção <literal>"hedge"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         O parâmetro <parameter>mode</parameter> agora aceita um valor de string,
-         que é consistente com a opção URI <literal>"readPreference"</literal>
-         para <function>MongoDB\Driver\Manager::__construct</function>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         Adicionado um terceiro parâmetro <parameter>options</parameter>, que suporta
-         a opção <literal>"maxStalenessSeconds"</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       PAssar um <type>int</type> para o argumento <parameter>mode</parameter>
+       não é mais suportado.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Passar um <type>int</type> no parâmetro <parameter>mode</parameter>
+       foi <emphasis>DESCONTINUADO</emphasis>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.8.0</entry>
+      <entry>
+       Adcionada a opção <literal>"hedge"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        O parâmetro <parameter>mode</parameter> agora aceita um valor de string,
+        que é consistente com a opção URI <literal>"readPreference"</literal>
+        para <function>MongoDB\Driver\Manager::__construct</function>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        Adicionado um terceiro parâmetro <parameter>options</parameter>, que suporta
+        a opção <literal>"maxStalenessSeconds"</literal>.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.gethedge" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "hedge" do ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.getmaxstalenessseconds" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,12 +22,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "maxStalenessSeconds" do ReadPreference. Se nenhuma inatividade máxima
    tiver sido especificada,
    <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>
    será retornada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/getmode.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.getmode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,12 +9,12 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função tornou-se <emphasis>PRETERIDA</emphasis> a partir da versão de
     extensão 1.20.0 e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\Driver\ReadPreference::getModeString</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "mode" do ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -47,21 +47,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.method-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.method-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.getmodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "mode" do ReadPreference como uma string.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="mongodb-driver-readpreference.gettagsets" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a opção "tagSets" do ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
15 refentries: ``Query`` + ``Command`` (incl. classes) and ``ReadConcern``, ``ReadPreference`` methods. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.

``readconcern.xml`` and ``readpreference.xml`` left out: their EN diff adds a new Properties section + changelog row, requires a real translation pass.