### PR TITLE
intl/Collator: fix double anchor tag when classname and link are used together (#5547)

### DIFF
--- a/reference/intl/collator/asort.xml
+++ b/reference/intl/collator/asort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.asort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::asort</refname>
@@ -144,7 +144,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes de Collator</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>

--- a/reference/intl/collator/get-attribute.xml
+++ b/reference/intl/collator/get-attribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::getAttribute</refname>
@@ -86,7 +86,7 @@ if( $val === false )
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes de Collator</link></member>
     <member><function>collator_set_attribute</function></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/get-strength.xml
+++ b/reference/intl/collator/get-strength.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.getstrength" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::getStrength</refname>
@@ -81,7 +81,7 @@ $strength = collator_get_strength( $coll );
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes de Collator</link></member>
     <member><function>collator_set_strength</function></member>
     <member><function>collator_get_attribute</function></member>
    </simplelist>

--- a/reference/intl/collator/set-attribute.xml
+++ b/reference/intl/collator/set-attribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0194deb3cec8d79ae6b13700f3cd031d14597838 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::setAttribute</refname>
@@ -89,7 +89,7 @@ collator_set_attribute($coll, Collator::NORMALIZATION_MODE, Collator::ON);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes de Collator</link></member>
     <member><function>collator_get_attribute</function></member>
     <member><function>collator_set_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 679cf93fa1e54cde82fc9cf545966eb13bcb0638 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.setstrength" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Collator::setStrength</refname>
@@ -226,7 +226,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes de Collator</link></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>
   </para>

--- a/reference/intl/collator/sort-with-sort-keys.xml
+++ b/reference/intl/collator/sort-with-sort-keys.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.sortwithsortkeys" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::sortWithSortKeys</refname>
@@ -94,7 +94,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes Collator</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_asort</function></member>
    </simplelist>

--- a/reference/intl/collator/sort.xml
+++ b/reference/intl/collator/sort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: leonardolara Status: ready -->
 <refentry xml:id="collator.sort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::sort</refname>
@@ -136,7 +136,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
+    <member><link linkend="intl.collator-constants">Constantes de Collator</link></member>
     <member><function>collator_asort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>


### PR DESCRIPTION
Sincroniza com [php/doc-en#5547](https://github.com/php/doc-en/pull/5547) (commit `e290572f25`), removendo o wrapping `<classname>...</classname>` em torno de `Collator` dentro do `<link linkend="intl.collator-constants">` nos seealso. O texto traduzido em português permanece o mesmo.

7 arquivos atualizados.