### PR TITLE
Sync EN: mongodb functions and tutorial chapters

### DIFF
--- a/reference/mongodb/functions/bson/fromjson.xml
+++ b/reference/mongodb/functions/bson/fromjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.bson-fromjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,11 +9,11 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
     1.20.0 da extensão, e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\BSON\Document::fromJSON</methodname> em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -23,11 +23,11 @@
    <type>string</type><methodname>MongoDB\BSON\fromJSON</methodname>
    <methodparam><type>string</type><parameter>json</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte uma string
    <link xlink:href="&url.mongodb.docs.extendedjson;">JSON estendida</link>
    para sua representação BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,9 +36,9 @@
    <varlistentry>
     <term><parameter>json</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor JSON a ser convertido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,9 +46,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O documento BSON serializado como uma string binária.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -64,21 +64,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.function-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.function-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.bson-fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,11 +9,11 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
     1.20.0 da extensão, e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\BSON\Document::fromPHP</methodname> em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -23,11 +23,11 @@
    <type>string</type><methodname>MongoDB\BSON\fromPHP</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Serializa um array ou objeto (ex.: documento) para sua
    representação <link xlink:href="&url.mongodb.docs.bson;">BSON</link>. A
    string binária retornada irá descrever um documento BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,9 +36,9 @@
    <varlistentry>
     <term><parameter>value</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
     <listitem>
-     <para>
+     <simpara>
       O valor PHP a ser serializado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,9 +46,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O documento BSON serializado como uma string binária.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -68,21 +68,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.function-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.function-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
+++ b/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.bson-tocanonicalextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,12 +9,12 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
     1.20.0 da extensão, e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -24,14 +24,14 @@
    <type>string</type><methodname>MongoDB\BSON\toCanonicalExtendedJSON</methodname>
    <methodparam><type>string</type><parameter>bson</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte uma string BSON em sua
    representação <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">JSON Estendida Canônica</link>.
    O formato canônico prefere a fidelidade de tipo em detrimento do
    resultado conciso e é mais adequado para produzir resultado que possa ser convertido
    de volta para BSON sem qualquer perda de informação de tipo (por exemplo, os tipos numéricos
    permanecerão diferenciados).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,9 +40,9 @@
    <varlistentry>
     <term><parameter>bson</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor BSON a ser convertido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -50,9 +50,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor JSON convertido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -64,21 +64,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.function-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.function-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/functions/bson/tojson.xml
+++ b/reference/mongodb/functions/bson/tojson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.bson-tojson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,13 +9,13 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
     1.20.0 da extensão, e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname> ou
     <methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -25,11 +25,11 @@
    <type>string</type><methodname>MongoDB\BSON\toJSON</methodname>
    <methodparam><type>string</type><parameter>bson</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte uma string BSON na sua
    representação
    <link xlink:href="&url.mongodb.docs.extendedjson;">JSON Estendida Legada</link>
-  </para>
+  </simpara>
   <note>
    <simpara>
     Existem vários formatos JSON para representar BSON. Esta função
@@ -65,9 +65,9 @@
    <varlistentry>
     <term><parameter>bson</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor BSON a ser convertido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -75,9 +75,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor JSON convertido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -89,21 +89,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.function-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.function-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.bson-tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,11 +9,11 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
     1.20.0 da extensão, e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\BSON\Document::toPHP</methodname> em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -24,11 +24,11 @@
    <methodparam><type>string</type><parameter>bson</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>typeMap</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Desserializa um documento BSON (ou seja, string binária) para sua representação PHP.
    O parâmetro <parameter>typeMap</parameter> pode ser usado para controlar os tipos
    PHP usados ​​para converter arrays e documentos BSON (raiz e incorporados).
-  </para>
+  </simpara>
   &mongodb.warning.duplicate-keys;
  </refsect1>
 
@@ -38,9 +38,9 @@
    <varlistentry>
     <term><parameter>bson</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor BSON a ser desserializado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    &mongodb.parameter.typeMap;
@@ -49,9 +49,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor PHP desserializado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -69,53 +69,51 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.function-removed;
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        <para>
-         Se a entrada contiver um tipo BSON obsoleto e sem suporte, a
-         extensão não registrará mais um aviso no registro de depuração, mas criará
-         um objeto que representa esse tipo.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.2</entry>
-       <entry>
-        <para>
-         <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>
-         não será mais lançada se a entrada contiver um tipo BSON obsoleto e
-         sem suporte. Esses tipos serão ignorados (como eram nas versões anteriores
-         a 1.3.0), embora a extensão agora grave um alerta no registro de depuração
-         (consulte: <link linkend="ini.mongodb.debug">mongodb.debug</link >).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>
-         será lançada se a entrada contiver um tipo BSON obsoleto e não suportado.
-         Anteriormente, esses tipos eram ignorados.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.function-removed;
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       <simpara>
+        Se a entrada contiver um tipo BSON obsoleto e sem suporte, a
+        extensão não registrará mais um aviso no registro de depuração, mas criará
+        um objeto que representa esse tipo.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.2</entry>
+      <entry>
+       <simpara>
+        <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>
+        não será mais lançada se a entrada contiver um tipo BSON obsoleto e
+        sem suporte. Esses tipos serão ignorados (como eram nas versões anteriores
+        a 1.3.0), embora a extensão agora grave um alerta no registro de depuração
+        (consulte: <link linkend="ini.mongodb.debug">mongodb.debug</link >).
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname>
+        será lançada se a entrada contiver um tipo BSON obsoleto e não suportado.
+        Anteriormente, esses tipos eram ignorados.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/functions/bson/torelaxedextendedjson.xml
+++ b/reference/mongodb/functions/bson/torelaxedextendedjson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.bson-torelaxedextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,12 +9,12 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta função foi <emphasis>DESCONTINUADA</emphasis> a partir da versão
     1.20.0 da extensão, e foi removida na 2.0. As aplicações devem usar
     <methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname>
     em seu lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -24,13 +24,13 @@
    <type>string</type><methodname>MongoDB\BSON\toRelaxedExtendedJSON</methodname>
    <methodparam><type>string</type><parameter>bson</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Converte uma string BSON em sua representação
    <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">JSON Estendida Relaxada</link>.
    O formato relaxado prefere o uso de primitivos do tipo JSON em
    detrimento da fidelidade do tipo e é mais adequado para produzir resultados que podem ser
    facilmente consumidos por APIs da web e por humanos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,9 +39,9 @@
    <varlistentry>
     <term><parameter>bson</parameter> (<type>string</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Valor BSON a ser convertido.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -49,9 +49,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O valor JSON convertido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -63,21 +63,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.function-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.function-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/functions/driver/monitoring/addsubscriber.xml
+++ b/reference/mongodb/functions/driver/monitoring/addsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.driver.monitoring.addsubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <type>void</type><methodname>MongoDB\Driver\Monitoring\addSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Registra um assinante de evento de monitoramento globalmente. O assinante será
    notificado de todos os eventos da extensão para qualquer Maanger.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Se o <parameter>subscriber</parameter> já estiver registrado globalmente, esta
@@ -33,9 +33,9 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um assinante de evento de monitoramento para registrar globalmente.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,9 +43,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/functions/driver/monitoring/removesubscriber.xml
+++ b/reference/mongodb/functions/driver/monitoring/removesubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40dbbc56e321e36deee0f82df820c91fa79087cb Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="function.mongodb.driver.monitoring.removesubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <type>void</type><methodname>MongoDB\Driver\Monitoring\removeSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cancela o registro de um assinante de evento de monitoramento globalmente.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Se o <parameter>subscriber</parameter> já não estiver registrado globalmente, esta
@@ -30,9 +30,9 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Um assinante de evento de monitoramento para cancelar o registro globalmente.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -40,9 +40,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Monitoramento de Desempenho de Aplicação (APM)</title>
 
- <para>
+ <simpara>
   A extensão contém uma API de assinante de evento, que permite que as aplicações
   monitorem comandos e atividades internas pertencentes à
   <link xlink:href="&url.mongodb.sdam;">Especificação de Descoberta e Monitoramento de Servidor</link>.
   Este tutorial demonstrará o monitoramento de comandos usando A
   interface <classname>MongoDB\Driver\Monitoring\CommandSubscriber</classname>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   A interface <classname>MongoDB\Driver\Monitoring\CommandSubscriber</classname>
   define três métodos: <literal>commandStarted</literal>,
   <literal>commandSucceeded</literal> e <literal>commandFailed</literal>.
@@ -21,19 +21,19 @@
   argumento <parameter>$event</parameter> de <literal>commandSucceeded</literal>
   é um objeto
   <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Neste tutorial implementaremos um assinante que cria uma lista de todos
   os perfis de consulta e o tempo médio gasto para fazê-lo.
- </para>
+ </simpara>
 
  <section>
   <title>Preparando a Classe do Assinante</title>
 
-  <para>
+  <simpara>
    Começamos com a estrutura para nosso assinante:
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[
@@ -62,13 +62,13 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
  <section>
   <title>Registrando o Assinante</title>
 
-  <para>
+  <simpara>
    Depois que um objeto assinante é instanciado, ele precisa ser registrado no
    sistema de monitoramento das extensões. Isso é feito chamando
    <methodname>MongoDB\Driver\Monitoring\addSubscriber</methodname> ou
    <methodname>MongoDB\Driver\Manager::addSubscriber</methodname> para registrar
    o assinante globalmente ou com um gerenciador específico, respectivamente.
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[
@@ -84,28 +84,28 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
  <section>
   <title>Implementando a Lógica</title>
 
-  <para>
+  <simpara>
    Com o objeto registrado, só falta implementar a lógica
    na classe do assinante. Para correlacionar os dois eventos que compõem um
    comando executado com sucesso (commandStarted e commandSucceeded), cada
    objeto de evento expõe um campo <literal>requestId</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Para registrar o tempo médio por formato de consulta, começaremos verificando um
    comando <literal>find</literal> no evento commandStarted. Adicionaremos então
    um item à propriedade <literal>pendingCommands</literal> indexado por seu
    <literal>requestId</literal> e com seu valor representando o formato da consulta.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Se recebermos um evento commandSucceeded correspondente com o mesmo
    <literal>requestId</literal>, adicionamos a duração do evento (de
    <literal>durationMicros</literal>) ao tempo total e incrementamos a
    contagem da operação.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Se um evento commandFailed correspondente for encontrado, apenas removemos a
    entrada da propriedade <literal>pendingCommands</literal>.
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready --><!-- CREDITS: leonardolara -->
 
 <section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Usando a Biblioteca do PHP para o MongoDB (PHPLIB)</title>
 
- <para>
+ <simpara>
   Após a configuração inicial da extensão, continuaremos explicando como começar
   a usar a biblioteca correspondente no nível do usuário para escrever nosso primeiro projeto.
- </para>
+ </simpara>
 
  <section>
   <title>Instalando a Biblioteca do PHP com o Composer</title>
 
-  <para>
+  <simpara>
    A última coisa que ainda precisamos instalar para começar a usar o aplicativo
    em si é a biblioteca PHP.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    A biblioteca precisa ser instalada com o
    <link xlink:href="&url.mongodb.composer;">Composer</link>, um gerenciador de pacotes
    para PHP. Instruções para instalar o Composer em diversas plataformas podem ser
    encontradas em seu site.
-  </para>
+   </simpara>
 
   <para>
    Instale a biblioteca executando:
@@ -50,11 +50,11 @@ Generating autoload files
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    O Composer criará vários arquivos: <code>composer.json</code>,
    <code>composer.lock</code> e um diretório <code>vendor</code> que
    conterá a biblioteca e quaisquer outras dependências do seu projeto pode exigir.
-  </para>
+  </simpara>
  </section>
 
  <section>
@@ -74,12 +74,12 @@ require 'vendor/autoload.php';
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    Com isto feito, agora você pode usar qualquer funcionalidade descrita na
    <link xlink:href="&url.mongodb.library.docs;">documentação da biblioteca</link>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Se você usou drivers MongoDB em outras linguagens, a API da biblioteca
    deverá parecer familiar. Ele contém uma
    classe <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBClient/">Client</link>
@@ -90,7 +90,7 @@ require 'vendor/autoload.php';
    classe <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBCollection">Collection</link>
    para operações em nível de coleção (por exemplo,
    métodos <link xlink:href="&url.mongodb.wiki.crud;">CRUD</link>, gerenciamento de índice).
-  </para>
+  </simpara>
 
   <para>
    Por exemplo, é assim que você insere um documento na
@@ -112,13 +112,13 @@ echo "Inserido com ID do Objeto '{$result->getInsertedId()}'";
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    Como o documento inserido não continha um campo <code>_id</code>, a
    extensão irá gerar um <classname>MongoDB\BSON\ObjectId</classname> para
    o servidor usar como <code>_id</code>. Este valor também é disponibilizado
    ao chamador por meio do objeto de resultado retornado pelo método
    <code>insertOne</code>.
-  </para>
+  </simpara>
 
   <para>
    Após a inserção, você pode consultar os dados que acabou de inserir.
@@ -142,7 +142,7 @@ foreach ($result as $entry) {
    </programlisting>
   </para>
 
-  <para>
+  <simpara>
    Embora possa não ser aparente nos exemplos, os documentos e arrays do BSON são
    desserializados como classes especiais na biblioteca por padrão. Essas classes
    estendem <classname>ArrayObject</classname> para usabilidade e implementam as
@@ -153,7 +153,7 @@ foreach ($result as $entry) {
    podem se transformar em documentos e vice-versa. Consulte a
    especificação <xref linkend="mongodb.persistence"/> para obter mais informações sobre
    como os valores são convertidos entre PHP e BSON.
-  </para>
+  </simpara>
  </section>
 </section>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
10 refentries: ``functions/bson/*``, ``functions/driver/monitoring/{add,remove}Subscriber.xml``, ``tutorial/{apm,library}.xml``. Mechanical XML refactor only (``<para>`` → ``<simpara>``, ``<para>`` wrapper dropped around ``<informaltable>``). Portuguese prose preserved.