### PR TITLE
Sync EN: appendices/aliases.xml (IMAP/PostgreSQL aliases)

### DIFF
--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6d46a5549bcb66444ce7a3b34301420ba7552bc8 Maintainer: ae Status: ready --><!-- CREDITS: felipe,rarruda,ae,pasf,fibbarth,adiel,lhsazevedo -->
+<!-- EN-Revision: e2274fb291cb76151378a209e8c92612d1ba5340 Maintainer: ae Status: ready --><!-- CREDITS: felipe,rarruda,ae,pasf,fibbarth,adiel,lhsazevedo -->
 <appendix xml:id="aliases" xmlns="http://docbook.org/ns/docbook">
  <title>Lista de funções sinônimas</title>
  <para>
@@ -129,16 +129,6 @@
      <row>
       <entry>imap_fetchtext</entry>
       <entry><function>imap_body</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getmailboxes</entry>
-      <entry><function>imap_list_full</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getsubscribed</entry>
-      <entry><function>imap_lsub_full</function></entry>
       <entry><link linkend="ref.imap">IMAP</link></entry>
      </row>
      <row>
@@ -589,6 +579,11 @@
      <row>
       <entry>pg_setclientencoding</entry>
       <entry><function>pg_set_client_encoding</function></entry>
+      <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
+     </row>
+     <row>
+      <entry>pg_exec</entry>
+      <entry><function>pg_query</function></entry>
       <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
      </row>
      <row>


### PR DESCRIPTION
- Remove `imap_getmailboxes` e `imap_getsubscribed` da tabela de aliases (não são mais aliases).
- Adiciona `pg_exec` como alias de `pg_query`.

Sincroniza com [php/doc-en@e2274fb291](https://github.com/php/doc-en/commit/e2274fb291cb76151378a209e8c92612d1ba5340).