### PR TITLE
[Sync EN] intl/mbstring: sync idn_to_ascii, idn_to_utf8, mb_strcut, mb_substr

### DIFF
--- a/reference/intl/idn/idn-to-ascii.xml
+++ b/reference/intl/idn/idn-to-ascii.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e908bfda98eb9fe16fb2c1b5773f312e5c684ee3 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.idn-to-ascii" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>idn_to_ascii</refname>
@@ -90,6 +90,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Agora lança um <exceptionname>ValueError</exceptionname>
+        se o parâmetro <parameter>domain</parameter> for vazio.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Agora lança um <exceptionname>ValueError</exceptionname>
+        se o parâmetro <parameter>variant</parameter> não for
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/intl/idn/idn-to-utf8.xml
+++ b/reference/intl/idn/idn-to-utf8.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6aee4a5004f7d532f24c06ea2ab2ac0b91b8664 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.idn-to-utf8" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>idn_to_utf8</refname>
@@ -90,6 +90,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Agora lança um <exceptionname>ValueError</exceptionname>
+        se o parâmetro <parameter>domain</parameter> for vazio.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Agora lança um <exceptionname>ValueError</exceptionname>
+        se o parâmetro <parameter>variant</parameter> não for
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="function.mb-strcut" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_strcut</refname>
@@ -107,6 +107,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       O comportamento agora é mais consistente em strings <literal>UTF-8</literal> e <literal>UTF-16</literal> inválidas.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="function.mb-substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_substr</refname>
@@ -97,6 +97,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Em strings inválidas (aquelas com erros de codificação),
+       os índices de caractere agora são interpretados da mesma maneira que a maioria
+       das outras funções mbstring. Isso significa que os índices de caractere retornados
+       por <function>mb_strpos</function> podem ser passados diretamente.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Sincroniza o changelog do PHP 8.4 para idn_to_ascii, idn_to_utf8, mb_strcut e mb_substr. Apenas adições de changelog, espelhando o EN.