### PR TITLE
Sync EN: language/attributes.xml (WASM annotations + ajustes de exemplo)

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -297,7 +297,7 @@ dumpMyAttributeData(new ReflectionClass(Thing::class));
   <example>
    <title>Classe de Atributo Simples</title>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -322,7 +322,7 @@ class MyAttribute
   <example>
    <title>Usando a especificação de destino para restringir onde os atributos podem ser usados</title>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -365,7 +365,7 @@ class MyAttribute
   <example>
    <title>Usando IS_REPEATABLE para permitir o atributo em uma declaração várias vezes</title>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 

--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0f14761ba340c6e49797706ac3f0cf1147d97253 Maintainer: leonardolara Status: ready --><!-- CREDITS: marcosmarcolin, adiel, leonardolara -->
-<chapter xml:id="language.attributes" xmlns="http://docbook.org/ns/docbook">
+<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: leonardolara Status: ready --><!-- CREDITS: marcosmarcolin, adiel, leonardolara -->
+<chapter xml:id="language.attributes" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Atributos</title>
  <sect1 xml:id="language.attributes.overview">
   <title>Visão geral dos atributos</title>
@@ -30,7 +30,7 @@
 
   <example>
    <title>Implementando métodos opcionais de uma interface com Atributos</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 interface ActionHandler
@@ -121,7 +121,7 @@ executeAction($copyAction);
   <example>
    <title>Sintaxe de Atributo</title>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // a.php
@@ -222,7 +222,11 @@ function dumpAttributeData($reflection) {
 }
 
 dumpAttributeData(new ReflectionClass(Thing::class));
-/*
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
 string(11) "MyAttribute"
 array(1) {
   ["value"]=>
@@ -232,10 +236,8 @@ object(MyAttribute)#3 (1) {
   ["value"]=>
   int(1234)
 }
-*/
-
 ]]>
-   </programlisting>
+   </screen>
   </example>
 
   <para>
@@ -250,6 +252,21 @@ object(MyAttribute)#3 (1) {
    <programlisting role="php">
 <![CDATA[
 <?php
+#[Attribute]
+class MyAttribute
+{
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}
+
+#[MyAttribute(value: 1234)]
+class Thing
+{
+}
 
 function dumpMyAttributeData($reflection) {
     $attributes = $reflection->getAttributes(MyAttribute::class);


### PR DESCRIPTION
- Adiciona `annotations="interactive"` ao `<chapter>` e `annotations="non-interactive"` aos `<programlisting>` que não devem ser interativos.
- Move o output do exemplo "Lendo Atributos Usando a API Reflection" do comentário de bloco para um `<screen>` dedicado, conforme o doc-en.
- Adiciona a definição de `MyAttribute`/`Thing` ao exemplo "Lendo Atributos Específicos Usando a API Reflection" para que ele seja autossuficiente.

Sincroniza com [php/doc-en@50e6f42c83](https://github.com/php/doc-en/commit/50e6f42c83ac3f6de5e1086b649e06adedd562ff).