### PR TITLE
Sync EN: ini & config (PHP 8.5 deprecations, fpm, http_build_query)

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 185dda85976e5ed392664db011abda0110726c0d Maintainer: leonardolara Status: ready --><!-- CREDITS: ae,fibbarth,fabioluciano,rogeriopradoj,adiel,geekcom,rafaelbernard,leonardolara -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: leonardolara Status: ready --><!-- CREDITS: ae,fibbarth,fabioluciano,rogeriopradoj,adiel,geekcom,rafaelbernard,leonardolara -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Descrição das principais diretivas do &php.ini;</title>
@@ -60,7 +60,7 @@
         <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
         <entry>""</entry>
         <entry>&php.ini; apenas</entry>
-        <entry></entry>
+        <entry>Removida a partir do PHP 8.5.0</entry>
        </row>
        <row>
         <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
@@ -235,15 +235,15 @@
        <type>string</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         Esta diretiva permite que certas classes sejam desabilitadas.
         Ela recebe uma lista de nomes de classes separadas por vírgula.
         Desabilitar uma classe apenas impede que ela seja instanciada.
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         Somente classes internas podem ser desabilitadas ao usar esta diretiva.
         Classes definidas pelo usuário não são afetadas.
-       </para>
+       </simpara>
        <simpara>
         Esta diretiva deve ser configurada no &php.ini;.
         Ela não pode ser configurada no &httpd.conf;.
@@ -254,6 +254,7 @@
          medida de segurança suficiente para ambientes de hospedagem compartilhados.
         </simpara>
        </warning>
+       &warn.removed.feature-8-5-0;
       </listitem>
      </varlistentry>
 
@@ -599,7 +600,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
         <entry>"1"</entry>
         <entry><constant>INI_PERDIR</constant></entry>
-        <entry></entry>
+        <entry>Descontinuada a partir do PHP 8.5.0</entry>
        </row>
        <row>
         <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
@@ -789,6 +790,16 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <simpara>
         Veja também <link linkend="features.commandline">PHP em linha de comando</link>.
        </simpara>
+       &warn.deprecated.feature-8-5-0;
+       <note>
+        <simpara>
+         Derivar <code>$_SERVER['argc']</code> e <code>$_SERVER['argv']</code>
+         a partir da query string para SAPIs não-CLI foi descontinuado.
+         Configure <literal>register_argc_argv=0</literal> e use
+         <varname>$_GET</varname> ou <code>$_SERVER['QUERY_STRING']</code>
+         para acessar a informação, depois de verificar que esse uso é seguro.
+        </simpara>
+       </note>
       </listitem>
      </varlistentry>
 

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: leonardolara Status: ready --><!-- CREDITS: galvao,ae,fabioluciano,geekcom,adiel,leonardolara -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: leonardolara Status: ready --><!-- CREDITS: galvao,ae,fabioluciano,geekcom,adiel,leonardolara -->
  <section xml:id="ini.list" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Lista de diretivas do &php.ini;</title>
   <para>
@@ -207,7 +207,7 @@
        <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
        <entry><literal>""</literal></entry>
        <entry>Somente no &php.ini;</entry>
-       <entry></entry>
+       <entry>Removida a partir do PHP 8.5.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
@@ -551,13 +551,13 @@
        <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_PERDIR</constant></entry>
-       <entry></entry>
+       <entry>Descontinuada a partir do PHP 8.5.0</entry>
       </row>
       <row>
        <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
-       <entry></entry>
+       <entry>Descontinuada a partir do PHP 8.5.0</entry>
       </row>
       <row>
        <entry>report_zend_debug</entry>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f0149750aedec8b2eaa46338d90213dc4767d8b3 Maintainer: leonardolara Status: ready --><!-- CREDITS: jeffersonnathan,fabioluciano,ae,leonardolara -->
+<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: leonardolara Status: ready --><!-- CREDITS: jeffersonnathan,fabioluciano,ae,leonardolara -->
   <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Configuração</title>
    <para>
@@ -392,16 +392,16 @@
        <para>
         <literal>static</literal> - o número de processos filho é fixo (<literal>pm.max_children</literal>).
        </para>
-       <para>
+       <simpara>
         <literal>ondemand</literal> - os processos são criados sob demanda (quando solicitado,
         em oposição a "dynamic", onde <literal>pm.start_servers</literal> são iniciados
-        quando o serviço é iniciado.
-       </para>
-       <para>
+        quando o serviço é iniciado).
+       </simpara>
+       <simpara>
         <literal>dynamic</literal> - o número de processos filhos é definido dinamicamente com base nas
         seguintes diretivas: <literal>pm.max_children</literal>, <literal>pm.start_servers</literal>,
         <literal>pm.min_spare_servers</literal> e <literal>pm.max_spare_servers</literal>.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="pm.max-children">
@@ -410,12 +410,12 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         O número de processos filhos a serem criados quando <literal>pm</literal> está definido como
         <literal>static</literal> e o número máximo de processos filhos a serem criados
-        quando <literal>pm</literal> está definido como <literal>dynamic</literal>. Esta
-        opção é obrigatória.
-       </para>
+        quando <literal>pm</literal> está definido como <literal>dynamic</literal> ou <literal>ondemand</literal>.
+        Esta opção é obrigatória.
+       </simpara>
        <para>
         Esta opção define o limite para o número de solicitações simultâneas que
         serão servidas. Equivalente à diretiva ApacheMaxClients com
@@ -1027,8 +1027,7 @@ php_admin_value[memory_limit] = 32M
      Configurações do PHP feitas com <literal>php_value</literal> ou
      <literal>php_flag</literal> irão sobrescrever o valor anterior.
      Observe que a definição de
-     <link linkend="ini.disable-functions">disable_functions</link> ou
-     <link linkend="ini.disable-classes">disable_classes</link> não
+     <link linkend="ini.disable-functions">disable_functions</link> não
      irá substituir os valores previamente definidos no <filename>php.ini</filename>,
      mas adicionará o novo valor em seu lugar.
     </para>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 72a6f3d35e914602703b698a5d8f52732b61ed3e Maintainer: leonardolara Status: ready --><!-- CREDITS: mauricio,leonardolara -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: leonardolara Status: ready --><!-- CREDITS: mauricio,leonardolara -->
 <section xml:id="errorfunc.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
  &extension.runtime;
@@ -64,7 +64,7 @@
      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry></entry>
+     <entry>Descontinuada a partir do PHP 8.5.0</entry>
     </row>
     <row>
      <entry><link linkend="ini.track-errors">track_errors</link></entry>

--- a/reference/url/functions/http-build-query.xml
+++ b/reference/url/functions/http-build-query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: e80ef2394f0c64be66917a5d4335736ae05b774f Maintainer: leonardolara Status: ready --><!-- CREDITS: narigone, fernandowobeto, leonardolara -->
+<!-- EN-Revision: f72c6031982a6f8152ef351d20f8e0d90e8f1612 Maintainer: leonardolara Status: ready --><!-- CREDITS: narigone, fernandowobeto, leonardolara -->
 <refentry xml:id="function.http-build-query" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>http_build_query</refname>
@@ -40,6 +40,14 @@
        Se <parameter>data</parameter> é um objeto, então somente propriedades
        públicas serão incorporadas ao resultado.
       </para>
+      <note>
+       <simpara>
+        O método mágico <link linkend="object.tostring">__toString()</link>
+        não é chamado quando um objeto é avaliado. Para usar a representação em
+        string de um objeto na query string, o objeto precisa ser explicitamente
+        convertido para string.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -260,6 +268,44 @@ echo http_build_query($parent);
    <screen>
 <![CDATA[
 pub=publicParent&pub_bar%5Bpub%5D=publicChild
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title>Usando <function>http_build_query</function> com objetos contendo
+    <link linkend="object.tostring">__toString()</link>
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Foo {
+    public $publicProperty = 'visible';
+
+    public function __toString() {
+        return "bar";
+    }
+}
+
+$params = array(
+    'a' => 'b',
+    'foo' => new Foo()
+);
+
+// Sem conversão, http_build_query lê as propriedades públicas
+echo http_build_query($params) . "\n";
+
+// Com conversão explícita, http_build_query usa o output de __toString()
+$params['foo'] = (string) new Foo();
+echo http_build_query($params) . "\n";
+?>
+]]>
+   </programlisting>
+ &example.outputs;
+   <screen>
+<![CDATA[
+a=b&foo%5BpublicProperty%5D=visible
+a=b&foo=bar
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
- `appendices/ini.core.xml` — `disable_classes` removida e `register_argc_argv` descontinuada no PHP 8.5 ([php/doc-en#5419](https://github.com/php/doc-en/pull/5419))
- `appendices/ini.list.xml` — tabela atualizada (disable_classes / register_argc_argv / report_memleaks)
- `reference/errorfunc/ini.xml` — nota de descontinuação para `report_memleaks`
- `install/fpm/configuration.xml` — `pm.max_children` menciona `ondemand`, `disable_classes` removida da nota ([php/doc-en#4619](https://github.com/php/doc-en/pull/4619))
- `reference/url/functions/http-build-query.xml` — esclarecimento e exemplo sobre comportamento com `__toString()` ([php/doc-en#5529](https://github.com/php/doc-en/pull/5529))