### PR TITLE
[Sync EN] Add PHP 8.4.0 changelog entries for SPL, Standard and Filesystem pages

### DIFF
--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1cacac75c04a115ee9b464015ce8e7782bd1517 Maintainer: leonardolara Status: ready --><!-- CREDITS: rarruda, ae, felipe, leonardolara -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: leonardolara Status: ready --><!-- CREDITS: rarruda, ae, felipe, leonardolara -->
 <refentry xml:id="function.tempnam" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>tempnam</refname>
@@ -70,6 +70,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       O nome dos arquivos criados por <function>tempnam</function> agora é
+       13 bytes mais longo. O comprimento total ainda depende
+       da plataforma.
+      </entry>
+     </row>
      <row>
       <entry>7.1.0</entry>
       <entry>

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <reference xml:id="class.splfixedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>A classe SplFixedArray</title>
  <titleabbrev>SplFixedArray</titleabbrev>
@@ -67,6 +67,17 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Acessos fora dos limites em <classname>SplFixedArray</classname> agora lançam
+        exceções do tipo <exceptionname>OutOfBoundsException</exceptionname>
+        em vez de <exceptionname>RuntimeException</exceptionname>.
+        Como <exceptionname>OutOfBoundsException</exceptionname> é uma classe
+        filha de <exceptionname>RuntimeException</exceptionname>, nenhuma mudança
+        de comportamento é exibida ao tentar capturar essas exceções.
+       </entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2a5223230bf6177c225003ca30c63f48ef266cc0 Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: leonardolara Status: ready --><!-- CREDITS: felipe,leonardolara -->
 <refentry xml:id="function.debug-zval-dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>debug_zval_dump</refname>
@@ -47,6 +47,30 @@
    &return.void;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>debug_zval_dump</function> agora indica se um
+       array é compactado (packed).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Adiciona as entradas de changelog do PHP 8.4.0 para tempnam, SplFixedArray e debug_zval_dump. Atualiza os hashes EN-Revision.