### PR TITLE
Sync EN: PHP 8.5 features (HEIF, cast (void), Dblib::ATTR_DATETIME_CONVERT)

### DIFF
--- a/appendices/migration85/constants.xml
+++ b/appendices/migration85/constants.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: leonardolara Status: ready -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: f8bab1dfb5c61e8be94f4b0acaae7e59c7eddb31 Maintainer: leonardolara Status: ready -->
 <sect1 xml:id="migration85.constants">
  <title>Novas Constantes Globais</title>
 
@@ -160,6 +160,9 @@
   <title>Padrão</title>
 
   <simplelist>
+   <member>
+    <constant>IMAGETYPE_HEIF</constant>
+   </member>
    <member>
     <constant>IMAGETYPE_SVG</constant>
     quando a libxml estiver carregada.

--- a/doc-pt_br
+++ b/doc-pt_br
@@ -1,0 +1,1 @@
+doc-pt_br

--- a/doc-pt_br
+++ b/doc-pt_br
@@ -1,1 +1,0 @@
-doc-pt_br

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96b10a98853e3b8236504e5775f95eb4a15c82c3 Maintainer: leonardolara Status: ready --><!-- CREDITS: ThamaraHessel,pauloelr,royopa,ae,geekcom,leonardolara -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: leonardolara Status: ready --><!-- CREDITS: ThamaraHessel,pauloelr,royopa,ae,geekcom,leonardolara -->
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Usando PHP a partir da linha de comando</title>
  <titleabbrev>Uso da linha de Comando</titleabbrev>
@@ -203,6 +203,7 @@ if (php_sapi_name() === 'cli') {
             </informalexample>
            </para>
           </warning>
+          &warn.deprecated.feature-8-5-0;
           </entry>
          </row>
          <row>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,fabioluciano,geekcom,gabrielsanva,ae,leonardolara -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,fabioluciano,geekcom,gabrielsanva,ae,leonardolara -->
 <sect1 xml:id="language.types.type-juggling">
  <title>Conversão automática de tipos</title>
 
@@ -317,6 +317,12 @@ var_dump($bar);
    <member><literal>(unset)</literal> - converte para <type>NULL</type></member>
   </simplelist>
 
+  <simpara>
+   A conversão <link linkend="language.types.void.casting"><literal>(void)</literal></link>
+   também está disponível a partir do PHP 8.5.0, mas não é uma conversão de valor.
+   Ela é usada como uma instrução para descartar explicitamente o resultado de uma expressão.
+  </simpara>
+
   <warning>
    <para>
     <literal>(integer)</literal> é um sinônimo de <literal>(int)</literal>.
@@ -422,6 +428,7 @@ if ($fst === $str) {
     <member><link linkend="language.types.object.casting">Convertendo para object</link></member>
     <member><link linkend="language.types.resource.casting">Convertendo para resource</link></member>
     <member><link linkend="language.types.null.casting">Convertendo para NULL</link></member>
+    <member><link linkend="language.types.void.casting">Descartando um valor com <literal>(void)</literal></link></member>
     <member><link linkend="types.comparisons">Tabela de conversão de tipos</link></member>
    </simplelist>
   </para>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: marcosmarcolin Status: ready --><!-- CREDITS: marcosmarcolin -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: marcosmarcolin Status: ready --><!-- CREDITS: marcosmarcolin -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>
 
@@ -17,6 +17,38 @@
   </simpara>
  </note>
 
+ <sect2 xml:id="language.types.void.casting">
+  <title>Descartando um valor com <literal>(void)</literal></title>
+
+  <simpara>
+   A sintaxe <literal>(void)</literal> pode ser usada para descartar
+   explicitamente o resultado de uma expressão. Isso é útil para indicar que
+   ignorar um valor de retorno é intencional, especialmente ao chamar uma
+   função ou método marcado com o atributo <classname>NoDiscard</classname>.
+  </simpara>
+
+  <simpara>
+   Diferentemente de outras conversões, <literal>(void)</literal> não converte
+   o valor para outro tipo e não produz um valor. É uma instrução e não pode
+   ser usada como parte de uma expressão.
+  </simpara>
+
+  <example>
+   <title>Descartando um valor de retorno</title>
+   <programlisting role="php" annotations="non-interactive">
+    <![CDATA[
+<?php
+#[\NoDiscard]
+function process(): bool {
+    return true;
+}
+
+(void) process(); // Descarta explicitamente o valor de retorno
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect2>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6a08181be1706dfebdb3ad6e45620bceb08019ba Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<!-- EN-Revision: f8bab1dfb5c61e8be94f4b0acaae7e59c7eddb31 Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
 <!-- splitted from ./en/functions/image.xml, last change in rev 1.81 -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.exif-imagetype">
  <refnamediv>
@@ -135,6 +135,10 @@
        <entry>19</entry>
        <entry><constant>IMAGETYPE_AVIF</constant></entry>
       </row>
+      <row>
+       <entry>20</entry>
+       <entry><constant>IMAGETYPE_HEIF</constant></entry>
+      </row>
      </tbody>
     </tgroup>
    </table>
@@ -172,6 +176,12 @@
       <entry>8.1.0</entry>
       <entry>
        Adicionado suporte a AVIF.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Adicionado suporte a HEIF.
       </entry>
      </row>
     </tbody>

--- a/reference/image/constants.xml
+++ b/reference/image/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7f5d646f3ee39231150e767fb876b56610f56c2b Maintainer: ae Status: ready --><!-- CREDITS: felipe,ae,leonardolara -->
+<!-- EN-Revision: f8bab1dfb5c61e8be94f4b0acaae7e59c7eddb31 Maintainer: ae Status: ready --><!-- CREDITS: felipe,ae,leonardolara -->
 <appendix xml:id="image.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -698,6 +698,18 @@
     &gd.constants.type;
     <simpara>
      (Disponível a partir do PHP 8.1.0)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.imagetype-heif">
+   <term>
+    <constant>IMAGETYPE_HEIF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    &gd.constants.type;
+    <simpara>
+     (Disponível a partir do PHP 8.5.0)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/image/functions/image-type-to-mime-type.xml
+++ b/reference/image/functions/image-type-to-mime-type.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: f8bab1dfb5c61e8be94f4b0acaae7e59c7eddb31 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.image-type-to-mime-type" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>image_type_to_mime_type</refname>
@@ -124,6 +124,10 @@
       <row>
        <entry><constant>IMAGETYPE_AVIF</constant></entry>
        <entry><literal>image/avif</literal></entry>
+      </row>
+      <row>
+       <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       <entry><literal>image/heif</literal></entry>
       </row>
      </tbody>
     </tgroup>

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 608815b2f52cc7dae75eb02e27f457aad1e5e977 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
  <title>A classe Pdo\Dblib</title>
  <titleabbrev>Pdo\Dblib</titleabbrev>
@@ -142,6 +142,14 @@
      <term><constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant></term>
      <listitem>
       <simpara>
+       Esse atributo de conexão controla o formato das strings para tipos
+       datetime. Quando definido como &false;, o PDO_DBLIB retornará um tipo
+       datetime como uma string no formato em que o SQL Server o retorna (ou
+       seja, <literal>"2017-10-27 10:22:44"</literal>). Quando &true;, o
+       PDO_DBLIB converterá o tipo datetime em uma string usando um formato
+       definido pelo usuário ou pelo locale, conforme especificado no arquivo
+       <filename>locales.conf</filename> do FreeTDS. Por padrão, esse atributo
+       é &false;.
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Sincroniza diversas adições do PHP 8.5 do php/doc-en:

- `reference/image/constants.xml` — adiciona `IMAGETYPE_HEIF` ([php/doc-en#5042](https://github.com/php/doc-en/pull/5042))
- `reference/image/functions/image-type-to-mime-type.xml` — entrada HEIF / `image/heif`
- `reference/exif/functions/exif-imagetype.xml` — `IMAGETYPE_HEIF` (valor 20) e changelog 8.5
- `appendices/migration85/constants.xml` — `IMAGETYPE_HEIF` na lista
- `features/commandline.xml` — `&warn.deprecated.feature-8-5-0;` ([php/doc-en#5419](https://github.com/php/doc-en/pull/5419))
- `language/types/type-juggling.xml` — bullet do cast `(void)` ([php/doc-en#5546](https://github.com/php/doc-en/pull/5546))
- `language/types/void.xml` — nova seção "Descartando um valor com `(void)`"
- `reference/pdo_dblib/pdo-dblib.xml` — descrição de `Pdo\Dblib::ATTR_DATETIME_CONVERT` ([php/doc-en#4658](https://github.com/php/doc-en/pull/4658))