### PR TITLE
[Sync EN] gd: fix parameter descriptions and examples (imagedashedline, imagerectangle, imagesetbrush, imagesetthickness)

### DIFF
--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagedashedline</refname>
@@ -19,7 +19,7 @@
   <para>
    Esta função foi descontinuada. Use uma combinação de
    <function>imagesetstyle</function> e <function>imageline</function>
-   em seu lugar.
+   em seu lugar. 0, 0 é o canto superior esquerdo da imagem.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -31,7 +31,7 @@
      <term><parameter>x1</parameter></term>
      <listitem>
       <para>
-       Coordenada x do ponto inicial.
+       Coordenada x do primeiro ponto.
       </para>
      </listitem>
     </varlistentry>
@@ -39,7 +39,7 @@
      <term><parameter>y1</parameter></term>
      <listitem>
       <para>
-       Coordenada y do ponto inicial. 0, 0 é o canto superior esquerdo da imagem.
+       Coordenada y do primeiro ponto.
       </para>
      </listitem>
     </varlistentry>
@@ -47,7 +47,7 @@
      <term><parameter>x2</parameter></term>
      <listitem>
       <para>
-       Coordenada x do ponto final.
+       Coordenada x do segundo ponto.
       </para>
      </listitem>
     </varlistentry>
@@ -55,7 +55,7 @@
      <term><parameter>y2</parameter></term>
      <listitem>
       <para>
-       Coordenada y do ponto final.
+       Coordenada y do segundo ponto.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagerectangle</refname>
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    <function>imagerectangle</function> cria um retângulo
-   nas coordenadas especificadas.
+   nas coordenadas especificadas. 0, 0 é o canto superior esquerdo da imagem.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -39,7 +39,6 @@
      <listitem>
       <para>
        Coordenada y do canto superior esquerdo.
-       0, 0 é o canto superior esquerdo da imagem.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.imagesetbrush" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagesetbrush</refname>
@@ -84,6 +84,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Carrega uma mini logomarca do PHP
 $php = imagecreatefrompng('./php.png');
 
@@ -92,7 +93,7 @@ $im = imagecreatetruecolor(100, 100);
 
 // Preenche o fundo com a cor branca
 $white = imagecolorallocate($im, 255, 255, 255);
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 99, 99, $white);
 
 // Define o pincel
 imagesetbrush($im, $php);

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: leonardolara Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: leonardolara Status: ready -->
 <refentry xml:id="function.imagesetthickness" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagesetthickness</refname>
@@ -66,13 +66,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Cria uma imagem 200x100
 $im = imagecreatetruecolor(200, 100);
 $white = imagecolorallocate($im, 0xFF, 0xFF, 0xFF);
 $black = imagecolorallocate($im, 0x00, 0x00, 0x00);
 
 // Fundo branco
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 199, 99, $white);
 
 // Espessura da linha de 5 pixels
 imagesetthickness($im, 5);


### PR DESCRIPTION
Sincroniza com o inglês as descrições de parâmetros e exemplos das funções gd (imagedashedline, imagerectangle, imagesetbrush, imagesetthickness). Ajustes nas coordenadas dos exemplos e nas descrições dos pontos.