### PR TITLE
Sync EN: ext/zip - converter <para> para <simpara> (#5536)

### DIFF
--- a/reference/zip/book.xml
+++ b/reference/zip/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aebf045bfb7f4f2350db5e1e908cf290be334075 Maintainer: leonardolara Status: ready --><!-- CREDITS: ae,felope,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: leonardolara Status: ready --><!-- CREDITS: ae,felope,leonardolara -->
 
 <book xml:id="book.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundledexternal" ?>
@@ -8,10 +8,10 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.zip">
   &reftitle.intro;
-  <para>
+  <simpara>
    Esta extensão habilita você a ler ou escrever arquivos
    ZIP e os arquivos compactados internamente.
-  </para>
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 7747acdc55fe497b9e920d6edcbe70c71e03ea30 Maintainer: ae Status: ready --><!-- CREDITS: lisaldo,felipe,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: lisaldo,felipe,ae,leonardolara -->
 <section xml:id="zip.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
  <section xml:id="zip.installation.linux">
   <title>Sistemas Linux</title>
-  <para>
+  <simpara>
    Para usar estas funções, o PHP deve ser compilado com suporte ZIP
    usando-se a opção de configuração
    <option role="configure">--with-zip</option>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Antes do PHP 7.4.0, libzip era incluída no PHP,
    e para compilar a extensão era necessário usar a
    opção de configuração
@@ -19,30 +19,30 @@
    mas ainda possível, usando-se
    a opção de configuração
    <option role="configure">--without-libzip</option>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Um opção de configuração <option role="configure">--with-libzip=DIR</option>
    foi adicionada para usar uma instalação libzip de sistema. A
    versão 0.11 da libzip é requerida, com 0.11.2 ou posterior recomendada.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="zip.installation.new.windows">
   <title>Windows</title>
-  <para>
+  <simpara>
    A partir do PHP 8.2.0, a DLL <filename>php_zip.dll</filename> precisa ser
    <link linkend="install.pecl.windows.loading">ativada</link> no
    &php.ini;.
    Anteriormente, esta extensão era interna.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="zip.installation.pecl">
   <title>Instalação via PECL</title>
-  <para>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;zip">&url.pecl.package;zip</link>.
-  </para>
+  </simpara>
  </section>
 
 </section>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8afee82662753fe5ed0c3b8003b14118f00547ef Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <appendix xml:id="zip.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
 
-  <para>
+  <simpara>
    <classname>ZipArchive</classname> utiliza constantes de classe.
    Existem vários tipos de constantes, os principais são:
    Opções (prefixadas com <literal>FL_</literal>),
    Opções globais (prefixadas com <literal>AFL_</literal>),
    erros (prefixadas com <literal>ER_</literal>) e
    modo (sem prefixo).
-  </para>
+  </simpara>
 
  <variablelist xml:id="ziparchive.constants.mode">
   <title>Modos de abertura do arquivo</title>

--- a/reference/zip/examples.xml
+++ b/reference/zip/examples.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: bac24fafb415f56925732ef41ec7b2326ded3d8e Maintainer: felipe Status: ready --><!-- CREDITS: lisaldo -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: felipe Status: ready --><!-- CREDITS: lisaldo -->
 
 <chapter xml:id="zip.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -78,13 +78,13 @@ print_r($odt_meta);
 ]]>
   </programlisting>
  </example>
- <para>
+ <simpara>
   Este exemplo usa a velha API (PHP 4), ela abre um arquivo ZIP,
   ler cada arquivo do arquivo e imprime o conteúdo deles.
   O arquivo <filename>test2.zip</filename> usado neste exemplo
   é um arquivo de teste do fonte da distruição
   ZZIPlib.
- </para>
+ </simpara>
  <example>
   <title>Exemplo de uso</title>
   <programlisting role="php">

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!---->
 <refentry xml:id="function.zip-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type>void</type><methodname>zip_close</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Fecha um dado arquivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Um arquivo ZIP previamente aberto com <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!---->
 <refentry xml:id="function.zip-entry-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type>bool</type><methodname>zip_entry_close</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Fecha uma especificada lista de entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Um diretório de entrada previamente aberto com <function>zip_entry_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!---->
 <refentry xml:id="function.zip-entry-compressedsize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_compressedsize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o tamanho do arquivo compactado dentro do arquivo ZIP especificado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Uma lista de entrada retornada pela <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O tamanho comprimido, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!---->
 <refentry xml:id="function.zip-entry-compressionmethod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,10 +18,10 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_compressionmethod</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera qual o método de compressão foi utilizado no arquivo
    passado por <parameter>zip_entry</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Uma lista de entrada retornada pela <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,9 +40,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O método de compressão, ou , &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-filesize.xml
+++ b/reference/zip/functions/zip-entry-filesize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!-- -->
 <refentry xml:id="function.zip-entry-filesize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_filesize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o tamanho atual do especificado diretório de entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Um diretório de entrada retornado por <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O tamanho do item de diretório, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-name.xml
+++ b/reference/zip/functions/zip-entry-name.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!-- -->
 <refentry xml:id="function.zip-entry-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_name</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome do arquivo especificado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        A lista de entrada retornada pela <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,9 +39,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    O nome do arquivo, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: ricardo,ae,leonardolara -->
 <!-- -->
 <refentry xml:id="function.zip-entry-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,9 +20,9 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Abre um arquivo para leitura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,32 +31,32 @@
     <varlistentry>
      <term><parameter>zip_dp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Um recurso válido retornado por <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Uma entrada de diretório retornada por <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>mode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Algum dos modos especificados na documentação da
        <function>fopen</function>.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Atualmente, o parâmetro <parameter>mode</parameter> é ignorado e o modo padrão suportado é
         <literal>"rb"</literal>. Isto é devido ao fato que o suporte a zip
         no PHP é apenas de leitura.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -65,16 +65,16 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Diferentemente de <function>fopen</function> e outras funções similares,
     o valor retornado de <function>zip_entry_open</function> somente
     indica o resultado da operação, e não o valor em si não é necessário para
     a leitura ou fechamento recurso.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: felipe,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: felipe,ae,leonardolara -->
 <!-- -->
 <refentry xml:id="function.zip-entry-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>1024</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtém dados de um arquivo.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,21 +30,21 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Um arquivo retornado pela <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O número de bytes para retornar.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Este deve ser o tamanho não comprimido que você deseja ler.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -53,9 +53,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna a informação lida, string vazia no fim de um arquivo, ou &false; em caso de erro.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: felipe,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: felipe,ae,leonardolara -->
 <!-- splitted from ./en/functions/zip.xml, last change in rev 1.11 -->
 <refentry xml:id="function.zip-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type class="union"><type>resource</type><type>int</type><type>false</type></type><methodname>zip_open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Abre um arquivo ZIP para ser lido.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O nome do arquivo ZIP para abrir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,12 +39,12 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um identificador que pode ser usado com as funções
    <function>zip_read</function> e <function>zip_close</function>
    ou retorna &false; ou ainda o número de erro se <parameter>filename</parameter>
    não existir e/ou outras situações.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: ae Status: ready --><!-- CREDITS: lisaldo,felipe,ae,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: lisaldo,felipe,ae,leonardolara -->
 <!-- splitted from ./en/functions/zip.xml, last change in rev 1.11 -->
 <refentry xml:id="function.zip-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,9 +18,9 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>zip_read</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Lê o próximo item dentro de uma arquivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -29,9 +29,9 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Um arquivo ZIP anteriormente aberto com <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -39,12 +39,12 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma conexao com o arquivo ZIP para ser usado com as funções
    <literal>zip_entry_...</literal>, ou &false; se não houver
    arquivos para serem lidos, ou um código de erro caso ocorra
    algum.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/setup.xml
+++ b/reference/zip/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 765b2d6eec7dfbaeed900b32aa91a1360d73df42 Maintainer: ae Status: ready --><!-- CREDITS: lisaldo,felipe,ae -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: ae Status: ready --><!-- CREDITS: lisaldo,felipe,ae -->
 
 <chapter xml:id="zip.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -7,12 +7,12 @@
  <!-- {{{ Requirements -->
  <section xml:id="zip.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    Esta extensão requer <link xlink:href="&url.libzip;">libzip</link>. A versão 1.1.2 era internalizada no PHP até a versão 7.3.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    A versão mínima necessária é 0.11, mas uma versão mais recente é recomendada.
-  </para>
+  </simpara>
   <para>
      <simplelist>
       <member>A versão 1.2 é requerida para suporte criptografia, veja <methodname>ZipArchive::setEncryptionIndex</methodname></member>
@@ -30,11 +30,11 @@
  <!-- {{{ Resources -->
  <section xml:id="zip.resources">
   &reftitle.resources;
-  <para>
+  <simpara>
    Há dois tipos de recursos neste módulo. O primeiro é
    um Zip directory para arquivo Zip, o segundo Zip Entry para
    entradas de arquivos.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0e48705eb88453af785e0e4a6cbd526085dfe3a Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandowobeto -->
 <reference xml:id="class.ziparchive" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>A classe <classname>ZipArchive</classname></title>
  <titleabbrev>ZipArchive</titleabbrev>
@@ -9,9 +9,9 @@
 <!-- {{{ ZipArchive intro -->
   <section xml:id="ziparchive.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Um arquivo compactado com Zip.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -745,40 +745,40 @@
     <varlistentry xml:id="ziparchive.props.lastid">
      <term><varname>lastId</varname></term>
      <listitem>
-      <para>Valor do índice da última entrada adicionada (arquivo ou diretório).
-      Disponível a partir do PHP 8.0.0 e PECL zip 1.18.0.</para>
+      <simpara>Valor do índice da última entrada adicionada (arquivo ou diretório).
+      Disponível a partir do PHP 8.0.0 e PECL zip 1.18.0.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.status">
      <term><varname>status</varname></term>
      <listitem>
-      <para>Status do arquivo Zip.
-      Disponível para arquivos fechados, a partir do PHP 8.0.0 e PECL zip 1.18.0.</para>
+      <simpara>Status do arquivo Zip.
+      Disponível para arquivos fechados, a partir do PHP 8.0.0 e PECL zip 1.18.0.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.statussys">
      <term><varname>statusSys</varname></term>
      <listitem>
-      <para>Status do sistema do arquivo Zip.
-      Disponível para arquivos fechados, a partir do PHP 8.0.0 e PECL zip 1.18.0.</para>
+      <simpara>Status do sistema do arquivo Zip.
+      Disponível para arquivos fechados, a partir do PHP 8.0.0 e PECL zip 1.18.0.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.numfiles">
      <term><varname>numFiles</varname></term>
      <listitem>
-      <para>Número de arquivos no arquivo Zip</para>
+      <simpara>Número de arquivos no arquivo Zip</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.filename">
      <term><varname>filename</varname></term>
      <listitem>
-      <para>Nome do arquivo no sistema de arquivos</para>
+      <simpara>Nome do arquivo no sistema de arquivos</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.comment">
      <term><varname>comment</varname></term>
      <listitem>
-      <para>Comentário para o arquivo Zip</para>
+      <simpara>Comentário para o arquivo Zip</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0545e305cf06937b14b3f0694d6e716c9881ffd7 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.addemptydir" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::addEmptyDir</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>dirname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona um diretório vazio no arquivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,22 +24,22 @@
     <varlistentry>
      <term><parameter>dirname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O diretório a ser adicionado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits consistindo de
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        O comportamento dessas constantes é descrito na página de
        <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,9 +48,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: leonardolara Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
 <refentry xml:id="ziparchive.addfile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::addFile</refname>
@@ -15,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona um arquivo a um arquivo ZIP a partir de um caminho fornecido.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -27,42 +27,42 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O caminho para o arquivo a ser adicionado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>entryname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se fornecido e não vazio, este é o nome local dentro do arquivo ZIP que substituirá o <parameter>filepath</parameter>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para cópia parcial, posição de início.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para cópia parcial, comprimento a ser copiado,
        se <constant>ZipArchive::LENGTH_TO_END</constant> (0) o tamanho do arquivo é usado,
        se <constant>ZipArchive::LENGTH_UNCHECKED</constant> o arquivo inteiro é usado
        (a partir de <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits consistindo de
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -71,7 +71,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        O comportamento dessas constantes é descrito na página de
        <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -80,9 +80,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -123,12 +123,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo abre um arquivo ZIP
      <filename>test.zip</filename> e adiciona
      o arquivo <filename>/caminho/para/index.txt</filename>.
      como <filename>newname.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Abrir e adicionar</title>
      <programlisting role="php">
@@ -151,14 +151,14 @@ if ($zip->open('test.zip') === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Quando um arquivo é configurado para ser adicionado ao arquivo, o PHP irá bloquear o arquivo. O
     bloqueio é liberado apenas depois que o objeto <classname>ZipArchive</classname>
     foi fechado, seja via <methodname>ZipArchive::close</methodname> ou
     o objeto <classname>ZipArchive</classname> sendo destruído. Isso pode
     impedir que você consiga excluir o arquivo sendo adicionado até depois que o
     bloqueio tenha sido liberado.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.addfromstring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::addFromString</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona um arquivo a um arquivo ZIP usando seu conteúdo.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -25,24 +25,24 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O nome da entrada a ser criada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>content</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O conteúdo a ser usado para criar a entrada. É usado em um modo binário
        seguro.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits consistindo de
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -50,7 +50,7 @@
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        O comportamento dessas constantes é descrito na página de
        <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -58,9 +58,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.addglob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZipArchive::addGlob</refname>
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona arquivos de um diretório que correspondem ao <parameter>pattern</parameter> glob.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
 
@@ -26,17 +26,17 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Um padrão <function>glob</function> contra o qual os arquivos serão correspondidos.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>flags</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma máscara de bits de opções <literal>glob()</literal>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,37 +46,37 @@
       Um array associativo de opções. As opções disponíveis são:
       <itemizedlist>
        <listitem>
-        <para>
+        <simpara>
          <literal>"add_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Prefixo a ser adicionado ao traduzir para o caminho local do arquivo dentro
          do arquivo. Isso é aplicado após quaisquer operações de remoção definidas pelas
          opções <literal>"remove_path"</literal> ou
          <literal>"remove_all_path"</literal>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Prefixo a ser removido dos caminhos de arquivo correspondentes antes de serem adicionados ao arquivo.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_all_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          &true; para usar apenas o nome do arquivo e adicionar à raiz do arquivo.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Máscara de bits consistindo em
          <constant>ZipArchive::FL_OVERWRITE</constant>,
          <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -85,41 +85,41 @@
          <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
          O comportamento dessas constantes é descrito na página de
          <link linkend="zip.constants">constantes ZIP</link>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Método de compressão, uma das constantes
          <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>,
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Nível de compressão.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Método de criptografia, um dos constantes
          <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_password"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Senha usada para criptografia.
-        </para>
+        </simpara>
        </listitem>
       </itemizedlist>
      </para>
@@ -130,9 +130,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Um <type>array</type> de arquivos adicionados em caso de sucesso &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -177,9 +177,9 @@
   &reftitle.examples;
   <example xml:id="ziparchive.addglob.example.basic">
    <title>Exemplo de <methodname>ZipArchive::addGlob</methodname></title>
-   <para>
+   <simpara>
     Adiciona todos os scripts php e arquivos de texto do diretório de trabalho atual
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/addpattern.xml
+++ b/reference/zip/ziparchive/addpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.addpattern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZipArchive::addPattern</refname>
@@ -14,10 +14,10 @@
    <methodparam choice="opt"><type>string</type><parameter>path</parameter><initializer>"."</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adiciona arquivos de um diretório que correspondem à expressão regular <parameter>pattern</parameter>.
    A operação não é recursiva. O padrão será correspondido apenas ao nome do arquivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,25 +26,25 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Uma expressão regular <link linkend="book.pcre">PCRE</link> com a qual os arquivos serão correspondidos.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>path</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       O diretório que será examinado. O padrão é o diretório de trabalho atual.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Um array associativo de opções aceitas por <methodname>ZipArchive::addGlob</methodname>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -52,18 +52,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Um <type>array</type> de arquivos adicionados em caso de sucesso &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="ziparchive.addpattern.example.basic">
    <title>Exemplo de <methodname>ZipArchive::addPattern</methodname></title>
-   <para>
+   <simpara>
     Adiciona todos os scripts php e arquivos de texto do diretório atual
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/clearerror.xml
+++ b/reference/zip/ziparchive/clearerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.clearerror" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::clearError</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>void</type><methodname>ZipArchive::clearError</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Limpa a mensagem de erro de status, mensagens do sistema e/ou do zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::close</refname>
@@ -11,16 +11,16 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::close</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Fecha o arquivo aberto ou criado e salva as alterações. Este método é
    chamado automaticamente no final do script.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Se o arquivo não contiver arquivos, o arquivo é completamente removido por padrão
    (nenhum arquivo vazio é gravado) de acordo com o valor do
    <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
    global flag.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/count.xml
+++ b/reference/zip/ziparchive/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::count</refname>
@@ -21,9 +21,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o número de arquivos no arquivo.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/zip/ziparchive/deleteindex.xml
+++ b/reference/zip/ziparchive/deleteindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.deleteindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::deleteIndex</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exclui uma entrada no arquivo usando seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada a ser excluída.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/deletename.xml
+++ b/reference/zip/ziparchive/deletename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.deletename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::deleteName</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exclui uma entrada no arquivo usando seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada a ser excluída.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b61758269e3619194047cb5d6d4962734372c0a6 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.extractto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::extractTo</refname>
@@ -12,23 +12,23 @@
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>files</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Extrai o arquivo completo ou os arquivos fornecidos para o destino
    especificado.
-  </para>
+  </simpara>
   <warning>
-   <para>
+   <simpara>
     As permissões padrão para os arquivos e diretórios extraídos
     dão o acesso mais amplo possível. Isso pode ser restrito
     configurando o umask atual, que pode ser alterado usando
     <function>umask</function>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Por motivos de segurança, as permissões originais não são restauradas.
     Para um exemplo de como restaurá-las, consulte o
     <link linkend="ziparchive.getexternalattributesindex.examples.perms">exemplo de código</link>
     na página <methodname>ZipArchive::getExternalAttributesIndex</methodname>.
-   </para>
+   </simpara>
   </warning>
  </refsect1>
  <refsect1 role="parameters">
@@ -38,18 +38,18 @@
     <varlistentry>
      <term><parameter>pathto</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Local para onde extrair os arquivos.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>files</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        As entradas para extrair. Aceita um único nome de entrada ou
        um array de nomes.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -57,9 +57,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getarchivecomment.xml
+++ b/reference/zip/ziparchive/getarchivecomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getarchivecomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getArchiveComment</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>ZipArchive::getArchiveComment</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o comentário do arquivo Zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,10 +23,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se a opção estiver definida como <constant>ZipArchive::FL_UNCHANGED</constant>, o comentário original e não alterado
        é retornado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o comentário do arquivo Zip&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bb6e8c9fb1f4cc4c83a67a2c3e031ac3c8c28ccc Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <refentry xml:id="ziparchive.getarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getArchiveFlag</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o valor de uma opção global do arquivo Zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,24 +28,24 @@
        A opção global a ser recuperada, entre as constantes <literal>AFL_*</literal>:
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -54,10 +54,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se o parâmetro <parameter>flags</parameter> estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>,
        a opção original inalterada é retornada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -66,9 +66,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna 1 se a opção estiver definida para o arquivo, 0 se não estiver, e -1 se ocorrer um erro.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getcommentindex.xml
+++ b/reference/zip/ziparchive/getcommentindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getcommentindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getCommentIndex</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o comentário de uma entrada usando o índice da entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,18 +23,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, o comentário original e não alterado é
        retornado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o comentário em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getcommentname.xml
+++ b/reference/zip/ziparchive/getcommentname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getcommentname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getCommentName</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o comentário de uma entrada usando o nome da entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,18 +23,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, o comentário original
        e não alterado é retornado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o comentário em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b61758269e3619194047cb5d6d4962734372c0a6 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getExternalAttributesIndex</refname>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera os atributos externos de uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,34 +25,34 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Em caso de sucesso, recebe o código do sistema operacional definido por uma das constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Em caso de sucesso, recebe os atributos externos. O valor depende do sistema operacional.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, os atributos originais inalterados
        são retornados.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,17 +60,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo extrai todas as entradas de um arquivo ZIP
      <filename>test.zip</filename> e
      define os direitos Unix a partir dos atributos externos.
-    </para>
+    </simpara>
     <example xml:id="ziparchive.getexternalattributesindex.examples.perms">
      <title>Extrair todas as entradas com direitos Unix</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/getexternalattributesname.xml
+++ b/reference/zip/ziparchive/getexternalattributesname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getexternalattributesname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getExternalAttributesName</refname>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera os atributos externos de uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,34 +25,34 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Em caso de sucesso, recebe o código do sistema operacional definido por uma das constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Em caso de sucesso, recebe os atributos externos. O valor depende do sistema operacional.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, os atributos originais inalterados
        são retornados.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,9 +60,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getfromindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getFromIndex</refname>
@@ -13,9 +13,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o conteúdo da entrada usando seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O comprimento a ser lido da entrada. Se <literal>0</literal>, então a
        entrada inteira é lida.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -46,14 +46,14 @@
        ser ORed a ele.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -64,9 +64,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o conteúdo da entrada em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getfromname.xml
+++ b/reference/zip/ziparchive/getfromname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getfromname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getFromName</refname>
@@ -13,9 +13,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o conteúdo da entrada usando seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O comprimento a ser lido da entrada. Se <literal>0</literal>, então a
        entrada inteira é lida.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -46,19 +46,19 @@
        ser ORed.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -69,9 +69,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o conteúdo da entrada em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getnameindex.xml
+++ b/reference/zip/ziparchive/getnameindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getnameindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getNameIndex</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna o nome de uma entrada usando seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,18 +23,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, o nome original inalterado
        é retornado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o nome em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0545e305cf06937b14b3f0694d6e716c9881ffd7 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getstatusstring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getStatusString</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>string</type><methodname>ZipArchive::getStatusString</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retorna a mensagem de erro de status, mensagens do sistema e/ou zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna uma <type>string</type> com a mensagem de status.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/getstream.xml
+++ b/reference/zip/ziparchive/getstream.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getstream" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getStream</refname>
@@ -11,10 +11,10 @@
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>ZipArchive::getStream</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtém um manipulador de arquivo para a entrada definida pelo seu nome. Por enquanto, suporta apenas
    operações de leitura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O nome da entrada a ser usado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um ponteiro de arquivo (recurso) em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamindex.xml
+++ b/reference/zip/ziparchive/getstreamindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getstreamindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getStreamIndex</refname>
@@ -12,10 +12,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtenha um manipulador de arquivo para a entrada definida pelo seu índice. Por enquanto, suporta apenas
    operações de leitura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, o fluxo original inalterado
        é retornado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um ponteiro de arquivo (recurso) em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamname.xml
+++ b/reference/zip/ziparchive/getstreamname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.getstreamname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getStreamName</refname>
@@ -12,10 +12,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtém um manipulador de arquivo para a entrada definida pelo seu nome. Por enquanto, suporta apenas
    operações de leitura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O nome da entrada a ser usado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se flags estiver definido como <constant>ZipArchive::FL_UNCHANGED</constant>, o fluxo original inalterado
        é retornado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um ponteiro de arquivo (recurso) em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <refentry xml:id="ziparchive.iscompressionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::isCompressionMethodSupported</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Verifica se um método de compressão é suportado pelo libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O método de compressão, uma das constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se &true;, verifica a compressão; caso contrário, verifica a descompressão.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,17 +45,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função está disponível apenas se compilada contra libzip ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <refentry xml:id="ziparchive.isencryptionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::isEncryptionMethodSupported</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Verifica se um método de criptografia é suportado pelo libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O método de criptografia, uma das constantes
        <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se &true;, verifica a criptografia; caso contrário, verifica a descriptografia.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,17 +45,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função está disponível apenas se compilada com libzip ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/locatename.xml
+++ b/reference/zip/ziparchive/locatename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.locatename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::locateName</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Localiza uma entrada usando seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O nome da entrada a ser procurada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -36,14 +36,14 @@
        ou 0 para nenhum deles.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -54,9 +54,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna o índice da entrada em caso de sucesso&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.open" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZipArchive::open</refname>
@@ -12,12 +12,12 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Abre um arquivo compactado ZIP novo ou existente para leitura, escrita ou modificação.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Desde o libzip 1.6.0, um arquivo vazio não é mais um arquivo compactado válido.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,9 +26,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O nome do arquivo compactado ZIP a ser aberto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -38,29 +38,29 @@
        O modo a ser usado para abrir o arquivo compactado.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::OVERWRITE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CREATE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::EXCL</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CHECKCONS</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>

--- a/reference/zip/ziparchive/registercancelcallback.xml
+++ b/reference/zip/ziparchive/registercancelcallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.registercancelcallback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::registerCancelCallback</refname>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::registerCancelCallback</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Registra uma função de <parameter>callback</parameter> para permitir o cancelamento durante o fechamento do arquivo compactado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Se esta função retornar 0, a operação continuará; qualquer outro valor resultará no cancelamento.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -35,18 +35,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo cria um arquivo compactado ZIP
      <filename>php.zip</filename> e cancela
      a operação em algumas condições de execução.
-    </para>
+    </simpara>
     <example>
      <title>Arquivar um arquivo</title>
      <programlisting role="php">
@@ -68,9 +68,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função só está disponível se for construída com libzip ≥ 1.6.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/registerprogresscallback.xml
+++ b/reference/zip/ziparchive/registerprogresscallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.registerprogresscallback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::registerProgressCallback</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>float</type><parameter>rate</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Registra uma função de <parameter>callback</parameter> para fornecer atualizações durante o fechamento do arquivo compactado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +25,17 @@
     <varlistentry>
      <term><parameter>rate</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Alteração entre cada chamada do retorno de chamada (de 0.0 a 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Esta função receberá o <parameter>state</parameter> atual como um <type>float</type> (de 0.0 a 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,18 +44,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo cria um arquivo compactado ZIP
      <filename>php.zip</filename> e mostra
      a progressão.
-    </para>
+    </simpara>
     <example>
      <title>Archive a file</title>
      <programlisting role="php">
@@ -76,9 +76,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função só está disponível se for construída com libzip ≥ 1.3.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/renameindex.xml
+++ b/reference/zip/ziparchive/renameindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.renameindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::renameIndex</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renomeia uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada a ser renomeada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Novo nome.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/renamename.xml
+++ b/reference/zip/ziparchive/renamename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.renamename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::renameName</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renomeia uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada a ser renomeada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Novo nome.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.replacefile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::replaceFile</refname>
@@ -15,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Substitui um arquivo no arquivo ZIP por um caminho fornecido.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -27,42 +27,42 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O caminho para o arquivo a ser adicionado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O índice do arquivo a ser substituído, seu nome não é alterado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para cópia parcial, posição inicial.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para cópia parcial, comprimento a ser copiado,
        se <constant>ZipArchive::LENGTH_TO_END</constant> (0), o tamanho do arquivo é usado,
        se <constant>ZipArchive::LENGTH_UNCHECKED</constant>, o arquivo inteiro é usado
        (a partir de <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits consistindo em
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
@@ -70,7 +70,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        O comportamento dessas constantes é descrito na página
        <link linkend="zip.constants">constantes do ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -79,9 +79,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -116,11 +116,11 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo abre um arquivo ZIP
      <filename>test.zip</filename> e substitui a entrada do índice 1
      pelo arquivo <filename>/path/to/index.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Abrir e substituir</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/setarchivecomment.xml
+++ b/reference/zip/ziparchive/setarchivecomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setarchivecomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setArchiveComment</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setArchiveComment</methodname>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o comentário de um arquivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O conteúdo do comentário.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setArchiveFlag</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define uma opção global de um arquivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -27,14 +27,14 @@
        A opção global a ser alterada, entre as constantes <literal>AFL_*</literal>.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -43,9 +43,9 @@
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O novo valor da opção.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/setcommentindex.xml
+++ b/reference/zip/ziparchive/setcommentindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setcommentindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setCommentIndex</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o comentário de uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O conteúdo do comentário.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcommentname.xml
+++ b/reference/zip/ziparchive/setcommentname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setcommentname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setCommentName</refname>
@@ -12,9 +12,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o comentário de uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,17 +23,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O conteúdo do comentário.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionindex.xml
+++ b/reference/zip/ziparchive/setcompressionindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <refentry xml:id="ziparchive.setcompressionindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setCompressionIndex</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o método de compressão de uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,26 +24,26 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O método de compressão, uma das constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de compressão.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionname.xml
+++ b/reference/zip/ziparchive/setcompressionname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto,leonardolara -->
 <refentry xml:id="ziparchive.setcompressionname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setCompressionName</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o método de compressão de uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,26 +24,26 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O método de compressão, uma das constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nível de compressão.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setencryptionindex.xml
+++ b/reference/zip/ziparchive/setencryptionindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
 <refentry xml:id="ziparchive.setencryptionindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setEncryptionIndex</refname>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o método de criptografia de uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,25 +26,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O método de criptografia definido por uma das constantes ZipArchive::EM_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Senha opcional, usada por padrão quando ausente.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -53,9 +53,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -83,9 +83,9 @@
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função está disponível apenas se construída contra libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setencryptionname.xml
+++ b/reference/zip/ziparchive/setencryptionname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
 <refentry xml:id="ziparchive.setencryptionname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setEncryptionName</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o método de criptografia de uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,25 +24,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O método de criptografia definido por uma das constantes ZipArchive::EM_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Senha opcional, usada por padrão quando ausente.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,9 +50,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -79,12 +79,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo cria um arquivo ZIP
      <filename>test.zip</filename> e adiciona
      o arquivo <filename>test.txt</filename>
      criptografado usando o método AES 256.
-    </para>
+    </simpara>
     <example>
      <title>Arquivar e criptografar um arquivo</title>
      <programlisting role="php">
@@ -109,9 +109,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função está disponível apenas se construída contra libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setexternalattributesindex.xml
+++ b/reference/zip/ziparchive/setexternalattributesindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setExternalAttributesIndex</refname>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define os atributos externos de uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,33 +25,33 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O código do sistema operacional definido por uma das constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Os atributos externos. O valor depende do sistema operacional.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Opções opcionais. Atualmente não utilizado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,9 +59,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setexternalattributesname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setExternalAttributesName</refname>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define os atributos externos de uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,33 +25,33 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O código do sistema operacional definido por uma das constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Os atributos externos. O valor depende do sistema operacional.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Opções opcionais. Atualmente não utilizado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,18 +59,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo abre um arquivo ZIP
      <filename>test.zip</filename> e adiciona
      o arquivo <filename>test.txt</filename>
      com seus direitos Unix como atributos externos.
-    </para>
+    </simpara>
     <example>
      <title>Arquivar um arquivo, com seus direitos Unix</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/setmtimeindex.xml
+++ b/reference/zip/ziparchive/setmtimeindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setmtimeindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setMtimeIndex</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o tempo de modificação de uma entrada definida pelo seu índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,25 +24,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O tempo de modificação (timestamp Unix) do arquivo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Opções opcionais, não utilizados por enquanto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,19 +50,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo cria um arquivo ZIP
      <filename>test.zip</filename> e adiciona
      o arquivo <filename>test.txt</filename>
      com sua data de modificação.
-    </para>
+    </simpara>
     <example>
      <title>Arquivar um arquivo</title>
      <programlisting role="php">
@@ -86,9 +86,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função só está disponível se compilada com libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setmtimename.xml
+++ b/reference/zip/ziparchive/setmtimename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.setmtimename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::setMtimeName</refname>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define o tempo de modificação de uma entrada definida pelo seu nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,25 +24,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        O tempo de modificação (timestamp Unix) do arquivo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Opções opcionais, não utilizados por enquanto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -50,19 +50,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este exemplo cria um arquivo ZIP
      <filename>test.zip</filename> e adiciona
      o arquivo <filename>test.txt</filename>
      com sua data de modificação.
-    </para>
+    </simpara>
     <example>
      <title>Arquivar um arquivo</title>
      <programlisting role="php">
@@ -86,9 +86,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta função só está disponível se compilada com libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setpassword.xml
+++ b/reference/zip/ziparchive/setpassword.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto, leonardolara -->
 <refentry xml:id="ziparchive.setpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZipArchive::setPassword</refname>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setPassword</methodname>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define a senha para o arquivo ZIP ativo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
    <varlistentry>
     <term><parameter>password</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A senha a ser usada para o arquivo.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -33,22 +33,22 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     A partir do PHP 7.2.0 e libzip 1.2.0, a senha é usada para descompactar o arquivo ZIP
     e também é a senha padrão para <methodname>ZipArchive::setEncryptionName</methodname>
     e <methodname>ZipArchive::setEncryptionIndex</methodname>.
     Anteriormente, esta função apenas definia a senha a ser usada para descompactar o arquivo ZIP;
     ela não transformava um <classname>ZipArchive</classname> sem senha
     em um <classname>ZipArchive</classname> com senha.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/statindex.xml
+++ b/reference/zip/ziparchive/statindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.statindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::statIndex</refname>
@@ -12,10 +12,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     A função obtém informações sobre a entrada definida pelo seu
     índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,19 +24,19 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <constant>ZipArchive::FL_UNCHANGED</constant> pode ser ORed para solicitar
        informações sobre o arquivo original no arquivo,
        ignorando quaisquer alterações feitas.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array contendo os detalhes da entrada&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/statname.xml
+++ b/reference/zip/ziparchive/statname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.statname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::statName</refname>
@@ -12,10 +12,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     A função obtém informações sobre a entrada definida pelo seu
     nome.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -39,19 +39,19 @@
        ignorando quaisquer alterações feitas.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -62,9 +62,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retorna um array contendo os detalhes da entrada &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/unchangeall.xml
+++ b/reference/zip/ziparchive/unchangeall.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.unchangeall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::unchangeAll</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeAll</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Desfaz todas as alterações feitas no arquivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -23,9 +23,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangearchive.xml
+++ b/reference/zip/ziparchive/unchangearchive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.unchangearchive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::unchangeArchive</refname>
@@ -11,10 +11,10 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeArchive</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reverte todas as alterações globais feitas no arquivo. Por enquanto, isso
    só reverte alterações no comentário do arquivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangeindex.xml
+++ b/reference/zip/ziparchive/unchangeindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.unchangeindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::unchangeIndex</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reverter todas as alterações feitas a uma entrada no índice fornecido.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangename.xml
+++ b/reference/zip/ziparchive/unchangename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="ziparchive.unchangename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::unchangeName</refname>
@@ -11,9 +11,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reverte todas as alterações feitas a uma entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -22,9 +22,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nome da entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -32,9 +32,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Sincroniza com [php/doc-en#5536](https://github.com/php/doc-en/pull/5536) (commit `963af75faf`), convertendo `<para>` para `<simpara>` em toda a extensão `zip` onde o conteúdo é puramente inline (sem blocos aninhados como `<itemizedlist>`, `<programlisting>`, `<table>`, etc).

68 arquivos atualizados. O texto traduzido em português permanece inalterado, apenas as tags de wrapping foram convertidas.