### PR TITLE
Sync EN: language/predefined/iteratoraggregate.xml (exemplo simplificado)

### DIFF
--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 20b4b383127faaf37495d7746885f2bb674a1a33 Maintainer: leonardolara Status: ready --><!-- CREDITS: royopa,ae,leonardolara -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: leonardolara Status: ready --><!-- CREDITS: royopa,ae,leonardolara -->
 <reference xml:id="class.iteratoraggregate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>A interface IteratorAggregate</title>
@@ -49,19 +49,13 @@
 
 class myData implements IteratorAggregate
 {
-    public $property1 = "Public property one";
-    public $property2 = "Public property two";
-    public $property3 = "Public property three";
-    public $property4 = "";
-
-    public function __construct()
-    {
-        $this->property4 = "last property";
-    }
-
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this);
+        return new ArrayIterator([
+            "key one" => "item one",
+            "key two" => "item two",
+            "key three" => "item three"
+        ]);
     }
 }
 
@@ -71,24 +65,19 @@ foreach ($obj as $key => $value) {
     var_dump($key, $value);
     echo "\n";
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-string(9) "property1"
-string(19) "Public property one"
+string(7) "key one"
+string(8) "item one"
 
-string(9) "property2"
-string(19) "Public property two"
+string(7) "key two"
+string(8) "item two"
 
-string(9) "property3"
-string(21) "Public property three"
-
-string(9) "property4"
-string(13) "last property"
+string(9) "key three"
+string(10) "item three"
 
 ]]>
     </screen>


### PR DESCRIPTION
Atualiza o exemplo de `IteratorAggregate` para usar uma forma mais simples e idiomática (`ArrayIterator` com um array literal em vez de `\$this`), conforme [php/doc-en@4b06b2d5c3](https://github.com/php/doc-en/commit/4b06b2d5c3a28a13504972df0f0be6deffabb4c5). A saída esperada foi atualizada de acordo.