### PR TITLE
Sync EN: micro-fixes diversos (flock, curl CAINFO_BLOB, predefined classes)

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: ae Status: ready --><!-- CREDITS: royopa,fabioluciano,hugouke,ae,adaiasmagdiel -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: ae Status: ready --><!-- CREDITS: royopa,fabioluciano,hugouke,ae,adaiasmagdiel -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>A interface ArrayAccess</title>
@@ -81,7 +81,6 @@ $obj[] = 'Append 1';
 $obj[] = 'Append 2';
 $obj[] = 'Append 3';
 print_r($obj);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -91,9 +90,9 @@ bool(true)
 int(2)
 bool(false)
 string(7) "A value"
-obj Object
+Obj Object
 (
-    [container:obj:private] => Array
+    [container] => Array
         (
             [one] => 1
             [three] => 3

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
-<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>A classe Fiber</title>
  <titleabbrev>Fiber</titleabbrev>
 

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
-<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<?xml version="1.0" encoding="utf-8"?><!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>FiberError</title>
  <titleabbrev>FiberError</titleabbrev>
 

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 267a3d4e60d8a6da941e72d195386b5841052cca Maintainer: ae Status: ready --><!-- CREDITS: royopa,geekcom,ae,leonardolara -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: ae Status: ready --><!-- CREDITS: royopa,geekcom,ae,leonardolara -->
 
-<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+ annotations="interactive">
  <title>Interfaces e Classes predefinidas</title>
 
  <partintro>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: leonardolara Status: ready --><!-- CREDITS: fabioluciano,ae,leonardolara -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: leonardolara Status: ready --><!-- CREDITS: fabioluciano,ae,leonardolara -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>A interface Serializable</title>
@@ -88,6 +88,7 @@ var_dump($newobj->getData());
     &example.outputs.similar;
     <screen>
 <![CDATA[
+Deprecated: obj implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in script on line 2
 string(38) "C:3:"obj":23:{s:15:"My private data";}"
 string(15) "My private data"
 ]]>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,4 +1,4 @@
- <variablelist role="constant_list"><!-- EN-Revision: d7d6dd60085409b295916649e4bd7107742659a2 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+ <variablelist role="constant_list"><!-- EN-Revision: e38c9165b91df5e9c52eb705c169938bcdc20d31 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
   <title><function>curl_setopt</function></title>
   <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
    <term>
@@ -183,8 +183,9 @@
    </term>
    <listitem>
     <para>
-     Uma <type>string</type> com o nome de um arquivo PEM contendo um ou mais certificados com o qual
-     o par será verificado. Esta opção substitui a <constant>CURLOPT_CAINFO</constant>.
+     Uma <type>string</type> binária com conteúdo codificado em PEM contendo um ou mais
+     certificados com os quais o par será verificado. Esta opção substitui a
+     <constant>CURLOPT_CAINFO</constant>.
      Disponível a partir do PHP 8.2.0 e cURL 7.77.0.
     </para>
    </listitem>

--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0bfb0eb957e0468912af86bba09fae588010c1df Maintainer: leonardolara Status: ready --><!-- CREDITS: rarruda, ae, felipe, leonardolara -->
+<!-- EN-Revision: 75a76afb61d91f04feebc83931c5412b13682d2b Maintainer: leonardolara Status: ready --><!-- CREDITS: rarruda, ae, felipe, leonardolara -->
 <refentry xml:id="function.flock" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>flock</refname>
@@ -104,6 +104,7 @@ $fp = fopen("/tmp/lock.txt", "r+");
 
 if (flock($fp, LOCK_EX)) {  // adquire uma trava exclusiva
     ftruncate($fp, 0);      // trunca o arquivo
+    rewind($fp);
     fwrite($fp, "Escreve alguma coisa aqui\n");
     fflush($fp);            // descarrega a saída antes de liberar a trava
     flock($fp, LOCK_UN);    // libera a trava


### PR DESCRIPTION
Sincroniza diversas atualizações pequenas do php/doc-en:

- `reference/filesystem/functions/flock.xml` — `rewind()` no exemplo ([php/doc-en#3366](https://github.com/php/doc-en/pull/3366))
- `reference/curl/constants_curl_setopt.xml` — descrição de `CURLOPT_CAINFO_BLOB` (binary string + PEM encoded) ([php/doc-en#4746](https://github.com/php/doc-en/pull/4746))
- `language/predefined/interfaces.xml` — `annotations="interactive"`
- `language/predefined/fiber.xml`, `fibererror.xml` — `annotations="non-interactive"`
- `language/predefined/serializable.xml` — mensagem Deprecated no output do exemplo
- `language/predefined/arrayaccess.xml` — ajuste do output do exemplo