### PR TITLE
[Sync EN] scanf: amend the CS of the fscanf and sscanf code examples

### DIFF
--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: leonardolara Status: ready --><!-- CREDITS: rarruda,ae,diogo,leonardolara -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: leonardolara Status: ready --><!-- CREDITS: rarruda,ae,diogo,leonardolara -->
 <refentry xml:id="function.fscanf" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>fscanf</refname>
@@ -14,66 +14,68 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    A função <function>fscanf</function> é semelhante à
    <function>sscanf</function>, mas usa como entrada um arquivo
    associado com o fluxo <parameter>stream</parameter> e interpreta a
    entrada de acordo com o especificado em <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Qualquer espaço em branco na string do formato corresponde a quaisquer espaços em branco
    no fluxo de entrada. Isto significa que até mesmo uma tabulação (<literal>\t</literal>) na
    string do formato pode corresponder a um único caractere de espaço no fluxo de entrada.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cada chamada a <function>fscanf</function> lê uma linha do arquivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>stream</parameter></term>
-     <listitem>
-      &fs.file.pointer;
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Os valores opcionais atribuídos.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     &fs.file.pointer;
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Os valores opcionais atribuídos.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Se somente dois parâmetros forem passados a esta função, os valores interpretados
-   serão retornados como um array. Do contrário, se parâmetros opcionais forem passados,
+   serão retornados como um <type>array</type>. Do contrário, se parâmetros opcionais forem passados,
    a função retornará o número de valores atribuídos. Os parâmetros opcionais
    devem ser passados por referência.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Se houver mais substrings esperadas no parâmetro <parameter>format</parameter>
    do que estiverem disponíveis na <parameter>string</parameter>,
    &null; será retornado. Para outros erros, &false; será retornado.
-  </para>
+  </simpara>
+  <simpara>
+   Quando parâmetros opcionais são usados e o fim da entrada lida de
+   <parameter>stream</parameter> é alcançado antes que qualquer valor tenha sido
+   interpretado, <literal>-1</literal> é retornado.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemplo de <function>fscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemplo de <function>fscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $handle = fopen("users.txt", "r");
@@ -84,36 +86,31 @@ while ($userinfo = fscanf($handle, "%s\t%s\t%s\n")) {
 fclose($handle);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Conteúdo de users.txt</title>
-    <programlisting role="txt">
+   </programlisting>
+  </example>
+  <example>
+   <title>Conteúdo de users.txt</title>
+   <programlisting role="txt">
 <![CDATA[
 javier  argonaut        pe
 hiroshi sculptor        jp
 robert  slacker us
 luigi   florist it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fread</function></member>
-    <member><function>fgets</function></member>
-    <member><function>fgetss</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fread</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: fernandowobeto Status: ready --><!-- CREDITS: fernandowobeto -->
 <refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileObject::fscanf</refname>
@@ -13,81 +13,85 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Lê uma linha do arquivo e a interpreta de acordo com o <parameter>format</parameter> especificado.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Qualquer espaço em branco na string <parameter>format</parameter> corresponde a qualquer espaço em branco na linha do arquivo.
    Isso significa que até mesmo um tab (<literal>\t</literal>) na string de formato pode corresponder a um único caractere de espaço na sequência de entrada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Os valores atribuídos opcionais.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Os valores atribuídos opcionais.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Se apenas um parâmetro for passado para este método, os valores analisados serão
-   retornados como uma array. Caso contrário, se parâmetros opcionais forem passados, a
-   função retornará o número de valores atribuídos. Os parâmetros opcionais
+   retornados como uma <type>array</type>. Caso contrário, se parâmetros opcionais forem passados, o
+   método retornará o número de valores atribuídos. Os parâmetros opcionais
    devem ser passados por referência.
-  </para>
+  </simpara>
+  <simpara>
+   Se houver mais substrings esperadas em <parameter>format</parameter>
+   do que estiverem disponíveis na linha lida do arquivo,
+   &null; será retornado.
+  </simpara>
+  <simpara>
+   Quando parâmetros opcionais são usados e o fim da linha lida do
+   arquivo é alcançado antes que qualquer valor tenha sido interpretado,
+   <literal>-1</literal> é retornado.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemplo de <methodname>SplFileObject::fscanf</methodname></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemplo de <methodname>SplFileObject::fscanf</methodname></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $file = new SplFileObject("misc.txt");
 while ($userinfo = $file->fscanf("%s %s %s")) {
-    list ($name, $profession, $countrycode) = $userinfo;
-    // Faça algo com $name $profession $countrycode
+   list ($name, $profession, $countrycode) = $userinfo;
+   // Faça algo com $name $profession $countrycode
 }
 ?>
 ]]>
-    </programlisting>
-    <para>Conteúdo de users.txt</para>
-    <programlisting role="txt">
+   </programlisting>
+   <simpara>Conteúdo de users.txt</simpara>
+   <programlisting role="txt">
 <![CDATA[
 javier   argonaut    pe
 hiroshi  sculptor    jp
 robert   slacker     us
 luigi    florist     it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fscanf</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fscanf</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: leonardolara Status: ready --><!-- CREDITS: surfmax,felipe,leonardolara -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: leonardolara Status: ready --><!-- CREDITS: surfmax,felipe,leonardolara -->
 <refentry xml:id="function.sscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sscanf</refname>
@@ -14,65 +14,67 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    A função <function>sscanf</function> é a análoga de entrada a
    <function>printf</function>. <function>sscanf</function> lê
    da string <parameter>string</parameter> e interpreta-a
    de acordo com o especificado em <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Qualquer espaço em branco na string de formato corresponde a qualquer espaço
    em branco na string de entrada. Isto significa que até mesmo uma tabulação (<literal>\t</literal>) na string de formato pode corresponder
    a um caractere de espaço simples na string de entrada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string</parameter></term>
-     <listitem>
-      <para>
-       A <type>string</type> de entrada a ser analisada.
-      </para>
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Variáveis opcionais passadas por referência que conterão os valores analisados.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      A <type>string</type> de entrada a ser analisada.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Variáveis opcionais passadas por referência que conterão os valores analisados.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Se apenas dois parâmetros forem passados para esta função, os valores interpretados
-   serão retornados como um array. Caso contrário, se parâmetros opcionais forem passados, a
+   serão retornados como um <type>array</type>. Caso contrário, se parâmetros opcionais forem passados, a
    função retornará o número de valores atribuídos. Os parâmetros opcionais
    precisam ser passados por referência.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Se houver mais substrings esperadas em <parameter>format</parameter>
    do que estiverem disponíveis na <parameter>string</parameter>,
    &null; será retornado.
-  </para>
+  </simpara>
+  <simpara>
+   Quando parâmetros opcionais são usados e o fim da <parameter>string</parameter>
+   de entrada é alcançado antes que qualquer valor tenha sido interpretado,
+   <literal>-1</literal> é retornado.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemplo de <function>sscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemplo de <function>sscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Pegando o número serial
@@ -83,17 +85,15 @@ list($month, $day, $year) = sscanf($mandate, "%s %d %d");
 echo "O item $serial foi produzido em: $year-" . substr($month, 0, 3) . "-$day\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
    Se parâmetros opcionais forem passados, a função retornará o
    número de valores atribuídos.
-  </para>
-  <para>
-   <example>
-    <title><function>sscanf</function> - usando parâmetros opcionais</title>
-    <programlisting role="php">
+  </simpara>
+  <example>
+   <title><function>sscanf</function> - usando parâmetros opcionais</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // pega informação do autor e gera uma entrada de DocBook
@@ -105,26 +105,23 @@ echo "<author id='$id'>
 </author>\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-    <member><function>fprintf</function></member>
-    <member><function>vprintf</function></member>
-    <member><function>vsprintf</function></member>
-    <member><function>vfprintf</function></member>
-    <member><function>fscanf</function></member>
-    <member><function>number_format</function></member>
-    <member><function>date</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+   <member><function>fprintf</function></member>
+   <member><function>vprintf</function></member>
+   <member><function>vsprintf</function></member>
+   <member><function>vfprintf</function></member>
+   <member><function>fscanf</function></member>
+   <member><function>number_format</function></member>
+   <member><function>date</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sincroniza fscanf, SplFileObject::fscanf e sscanf com a EN: ajustes de coding standard nos exemplos e troca de para por simpara. Inclui o novo retorno -1 quando o fim da entrada e alcancado antes de qualquer valor ser interpretado.