### PR TITLE
[Sync EN] Fix non-runnable code examples (3/3)

### DIFF
--- a/reference/xlswriter/xlsx-kernel/auto-filter.xml
+++ b/reference/xlswriter/xlsx-kernel/auto-filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="vtiful-kernel-excel.autoFilter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -52,7 +52,7 @@ $config = [
 
 $fileObject  = new \Vtiful\Kernel\Excel($config);
 
-$file = $excel->fileName('test.xlsx')
+$file = $fileObject->fileName('test.xlsx')
         ->header(['name', 'age'])
         ->data($data)
         ->autoFilter('A1:B11')  // filtro automático

--- a/reference/xlswriter/xlsx-kernel/const-memory.xml
+++ b/reference/xlswriter/xlsx-kernel/const-memory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="vtiful-kernel-excel.constMemory" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -61,7 +61,7 @@ $config = [
 
 $fileObject = new \Vtiful\Kernel\Excel($config);
 
-$file = $instance->constMemory('tutorial.xlsx', 'sheet');
+$file = $fileObject->constMemory('tutorial.xlsx', 'sheet');
 ?>
 ]]>
    </programlisting>

--- a/reference/xlswriter/xlsx-kernel/file-name.xml
+++ b/reference/xlswriter/xlsx-kernel/file-name.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="vtiful-kernel-excel.filename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -61,7 +61,7 @@ $config = [
 
 $fileObject = new \Vtiful\Kernel\Excel($config);
 
-$file = $instance->fileName('tutorial.xlsx', 'sheet');
+$file = $fileObject->fileName('tutorial.xlsx', 'sheet');
 ?>
 ]]>
    </programlisting>

--- a/reference/xlswriter/xlsx-kernel/insert-text.xml
+++ b/reference/xlswriter/xlsx-kernel/insert-text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 19e8122137a1d42ed60f17fe2c0c2b69b0b2d16b Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: leonardolara Status: ready --><!-- CREDITS: leonardolara -->
 
 <refentry xml:id="vtiful-kernel-excel.insertText" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -87,7 +87,7 @@ for ($index = 0; $index < 10; $index++) {
     $file->insertText($index+1, 1, 10000, '#,##0');
 }
 
-$textFile->output();
+$file->output();
 ]]>
    </programlisting>
   </example>

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 338bf692d6d24357c4a3b36b098131bc30372378 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: leonardolara Status: ready -->
 
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -66,7 +66,7 @@
       <title>Garantindo que um item é armazenado</title>
       <programlisting role="php">
        <![CDATA[
-       while(!$yac->set("chave", "valor"));
+       while(!$yac->set("key", "value"));
        ]]>
       </programlisting>
      </example>

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -66,7 +66,7 @@
       <title>Garantindo que um item é armazenado</title>
       <programlisting role="php">
        <![CDATA[
-       while(!$yac->set("key", "value"));
+       while(!$yac->set("chave", "valor"));
        ]]>
       </programlisting>
      </example>

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c9389e4a0e96801fd14d91336ff3f12e45929a73 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: leonardolara Status: ready -->
 
 <refentry xml:id="yaf-route-rewrite.assemble" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -54,7 +54,7 @@
    <title>Exemplo de <function>Yaf_Route_Rewrite::assemble</function></title>
    <programlisting role="php">
 <![CDATA[
-router = new Yaf_Router();
+$router = new Yaf_Router();
 
 $route  = new Yaf_Route_Rewrite(
                 "/product/:name/:id/*",


### PR DESCRIPTION
Corrige exemplos de código não executáveis nas extensões xlswriter, yac e yaf, alinhando com a versão em inglês.

Refs: php/doc-en@8e2cfbdce0cd028a6521c6e073f148e0f7efac7c